### PR TITLE
Common protobuf for #91: #90, #89, #56, #52

### DIFF
--- a/proto/v2/e2ekeys.proto
+++ b/proto/v2/e2ekeys.proto
@@ -126,21 +126,6 @@ message TreeProof {
   bytes existing_entry_hash = 3;
 }
 
-// Step is a combined, ordered list of SignedEntryUpdates and SignedEpochHeads
-// which are made available to verifiers.
-// TODO: see coname VerifierStep
-// message Step {
-//   oneof type {
-//     // entry_changed contains a serialized SignedEntryUpdate.
-//     bytes entry_changed = 1;
-//     SignedEpochHead seh = 2;
-//   }
-//   // epoch of this udpate.
-//   uint64 epoch = 3;
-//   // commitment_timestamp is the ordered commitment_timestamp of this step.
-//   uint64 commitment_timestamp = 4;
-// }
-
 // EntryUpdate is the proto a client sends to update their profile.
 message PutProfileRequest {
   // UserID specifies the id for the new account to be registered. Updates to

--- a/proto/v2/todo.proto
+++ b/proto/v2/todo.proto
@@ -30,6 +30,23 @@ service KeyserverTODO {
   rpc ListSteps(ListStepsRequest) returns (ListStepsResponse);
 }
 
+
+// Step is a combined, ordered list of SignedEntryUpdates and SignedEpochHeads
+// which are made available to verifiers.
+// TODO: see coname VerifierStep
+message Step {
+  oneof type {
+    // entry_changed contains a serialized SignedEntryUpdate.
+    bytes entry_changed = 1;
+    SignedEpochHead seh = 2;
+  }
+  // epoch of this udpate.
+  uint64 epoch = 3;
+  // commitment_timestamp is the ordered commitment_timestamp of this step.
+  uint64 commitment_timestamp = 4;
+}
+
+
 // Get a list of historical values for a user.
 message ListUserHistoryRequest {
   // The user identifier.


### PR DESCRIPTION
Do not merge -- does not compile as is. All the code will need to be updated to reflect the changed names, but let's do that after we agree.

This pull request represents the changes I think we agreed upon in the last two meetings, and targets total agreement of the client-facing grpc-based protocol format and semantics. The corresponding change on the Yahoo side is https://github.com/yahoo/coname/blob/client-proto-agreement/proto/client.proto. The result of all this is that after ignoring comments and extensions (using https://github.com/yahoo/coname/blob/client-proto-agreement/proto/prune.sh), we have 0 lines of diff!

Some general notes on what I did where:
- order of message declaration was kept as on the Google side for easier reviewing, changes were made on Yahoo side
- Order of fields in a protobuf, if it differed between the two sides, was modified to whatever made more sense to me. Naturally, this caused more changes on the Google side than Yahoo side -- I am not attached to having these changes go in.
- protobuf fields were renumbered to be sequential from 1 in the order they are shown
- types that are not shared were moved out of the main proto file (todo.proto on google side)
- New types on Google side: AuthorizationPolicy, QuorumExpr, and TreeProof, pubkey->ed25519.
- New types on Yahoo side: pubkey->rsa, pubkey->p256.
- the package and service names need to match because they are used in grpc http2 queries. I tried to pick neutral names.

In principle this could be broken up to small changes, but I think that many things that we will want to discuss would be common to the smaller PR-s, so a big one makes more sense for now.
