### PR TITLE
Implementing App-Based Key Filtering

### DIFF
--- a/keyserver/key_server_test.go
+++ b/keyserver/key_server_test.go
@@ -228,7 +228,7 @@ func TestGetValidUser(t *testing.T) {
 		return
 	}
 	if got, want := p.GetKeys(), primaryKeys; !reflect.DeepEqual(got, want) {
-		t.Errorf("GetUser(%v) = %v, want: %v", primaryUserEmail, got, want)
+		t.Errorf("GetUser(%v).GetKeys() = %v, want: %v", primaryUserEmail, got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #94.

This is only implemented for `v1.GetUser`, see #94 for details.
