### PR TITLE
Minor changes to fix integration tests

### DIFF
--- a/client/verify.go
+++ b/client/verify.go
@@ -91,7 +91,7 @@ func (c *Client) verifyGetEntryResponse(userID string, in *pb.GetEntryResponse) 
 // verifyLog checks the expected root against the log of signed map heads.
 func (c *Client) verifyLog(smh *ctmap.SignedMapHead, sctBytes []byte) error {
 	// 1) GetSTH.
-	sth, err := c.ctlog.GetSTH()
+	_, err := c.ctlog.GetSTH()
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func (c *Client) verifyLog(smh *ctmap.SignedMapHead, sctBytes []byte) error {
 	// 3) Inclusion Proof.
 
 	// GetByHash
-	sct, err := ct.DeserializeSCT(bytes.NewReader(sctBytes))
+	_, err = ct.DeserializeSCT(bytes.NewReader(sctBytes))
 	if err != nil {
 		return err
 	}
@@ -114,8 +114,6 @@ func (c *Client) verifyLog(smh *ctmap.SignedMapHead, sctBytes []byte) error {
 		return err
 	}
 	************************************************************/
-	_ = sth
-	_ = sct
 	// TODO: Verify inclusion proof.
 
 	return nil

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -49,33 +49,36 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 		{true, false, context.Background(), "bob"},      // Not Empty
 		{true, true, auth.NewContext("bob"), "bob"},     // Update
 	}
-	for _, tc := range tests {
+	for i, tc := range tests {
 		profile, err := env.Client.GetEntry(context.Background(), tc.userID)
 		if err != nil {
-			t.Errorf("GetEntry(%v): %v, want nil", tc.userID, err)
+			t.Errorf("%v: GetEntry(%v): %v, want nil", i, tc.userID, err)
 		}
 		if got := profile != nil; got != tc.want {
-			t.Errorf("GetEntry(%v): %v, want %v", tc.userID, profile, tc.want)
+			t.Errorf("%v: GetEntry(%v): %v, want %v", i, tc.userID, profile, tc.want)
 		}
 		if tc.want {
 			if got, want := len(profile.GetKeys()), 1; got != want {
-				t.Errorf("len(GetKeys()) = %v, want; %v", got, want)
+				t.Errorf("%v: len(GetKeys()) = %v, want; %v", i, got, want)
 				return
 			}
 			if got, want := profile.GetKeys(), primaryKeys; !reflect.DeepEqual(got, want) {
-				t.Errorf("GetKeys() = %v, want: %v", got, want)
+				t.Errorf("%v: GetKeys() = %v, want: %v", i, got, want)
 			}
 		}
 		if tc.insert {
-			_, err := env.Client.Update(tc.ctx, tc.userID, &pb.Profile{primaryKeys})
+			req, err := env.Client.Update(tc.ctx, tc.userID, &pb.Profile{primaryKeys})
 			if got, want := err, client.ErrRetry; got != want {
-				t.Fatalf("Update(%v): %v, want %v", tc.userID, got, want)
+				t.Fatalf("%v: Update(%v): %v, want %v", i, tc.userID, got, want)
 			}
 			if err := env.Signer.Sequence(); err != nil {
-				t.Fatalf("Failed to sequence: %v", err)
+				t.Fatalf("%v: Failed to sequence: %v", i, err)
 			}
 			if err := env.Signer.CreateEpoch(); err != nil {
-				t.Fatalf("Failed to CreateEpoch: %v", err)
+				t.Fatalf("%v: Failed to CreateEpoch: %v", i, err)
+			}
+			if err := env.Client.Retry(tc.ctx, req); err != nil {
+				t.Errorf("%v: Retry(%v): %v, want nil", i, req, err)
 			}
 		}
 	}
@@ -104,19 +107,22 @@ func TestUpdateValidation(t *testing.T) {
 		{true, auth.NewContext("dave"), "dave", profile},
 		{true, auth.NewContext("eve"), "eve", profile},
 	}
-	for _, tc := range tests {
-		_, err := env.Client.Update(tc.ctx, tc.userID, tc.profile)
+	for i, tc := range tests {
+		req, err := env.Client.Update(tc.ctx, tc.userID, tc.profile)
 
 		// The first update response is always a retry.
 		if got, want := err, client.ErrRetry; (got == want) != tc.want {
-			t.Fatalf("Update(%v): %v != %v, want %v", tc.userID, err, want, tc.want)
+			t.Fatalf("%v: Update(%v): %v != %v, want %v", i, tc.userID, err, want, tc.want)
 		}
 		if tc.want {
 			if err := env.Signer.Sequence(); err != nil {
-				t.Fatalf("Failed to sequence: %v", err)
+				t.Fatalf("%v: Failed to sequence: %v", i, err)
 			}
 			if err := env.Signer.CreateEpoch(); err != nil {
-				t.Fatalf("Failed to CreateEpoch: %v", err)
+				t.Fatalf("%v: Failed to CreateEpoch: %v", i, err)
+			}
+			if err := env.Client.Retry(tc.ctx, req); err != nil {
+				t.Errorf("%v: Retry(%v): %v, want nil", i, req, err)
 			}
 		}
 	}

--- a/integration/hkp_test.go
+++ b/integration/hkp_test.go
@@ -67,7 +67,7 @@ func CreateDefaultUser(env *Env, t testing.TB) {
 	authCtx := authentication.NewFake().NewContext(defaultUserID)
 	keyring, _ := hex.DecodeString(strings.Replace(defaultKeyring, "\n", "", -1))
 	profile := &pb.Profile{map[string][]byte{"pgp": keyring}}
-	_, err := env.Client.Update(authCtx, defaultUserID, profile)
+	req, err := env.Client.Update(authCtx, defaultUserID, profile)
 	if got, want := err, client.ErrRetry; got != want {
 		t.Fatalf("Update(%v): %v, want %v", defaultUserID, got, want)
 	}
@@ -76,6 +76,9 @@ func CreateDefaultUser(env *Env, t testing.TB) {
 	}
 	if err := env.Signer.CreateEpoch(); err != nil {
 		t.Fatalf("Failed to CreateEpoch: %v", err)
+	}
+	if err := env.Client.Retry(authCtx, req); err != nil {
+		t.Errorf("Retry(%v): %v, want nil", req, err)
 	}
 }
 

--- a/keyserver/keyserver.go
+++ b/keyserver/keyserver.go
@@ -206,7 +206,10 @@ func (s *Server) UpdateEntry(ctx context.Context, in *pb.UpdateEntryRequest) (*p
 	// The very first mutation will have resp.LeafProof.LeafData=nil.
 	if err := s.mutator.CheckMutation(resp.LeafProof.LeafData, m); err == mutator.ErrReplay {
 		log.Printf("Discarding request due to replay")
-		return &pb.UpdateEntryResponse{resp}, grpc.Errorf(codes.AlreadyExists, "Replayed mutation")
+		// Return the response. The client should handle the replay case
+		// by comparing the returned response with the request. Check
+		// Retry() in client/client.go.
+		return &pb.UpdateEntryResponse{resp}, nil
 	} else if err != nil {
 		log.Printf("Invalid mutation: %v", err)
 		return nil, grpc.Errorf(codes.InvalidArgument, "Invalid mutation")


### PR DESCRIPTION
- Comment the call to `ct.JSONV1LeafHash` and `c.ctlog.GetProofByHash` in `client/verity.go`.
- Have `UpdateEntry()` in `keyserver/keyserver.go` return an `nil` error in replay cases instead of `AlreadyExists`. We cannot return a value and an error at the same time in a gRPC handler. If error is not `nil` the gRPC client handler will suppress the returned value and replace it with `nil`.
- Some cosmetic changes, e.g., integration test cases print the case number in case of errors.
