### PR TITLE
Implement v2 APIs Proxy Server

### DIFF
--- a/proto/v2/handlers.go
+++ b/proto/v2/handlers.go
@@ -1,0 +1,58 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google_security_e2ekeys_v2
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/google/e2e-key-server/rest/handlers"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	context "golang.org/x/net/context"
+)
+
+// Handler handles v2 API requests, call the appropriate API handler, and
+// return an error if the request cannot be parsed/decoded correctly or
+// the API call returns an error.
+// TODO: I wish this could be code generated.
+func Handler(srv interface{}, ctx context.Context, w http.ResponseWriter, r *http.Request, info *handlers.HandlerInfo) error {
+	// Parsing URL params and JSON. Parsing should always be called before
+	// attemping decoding JSON body because parsing will convert timestamp
+	// to the appropriate format.
+	err := info.Parser(r, &info.Arg)
+	if err != nil {
+		return err
+	}
+
+	// Json -> Proto.
+	decoder := json.NewDecoder(r.Body)
+	err = decoder.Decode(&info.Arg)
+	if err != nil && err != io.EOF {
+		return grpc.Errorf(codes.InvalidArgument, "decoding error:", err)
+	}
+
+	// Calling the actual API handler.
+	resp, err := info.H(srv, ctx, info.Arg)
+	if err != nil {
+		return err
+	}
+	// Proto -> json.
+	encoder := json.NewEncoder(w)
+	encoder.Encode(resp)
+	return nil
+}

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -115,9 +115,9 @@ func toHttpError(err error, w http.ResponseWriter) {
 	}
 }
 
-// GetUser_InitializeHandlerInfo initializes and returns HandlerInfo preparing
+// GetUserV1_InitializeHandlerInfo initializes and returns HandlerInfo preparing
 // to call proxy.GetUser API.
-func GetUser_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
+func GetUserV1_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
 	info := new(handlers.HandlerInfo)
 	// Set the API handler to call the proxy GetUser.
 	info.H = rInfo.Handler
@@ -157,11 +157,285 @@ func GetUser_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerIn
 	return info
 }
 
-// GetUser_RequestHandler calls proxy.GetUser and returns its results. An error
+// GetUserV1_RequestHandler calls proxy.GetUser and returns its results. An error
 // will be returned if proxy.GetUser returns an error.
-func GetUser_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
+func GetUserV1_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
 	var resp interface{}
 	resp, err := srv.(v1pb.E2EKeyProxyServer).GetUser(ctx, arg.(*v2pb.GetUserRequest))
