### PR TITLE
Add enough fields to Proof to support proof of absence

### DIFF
--- a/proto/v2/e2ekeys.proto
+++ b/proto/v2/e2ekeys.proto
@@ -212,11 +212,15 @@ message KeyPromise {
   Signature signature = 2;
 }
 
-// A Proof provides an authentication path through the Merkel Tree that
-// proves that an item is present in the tree.
+// A Proof provides an authentication path through the Merkle Tree that
+// proves that an item is or is not present in the tree.
 message Proof {
-  // Neighbors is a list of all the adacent nodes along the path from the leaf
-  // object to the root.  To save space, hashes for empty subtrees are omitted.
+  // Neighbors is a list of all the adacent nodes along the path from the
+  // bottommost node to the root. To save space, hashes for empty subtrees are
+  // nil, and the number of hashes is equal to the length of the longest common
+  // prefix with another entry in the tree (since a leaf node is moved up to
+  // that point -- subtrees with a single entry are coalesced into a single
+  // node).
   repeated bytes neighbors = 1;
   // The root node in the Merkle tree.
   SignedRoot epoch = 3;
@@ -224,6 +228,14 @@ message Proof {
   // Prevents an adversary from brute forcing a user's location in the Merkle
   // tree.
   bytes vuf = 4;
+  // This is the VUF for the binding that does exist; it will share a prefix
+  // with vuf, but in case the leaf contains the wrong contents, it will be
+  // different. It will be nil if the requested VUF falls under an empty branch.
+  bytes existingVuf = 5;
+  // This is the commitment for the binding that does exist. If the leaf
+  // contains the wrong contents, the client can use this to verify that it in
+  // fact is at that position in the tree.
+  bytes existingCommitment = 6;
 }
 
 // SignedRoot represents a signed state of the Merkel tree.


### PR DESCRIPTION
In the case that the desired VUF falls under a subtree that contains a
single, different, node, the proof of absence has to be a presence proof
for that node, showing that the different node exists but no other node
exists under that subtree.
