### PR TITLE
Making testdata/Makefile more robust

### DIFF
--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -17,5 +17,4 @@ vrf:
 	openssl ec -in vrf-key.pem -pubout -out vrf-pubkey.pem
 
 clean:
-	ls | grep -v Makefile | xargs rm
-
+	find . -type f ! -name 'Makefile' -exec rm -f '{}' \;


### PR DESCRIPTION
Allowing `make clean` to be called multiple consecutive time without giving an error. The problem was that  `ls | grep -v Makefile | xargs rm` could not be executed a second time without an error since the files being deleted were already deleted.