+	return &resp, err
+}
+
+// GetUserV2_InitializeHandlerInfo initializes and returns HandlerInfo preparing
+// to call keyserver.GetUser API.
+func GetUserV2_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
+	info := new(handlers.HandlerInfo)
+	// Set the API handler to call the keyserver GetUser.
+	info.H = rInfo.Handler
+	// Create a new GetUserRequest to be passed to the API handler.
+	info.Arg = new(v2pb.GetUserRequest)
+	// Create a new function that parses URL parameters.
+	info.Parser = func(r *http.Request, arg *interface{}) error {
+		// Get URL components.
+		components := strings.Split(strings.TrimLeft(r.URL.Path, "/"), "/")
+
+		in := (*arg).(*v2pb.GetUserRequest)
+		// Parse User ID; components[2] is userId = email.
+		userId, err := parseURLComponent(components, rInfo.UserIdIndex)
+		if err != nil {
+			return err
+		}
+		in.UserId = userId
+
+		m, _ := url.ParseQuery(r.URL.RawQuery)
+		// Parse Epoch. Epoch must be of type uint64.
+		if val, ok := m["epoch"]; ok {
+			if epoch, err := strconv.ParseUint(val[0], 10, 64); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Epoch must be uint64")
+			} else {
+				in.Epoch = uint64(epoch)
+			}
+		}
+
+		// Parse App ID.
+		if val, ok := m["app_id"]; ok {
+			in.AppId = val[0]
+		}
+
+		return nil
+	}
+
+	return info
+}
+
+// GetUserV2_RequestHandler calls keyserver.GetUser and returns its results. An error
+// will be returned if keyserver.GetUser returns an error.
+func GetUserV2_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
+	var resp interface{}
+	resp, err := srv.(v2pb.E2EKeyServiceClient).GetUser(ctx, arg.(*v2pb.GetUserRequest))
+	return &resp, err
+}
+
+// ListUserHistoryV2_InitializeHandlerInfo initializes and returns HandlerInfo preparing
+// to call keyserver.ListUserHistory API.
+func ListUserHistoryV2_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
+	info := new(handlers.HandlerInfo)
+	// Set the API handler to call the keyserver ListUserHistory.
+	info.H = rInfo.Handler
+	// Create a new ListUserHistoryRequest to be passed to the API handler.
+	info.Arg = new(v2pb.ListUserHistoryRequest)
+	// Create a new function that parses URL parameters.
+	info.Parser = func(r *http.Request, arg *interface{}) error {
+		// Get URL components.
+		components := strings.Split(strings.TrimLeft(r.URL.Path, "/"), "/")
+
+		in := (*arg).(*v2pb.ListUserHistoryRequest)
+		// Parse User ID; components[2] is userId = email.
+		userId, err := parseURLComponent(components, rInfo.UserIdIndex)
+		if err != nil {
+			return err
+		}
+		in.UserId = userId
+
+		m, _ := url.ParseQuery(r.URL.RawQuery)
+		// Parse StartEpoch. StartEpoch must be of type uint64.
+		if val, ok := m["start_epoch"]; ok {
+			if start_epoch, err := strconv.ParseUint(val[0], 10, 64); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Start Epoch must be uint64")
+			} else {
+				in.StartEpoch = uint64(start_epoch)
+			}
+		}
+
+		// Parse PageSize. PageSize must be of type int32.
+		if val, ok := m["page_size"]; ok {
+			if page_size, err := strconv.ParseInt(val[0], 10, 32); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Page size must be int32")
+			} else {
+				in.PageSize = int32(page_size)
+			}
+		}
+
+		return nil
+	}
+
+	return info
+}
+
+// ListUserHistoryV2_RequestHandler calls keyserver.ListUserHistory and returns its results. An error
+// will be returned if keyserver.ListUserHistory returns an error.
+func ListUserHistoryV2_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
+	var resp interface{}
+	resp, err := srv.(v2pb.E2EKeyServiceClient).ListUserHistory(ctx, arg.(*v2pb.ListUserHistoryRequest))
+	return &resp, err
+}
+
+// UpdateUserV2_InitializeHandlerInfo initializes and returns HandlerInfo preparing
+// to call keyserver.UpdateUser API.
+func UpdateUserV2_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
+	info := new(handlers.HandlerInfo)
+	// Set the API handler to call the keyserver UpdateUser.
+	info.H = rInfo.Handler
+	// Create a new UpdateUserRequest to be passed to the API handler.
+	info.Arg = new(v2pb.UpdateUserRequest)
+	// Create a new function that parses URL parameters.
+	info.Parser = func(r *http.Request, arg *interface{}) error {
+		// Get URL components.
+		components := strings.Split(strings.TrimLeft(r.URL.Path, "/"), "/")
+
+		in := (*arg).(*v2pb.UpdateUserRequest)
+		// Parse User ID; components[2] is userId = email.
+		userId, err := parseURLComponent(components, rInfo.UserIdIndex)
+		if err != nil {
+			return err
+		}
+		in.UserId = userId
+
+		return nil
+	}
+
+	return info
+}
+
+// UpdateUserV2_RequestHandler calls keyserver.UpdateUser and returns its results. An error
+// will be returned if keyserver.UpdateUser returns an error.
+func UpdateUserV2_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
+	var resp interface{}
+	resp, err := srv.(v2pb.E2EKeyServiceClient).UpdateUser(ctx, arg.(*v2pb.UpdateUserRequest))
+	return &resp, err
+}
+
+// ListSEHV2_InitializeHandlerInfo initializes and returns HandlerInfo preparing
+// to call keyserver.ListSEH API.
+func ListSEHV2_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
+	info := new(handlers.HandlerInfo)
+	// Set the API handler to call the keyserver ListSEH.
+	info.H = rInfo.Handler
+	// Create a new ListSEHRequest to be passed to the API handler.
+	info.Arg = new(v2pb.ListSEHRequest)
+	// Create a new function that parses URL parameters.
+	info.Parser = func(r *http.Request, arg *interface{}) error {
+		in := (*arg).(*v2pb.ListSEHRequest)
+
+		m, _ := url.ParseQuery(r.URL.RawQuery)
+		// Parse StartEpoch. StartEpoch must be of type uint64.
+		if val, ok := m["start_epoch"]; ok {
+			if start_epoch, err := strconv.ParseUint(val[0], 10, 64); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Start Epoch must be uint64")
+			} else {
+				in.StartEpoch = uint64(start_epoch)
+			}
+		}
+
+		// Parse PageSize. PageSize must be of type int32.
+		if val, ok := m["page_size"]; ok {
+			if page_size, err := strconv.ParseInt(val[0], 10, 32); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Page size must be int32")
+			} else {
+				in.PageSize = int32(page_size)
+			}
+		}
+
+		return nil
+	}
+
+	return info
+}
+
+// ListSEHV2_RequestHandler calls keyserver.ListSEH and returns its results. An error
+// will be returned if keyserver.ListSEH returns an error.
+func ListSEHV2_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
+	var resp interface{}
+	resp, err := srv.(v2pb.E2EKeyServiceClient).ListSEH(ctx, arg.(*v2pb.ListSEHRequest))
+	return &resp, err
+}
+
+// ListUpdateV2_InitializeHandlerInfo initializes and returns HandlerInfo preparing
+// to call keyserver.ListUpdate API.
+func ListUpdateV2_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
+	info := new(handlers.HandlerInfo)
+	// Set the API handler to call the keyserver ListUpdate.
+	info.H = rInfo.Handler
+	// Create a new ListUpdateRequest to be passed to the API handler.
+	info.Arg = new(v2pb.ListUpdateRequest)
+	// Create a new function that parses URL parameters.
+	info.Parser = func(r *http.Request, arg *interface{}) error {
+		in := (*arg).(*v2pb.ListUpdateRequest)
+
+		m, _ := url.ParseQuery(r.URL.RawQuery)
+		// Parse StartSequence. StartSequence must be of type uint64.
+		if val, ok := m["start_sequence"]; ok {
+			if start_sequence, err := strconv.ParseUint(val[0], 10, 64); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Start sequence must be uint64")
+			} else {
+				in.StartSequence = uint64(start_sequence)
+			}
+		}
+
+		// Parse PageSize. PageSize must be of type int32.
+		if val, ok := m["page_size"]; ok {
+			if page_size, err := strconv.ParseInt(val[0], 10, 32); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Page size must be int32")
+			} else {
+				in.PageSize = int32(page_size)
+			}
+		}
+
+		return nil
+	}
+
+	return info
+}
+
+// ListUpdateV2_RequestHandler calls keyserver.ListUpdate and returns its results. An error
+// will be returned if keyserver.ListUpdate returns an error.
+func ListUpdateV2_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
+	var resp interface{}
+	resp, err := srv.(v2pb.E2EKeyServiceClient).ListUpdate(ctx, arg.(*v2pb.ListUpdateRequest))
+	return &resp, err
+}
+
+// ListStepsV2_InitializeHandlerInfo initializes and returns HandlerInfo preparing
+// to call keyserver.ListSteps API.
+func ListStepsV2_InitializeHandlerInfo(rInfo handlers.RouteInfo) *handlers.HandlerInfo {
+	info := new(handlers.HandlerInfo)
+	// Set the API handler to call the keyserver ListSteps.
+	info.H = rInfo.Handler
+	// Create a new ListStepsRequest to be passed to the API handler.
+	info.Arg = new(v2pb.ListStepsRequest)
+	// Create a new function that parses URL parameters.
+	info.Parser = func(r *http.Request, arg *interface{}) error {
+		in := (*arg).(*v2pb.ListStepsRequest)
+
+		m, _ := url.ParseQuery(r.URL.RawQuery)
+		// Parse StartSequence. StartSequence must be of type uint64.
+		if val, ok := m["start_sequence"]; ok {
+			if start_sequence, err := strconv.ParseUint(val[0], 10, 64); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Start sequence must be uint64")
+			} else {
+				in.StartSequence = uint64(start_sequence)
+			}
+		}
+
+		// Parse PageSize. PageSize must be of type int32.
+		if val, ok := m["page_size"]; ok {
+			if page_size, err := strconv.ParseInt(val[0], 10, 32); err != nil {
+				return grpc.Errorf(codes.InvalidArgument, "Page size must be int32")
+			} else {
+				in.PageSize = int32(page_size)
+			}
+		}
+
+		return nil
+	}
+
+	return info
+}
+
+// ListStepsV2_RequestHandler calls keyserver.ListSteps and returns its results. An error
+// will be returned if keyserver.ListSteps returns an error.
+func ListStepsV2_RequestHandler(srv interface{}, ctx context.Context, arg interface{}) (*interface{}, error) {
+	var resp interface{}
+	resp, err := srv.(v2pb.E2EKeyServiceClient).ListSteps(ctx, arg.(*v2pb.ListStepsRequest))
 	return &resp, err
 }
 

