### PR TITLE
Use objecthash function that supports arbitrary Go objects

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,8 +23,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/google/key-transparency/commitments"
-	"github.com/google/key-transparency/mutator"
 	"github.com/google/key-transparency/signatures"
 	"github.com/google/key-transparency/tree/sparse"
 	tv "github.com/google/key-transparency/tree/sparse/verifier"
@@ -170,14 +170,11 @@ func (c *Client) Update(ctx context.Context, userID string, profile *pb.Profile,
 	if err != nil {
 		return nil, err
 	}
-	previous, err := mutator.ObjectHash(getResp.GetLeafProof().LeafData)
-	if err != nil {
-		return nil, err
-	}
+	previous := objecthash.ObjectHash(getResp.GetLeafProof().LeafData)
 	signedkv := &pb.SignedKV{
 		KeyValue:   kvData,
 		Signatures: nil, // TODO: Apply Signatures.
-		Previous:   previous,
+		Previous:   previous[:],
 	}
 
 	// Send request.

--- a/mutator/entry/entry.go
+++ b/mutator/entry/entry.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"log"
 
+	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/key-transparency/mutator"
 
@@ -48,10 +49,7 @@ func (*Entry) CheckMutation(oldValue, mutation []byte) error {
 	}
 
 	// Verify pointer to previous data.
-	prevEntryHash, err := mutator.ObjectHash(oldValue)
-	if err != nil {
-		return err
-	}
+	prevEntryHash := objecthash.ObjectHash(oldValue)
 	if !bytes.Equal(prevEntryHash[:], update.Previous) {
 		return mutator.ErrPreviousHash
 	}

--- a/mutator/entry/entry_test.go
+++ b/mutator/entry/entry_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/key-transparency/mutator"
 
@@ -71,10 +72,7 @@ func TestCheckMutation(t *testing.T) {
 	largeKey := bytes.Repeat(key, mutator.MaxMutationSize)
 
 	// Calculate hashes.
-	hashEntry1, err := mutator.ObjectHash(entryData1)
-	if err != nil {
-		t.Fatalf("ObjectHash(%v)=%v", entryData1, err)
-	}
+	hashEntry1 := objecthash.ObjectHash(entryData1)
 
 	tests := []struct {
 		key       []byte
@@ -83,10 +81,10 @@ func TestCheckMutation(t *testing.T) {
 		previous  []byte
 		err       error
 	}{
-		{key, entryData1, entryData2, hashEntry1, nil},                  // Normal case.
-		{key, entryData1, entryData1, hashEntry1, mutator.ErrReplay},    // Replayed mutation
-		{largeKey, entryData1, entryData2, hashEntry1, mutator.ErrSize}, // Large mutation
-		{key, entryData1, entryData1, nil, mutator.ErrPreviousHash},     // Invalid previous entry hash
+		{key, entryData1, entryData2, hashEntry1[:], nil},                  // Normal case.
+		{key, entryData1, entryData1, hashEntry1[:], mutator.ErrReplay},    // Replayed mutation
+		{largeKey, entryData1, entryData2, hashEntry1[:], mutator.ErrSize}, // Large mutation
+		{key, entryData1, entryData1, nil, mutator.ErrPreviousHash},        // Invalid previous entry hash
 		// TODO: test case for verifying signature from key in entry.
 	}
 

--- a/mutator/mutator.go
+++ b/mutator/mutator.go
@@ -16,12 +16,7 @@
 // the map.
 package mutator
 
-import (
-	"encoding/json"
-	"errors"
-
-	"github.com/benlaurie/objecthash/go/objecthash"
-)
+import "errors"
 
 var (
 	// MaxMutationSize represent the maximum allowed mutation size in bytes.
@@ -44,15 +39,4 @@ type Mutator interface {
 	CheckMutation(value, mutation []byte) error
 	// Mutate applies mutation to value
 	Mutate(value, mutation []byte) ([]byte, error)
-}
-
-// ObjectHash returns the hash of a given object.
-// TODO: migrate this function to github.com/benlaurie/objecthash/go/objecthash.
-func ObjectHash(obj interface{}) (hash []byte, err error) {
-	jsonObj, err := json.Marshal(obj)
-	if err != nil {
-		return nil, err
-	}
-	objHash := objecthash.CommonJSONHash(string(jsonObj))
-	return objHash[:], nil
 }


### PR DESCRIPTION
`objecthash` library implemented a new `ObjectHash` function that supports hashing arbitrary Go objects. This function is now used to hash previous entries in mutations.

Closes #244.
