### PR TITLE
Make the Sparse Merkle Tree store the current epoch

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -38,7 +38,6 @@ type Signer struct {
 	mutator  mutator.Mutator
 	tree     tree.SparseHist
 	appender appender.Appender
-	epoch    int64
 }
 
 // New creates a new instance of the signer.
@@ -49,7 +48,6 @@ func New(queue queue.Queuer, tree tree.SparseHist, mutator mutator.Mutator, appe
 		mutator:  mutator,
 		tree:     tree,
 		appender: appender,
-		// TODO: Read current epoch out of database.
 	}
 
 	return s, nil
@@ -82,7 +80,7 @@ func (s *Signer) StartSigning(interval time.Duration) {
 func (s *Signer) sequenceOne(index, mutation []byte) error {
 	// Get current value.
 	ctx := context.Background()
-	v, err := s.tree.ReadLeafAt(ctx, index, s.epoch)
+	v, err := s.tree.ReadLeafAt(ctx, index, s.tree.Epoch())
 	if err != nil {
 		return err
 	}
@@ -107,8 +105,7 @@ func (s *Signer) CreateEpoch() error {
 	if err != nil {
 		return err
 	}
-	s.epoch = epoch
-	root, err := s.tree.ReadRootAt(ctx, s.epoch)
+	root, err := s.tree.ReadRootAt(ctx, epoch)
 	if err != nil {
 		return err
 	}

--- a/tree/sparse/doc.go
+++ b/tree/sparse/doc.go
@@ -13,5 +13,3 @@
 // limitations under the License.
 
 package sparse
-
-import ()

--- a/tree/sparse/sqlhist/sqlhist.go
+++ b/tree/sparse/sqlhist/sqlhist.go
@@ -74,6 +74,11 @@ func New(db *sql.DB, mapID string) *Map {
 	return m
 }
 
+// Epoch returns the current epoch of the merkle tree.
+func (m *Map) Epoch() int64 {
+	return m.epoch
+}
+
 // QueueLeaf should only be called by the sequencer.
 func (m *Map) QueueLeaf(ctx context.Context, index, leaf []byte) error {
 	if got, want := len(index), size; got != want {

--- a/tree/tree.go
+++ b/tree/tree.go
@@ -51,4 +51,7 @@ type SparseHist interface {
 	ReadLeafAt(ctx context.Context, index []byte, epoch int64) ([]byte, error)
 	// Neighbors returns the list of neighbors from the neighbor leaf to just below the root at epoch.
 	NeighborsAt(ctx context.Context, index []byte, epoch int64) ([][]byte, error)
+
+	// Epoch returns the current epoch of the merkle tree.
+	Epoch() int64
 }


### PR DESCRIPTION
The signer was previously not resuming from a previously written epoch. 
This moves the responsibility for knowing the current epoch to the Sparse Merkle Tree Database. 