--- a/server.go
+++ b/server.go
@@ -28,21 +28,81 @@ import (
 	"golang.org/x/net/context"
 
 	v1pb "github.com/google/e2e-key-server/proto/v1"
+	v2pb "github.com/google/e2e-key-server/proto/v2"
 )
 
 var port = flag.Int("port", 8080, "TCP port to listen on")
 
-// v1Routes contains all routes information.
+// v1Routes contains all routes information for v1 APIs.
 // TODO(cesarghali): find a better way to populate this map.
 var v1Routes = []handlers.RouteInfo{
 	// GetUser API
 	handlers.RouteInfo{
-		"/v1/users/{userid}",
+		"/v1/users/{user_id}",
 		2,
 		-1, // No keyId in the path.
 		"GET",
-		rest.GetUser_InitializeHandlerInfo,
-		rest.GetUser_RequestHandler,
+		rest.GetUserV1_InitializeHandlerInfo,
+		rest.GetUserV1_RequestHandler,
+	},
+}
+
+// v2Routes contains all routes information for v2 APIs.
+// TODO(cesarghali): find a better way to populate this map.
+var v2Routes = []handlers.RouteInfo{
+	// GetUser API
+	handlers.RouteInfo{
+		"/v2/users/{user_id}",
+		2,
+		-1, // No keyId in the path.
+		"GET",
+		rest.GetUserV2_InitializeHandlerInfo,
+		rest.GetUserV2_RequestHandler,
+	},
+	// ListUserHistory API
+	handlers.RouteInfo{
+		"/v2/users/{user_id}/history",
+		2,
+		-1, // No keyId in the path.
+		"GET",
+		rest.ListUserHistoryV2_InitializeHandlerInfo,
+		rest.ListUserHistoryV2_RequestHandler,
+	},
+	// UpdateUser API
+	handlers.RouteInfo{
+		"/v2/users/{user_id}",
+		2,
+		-1, // No keyId in the path.
+		"PUT",
+		rest.UpdateUserV2_InitializeHandlerInfo,
+		rest.UpdateUserV2_RequestHandler,
+	},
+	// ListSEH API
+	handlers.RouteInfo{
+		"/v2/seh",
+		-1,
+		-1, // No keyId in the path.
+		"GET",
+		rest.ListSEHV2_InitializeHandlerInfo,
+		rest.ListSEHV2_RequestHandler,
+	},
+	// ListUpdate API
+	handlers.RouteInfo{
+		"/v2/update",
+		-1,
+		-1, // No keyId in the path.
+		"GET",
+		rest.ListUpdateV2_InitializeHandlerInfo,
+		rest.ListUpdateV2_RequestHandler,
+	},
+	// ListSteps API
+	handlers.RouteInfo{
+		"/v2/step",
+		-1,
+		-1, // No keyId in the path.
+		"GET",
+		rest.ListStepsV2_InitializeHandlerInfo,
+		rest.ListStepsV2_RequestHandler,
 	},
 }
 
@@ -59,10 +119,15 @@ func main() {
 	v1 := proxy.New(v2)
 	s := rest.New(v1)
 
-	// Manually add routing paths.
+	// Manually add routing paths for v1 APIs.
 	// TODO: Auto derive from proto.
 	for _, v := range v1Routes {
 		s.AddHandler(v, v1pb.Handler)
+	}
+	// Manually add routing paths for v2 APIs.
+	// TODO: Auto derive from proto.
+	for _, v := range v2Routes {
+		s.AddHandler(v, v2pb.Handler)
 	}
 	// TODO: add hkp server api here.
 


### PR DESCRIPTION
Changes:
- Create proto/v2/handlers.go similar to proto/v1/handlers.go.
- Add V2 API logic in rest/rest.go.
- Implement GetUser API proxy.
- Implement UpdateUser API proxy.
- Implement ListUserHistory API proxy.
- Implement ListSEH API proxy.
- Implement ListUpdate API proxy.
- Implement ListSteps API proxy.
- Implement corresponding unit tests.
