### PR TITLE
Appender: store and send objects

### DIFF
--- a/appender/appender.go
+++ b/appender/appender.go
@@ -21,13 +21,13 @@ import (
 // Appender is an append only interface into a data structure.
 type Appender interface {
 	// Adds an object to the append-only data structure.
-	Append(ctx context.Context, epoch int64, data []byte) error
+	Append(ctx context.Context, epoch int64, obj interface{}) error
 
 	// Epoch retrieves a specific object.
-	// Returns data and a serialized ct.SignedCertificateTimestamp
-	Epoch(ctx context.Context, epoch int64) ([]byte, []byte, error)
+	// Returns obj and a serialized ct.SignedCertificateTimestamp
+	Epoch(ctx context.Context, epoch int64, obj interface{}) ([]byte, error)
 
 	// Latest returns the latest object.
-	// Returns epoch, data, and a serialized ct.SignedCertificateTimestamp
-	Latest(ctx context.Context) (int64, []byte, []byte, error)
+	// Returns epoch, obj, and a serialized ct.SignedCertificateTimestamp
+	Latest(ctx context.Context, obj interface{}) (int64, []byte, error)
 }

--- a/appender/ct_test.go
+++ b/appender/ct_test.go
@@ -59,7 +59,8 @@ func TestGetLatest(t *testing.T) {
 			t.Errorf("Append(%v, %v): %v, want nil", tc.epoch, tc.data, err)
 		}
 
-		epoch, _, b, err := a.Latest(context.Background())
+		var obj []byte
+		epoch, b, err := a.Latest(context.Background(), &obj)
 		if err != nil {
 			t.Errorf("Latest(): %v, want nil", err)
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -49,7 +49,7 @@ var (
 	// ErrRetry occurs when an update request has been submitted, but the
 	// results of the udpate are not visible on the server yet. The client
 	// must retry until the request is visible.
-	ErrRetry = errors.New("Update not present on server yet")
+	ErrRetry = errors.New("update not present on server yet")
 	hasher   = sparse.CONIKSHasher
 )
 

--- a/keyserver/keyserver.go
+++ b/keyserver/keyserver.go
@@ -61,19 +61,16 @@ func New(committer commitments.Committer, queue queue.Queuer, tree tree.SparseHi
 
 // GetSMH returns the current Signed Map Head (SMH).
 func (s *Server) GetSMH(ctx context.Context, epoch int64) (int64, *ctmap.SignedMapHead, []byte, error) {
-	var data, sct []byte
+	var sct []byte
+	smh := new(ctmap.SignedMapHead)
 	thisEpoch := epoch
 	var err error
 	if epoch == 0 {
-		thisEpoch, data, sct, err = s.appender.Latest(ctx)
+		thisEpoch, sct, err = s.appender.Latest(ctx, smh)
 	} else {
-		data, sct, err = s.appender.Epoch(ctx, epoch)
+		sct, err = s.appender.Epoch(ctx, epoch, smh)
 	}
 	if err != nil {
-		return 0, nil, nil, err
-	}
-	smh := new(ctmap.SignedMapHead)
-	if err := proto.Unmarshal(data, smh); err != nil {
 		return 0, nil, nil, err
 	}
 	return thisEpoch, smh, sct, nil

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/key-transparency/signatures"
 	"github.com/google/key-transparency/tree"
 
-	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 
 	ctmap "github.com/google/key-transparency/proto/ctmap"
@@ -130,11 +129,7 @@ func (s *Signer) CreateEpoch() error {
 		MapHead:    mh,
 		Signatures: map[string]*ctmap.DigitallySigned{s.signer.KeyName: sig},
 	}
-	signedMapHead, err := proto.Marshal(smh)
-	if err != nil {
-		return err
-	}
-	if err := s.sths.Append(ctx, epoch, signedMapHead); err != nil {
+	if err := s.sths.Append(ctx, epoch, smh); err != nil {
 		log.Printf("Append failure %v", err)
 		return err
 	}


### PR DESCRIPTION
Use interface{} rather than []byte for storing objects in the
append-only log.

Closes #232
