### PR TITLE
Add support for proofs of absence

### DIFF
--- a/proto/v2/e2ekeys.proto
+++ b/proto/v2/e2ekeys.proto
@@ -234,7 +234,7 @@ message SubtreeAbsenceProof {
 // existing binding.
 message SharedLeafAbsenceProof {
   // Neighbors is a list of all the adacent nodes along the path from the leaf
-  // object to the root (this is effectively a HashPath proof for otherVuf).
+  // object to the root (this is effectively a HashPath proof for existingVuf).
   repeated bytes neighbors = 1;
 
   // This is the VUF for the binding that does exist; it will share a prefix


### PR DESCRIPTION
We want to be able to prove to clients that their requested entry does not exist. With prefix trees, there are two cases for proofs of absence, one where the branch is not present in the tree, and one where the branch is present but contains the wrong leaf.

I wasn't sure what the best way of structuring the protobufs was. I went with the way that seemed clearest, but we could also do with less protubuf nesting if we wanted. For instance, all three possible proof types share a `bytes neighbors` member, which could be moved into `Proof`. However, `neighbors` actually has a bit of a different meaning in each case, so I wanted to split it. Let me know if this could be made clearer.
