### PR TITLE
Refactor Storage Interface

### DIFF
--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -51,7 +51,7 @@ type EntryUpdates struct {
 }
 
 func NewEnv(t *testing.T) *Env {
-	b := New(nil)
+	b := New()
 	updates := GenerateEntryUpdates(t)
 
 	return &Env{b, updates}

--- a/common/common.go
+++ b/common/common.go
@@ -26,12 +26,23 @@ import (
 	"google.golang.org/grpc/codes"
 
 	proto "github.com/golang/protobuf/proto"
+	corepb "github.com/google/e2e-key-server/proto/core"
 	v2pb "github.com/google/e2e-key-server/proto/v2"
 )
 
 const (
 	commitmentKeyLen = 16
+	// ChannelSize is the buffer size of the channel used to send an
+	// EntryStorage to the tree builder.
+	ChannelSize = 100
 )
+
+type Watcher interface {
+	// NewEntries  returns a channel containing EntryStorage entries, which
+	// are pushed into the channel whenever an EntryStorage is written in
+	// the storage.
+	NewEntries() chan *corepb.EntryStorage
+}
 
 // Commitment returns the commitment key and the profile commitment
 func Commitment(profile []byte) ([]byte, []byte, error) {

--- a/keyserver/key_server.go
+++ b/keyserver/key_server.go
@@ -69,7 +69,7 @@ func (s *Server) GetEntry(ctx context.Context, in *v2pb.GetEntryRequest) (*v2pb.
 		return nil, err
 	}
 
-	entryStorage, err := s.store.Read(ctx, commitmentTS)
+	entryStorage, err := s.store.Read(commitmentTS)
 	if err != nil {
 		if grpc.Code(err) == codes.NotFound {
 			// Return an empty proof.
@@ -139,7 +139,7 @@ func (s *Server) UpdateEntry(ctx context.Context, in *v2pb.UpdateEntryRequest) (
 	}
 
 	// If entry does not exist, insert it, otherwise update.
-	if err := s.store.Write(ctx, e); err != nil {
+	if err := s.store.Write(e); err != nil {
 		return nil, err
 	}
 

--- a/keyserver/key_server_test.go
+++ b/keyserver/key_server_test.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/codes"
 
 	proto "github.com/golang/protobuf/proto"
+	corepb "github.com/google/e2e-key-server/proto/core"
 	v2pb "github.com/google/e2e-key-server/proto/v2"
 )
 
@@ -142,8 +143,8 @@ func NewEnv(t *testing.T) *Env {
 	}
 	addr := "localhost:" + port
 	s := grpc.NewServer()
-	store := storage.CreateMem(context.Background())
-	b := builder.New(store.NewEntries())
+	b := builder.New()
+	store := storage.CreateMem([]chan *corepb.EntryStorage{b.NewEntries()})
 	server := New(store, b.GetTree())
 	v2pb.RegisterE2EKeyServiceServer(s, server)
 	go s.Serve(lis)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
+	corepb "github.com/google/e2e-key-server/proto/core"
 	v1pb "github.com/google/e2e-key-server/proto/v1"
 	v2pb "github.com/google/e2e-key-server/proto/v2"
 )
@@ -106,8 +107,8 @@ func NewEnv(t *testing.T) *Env {
 	}
 	addr := "localhost:" + port
 	s := grpc.NewServer()
-	store := storage.CreateMem(context.Background())
-	b := builder.New(store.NewEntries())
+	b := builder.New()
+	store := storage.CreateMem([]chan *corepb.EntryStorage{b.NewEntries()})
 	v2srv := keyserver.New(store, b.GetTree())
 	v1srv := New(v2srv)
 	v2pb.RegisterE2EKeyServiceServer(s, v2srv)

--- a/server.go
+++ b/server.go
@@ -26,8 +26,8 @@ import (
 	"github.com/google/e2e-key-server/rest"
 	"github.com/google/e2e-key-server/rest/handlers"
 	"github.com/google/e2e-key-server/storage"
-	"golang.org/x/net/context"
 
+	corepb "github.com/google/e2e-key-server/proto/core"
 	v1pb "github.com/google/e2e-key-server/proto/v1"
 	v2pb "github.com/google/e2e-key-server/proto/v2"
 )
@@ -114,10 +114,10 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	// Create a memory storage.
-	store := storage.CreateMem(context.Background())
 	// Create the tree builder.
-	b := builder.New(store.NewEntries())
+	b := builder.New()
+	// Create a memory storage.
+	store := storage.CreateMem([]chan *corepb.EntryStorage{b.NewEntries()})
 	// Create the servers.
 	v2 := keyserver.New(store, b.GetTree())
 	v1 := proxy.New(v2)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -12,36 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package storage provides an API to persistant storage, implemented with spanner.
+// Package storage provides an API to persistant storage.
 package storage
 
 import (
 	corepb "github.com/google/e2e-key-server/proto/core"
-	context "golang.org/x/net/context"
 )
 
 type Storage interface {
 	Reader
 	Writer
-	Watcher
 }
 
 type Reader interface {
 	// Read reads a EntryStroage from the storage.
-	Read(ctx context.Context, commitmentTS uint64) (*corepb.EntryStorage, error)
+	Read(commitmentTS uint64) (*corepb.EntryStorage, error)
 }
 
 type Writer interface {
 	// Write inserts a new EntryStorage in the storage. Fails if the row
 	// already exists.
-	Write(ctx context.Context, entry *corepb.EntryStorage) error
-}
-
-type Watcher interface {
-	// NewEntries  returns a channel containing EntryStorage entries, which
-	// are pushed into the channel whenever an EntryStorage is written in
-	// the stirage.
-	NewEntries() chan *corepb.EntryStorage
+	Write(entry *corepb.EntryStorage) error
 }
 
 // TODO(cesarghali): bring back ConkisStorage and make it compatible with the


### PR DESCRIPTION
- Remove Watcher from Storage interface.
- Add Watcher to builder/builder.go.
- Update channel now lives in builder/builder.go and is passed to MemStorage when it is created.
- Remove context from storage.
