### PR TITLE
Add back missing license header lines

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Package implements authenitcation mechanisms.
 package auth

--- a/keyserver/key_server_test.go
+++ b/keyserver/key_server_test.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Tests for key_server.go
 

--- a/keyserver/validate.go
+++ b/keyserver/validate.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
+// limitations under the License.
 
 package keyserver
 

--- a/keyserver/validate_test.go
+++ b/keyserver/validate_test.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
+// limitations under the License.
 
 package keyserver
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
+// limitations under the License.
 
 // Package storage provides an API to persistant storage, implemented with spanner.
 package storage


### PR DESCRIPTION
In five files, the line `// limitations under the License.` was dropped
