### PR TITLE
Implement ListEntryHistory in Client

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/golang/protobuf/proto"
-	ct "github.com/google/certificate-transparency/go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -40,6 +39,12 @@ import (
 )
 
 const (
+	// Each page contains pageSize profiles. Each profile contains multiple
+	// keys. Assuming 2 keys per profile (each of size 2048-bit), a page of
+	// size 16 will contain about 8KB of data.
+	defaultPageSize = int32(16)
+	// The delay before the client retry updating the profile if ErrRetry is
+	// received.
 	retryDelay = 3 * time.Second
 	// TODO: Public key of signer.
 	// TODO: Public keys of trusted monitors.
@@ -100,14 +105,6 @@ func (c *Client) GetEntry(ctx context.Context, userID string, opts ...grpc.CallO
 		return nil, err
 	}
 
-	sct, err := ct.DeserializeSCT(bytes.NewReader(e.SmhSct))
-	if err != nil {
-		return nil, err
-	}
-	if err := c.log.VerifySCT(e.GetSmh(), sct); err != nil {
-		return nil, err
-	}
-
 	// Empty case.
 	if e.GetCommitted() == nil {
 		return nil, nil
@@ -115,9 +112,67 @@ func (c *Client) GetEntry(ctx context.Context, userID string, opts ...grpc.CallO
 
 	profile := new(pb.Profile)
 	if err := proto.Unmarshal(e.GetCommitted().Data, profile); err != nil {
-		return nil, fmt.Errorf("Error unmarshaling profile: %v", err)
+		log.Printf("Error unmarshaling profile: %v", err)
+		return nil, err
 	}
 	return profile, nil
+}
+
+// ListHistory returns a list of profiles starting and ending at given epochs.
+// It also filters out all identical consecutive profiles.
+func (c *Client) ListHistory(ctx context.Context, userID string, startEpoch, endEpoch int64, opts ...grpc.CallOption) ([]*pb.Profile, error) {
+	currentProfile := []byte(nil)
+	profiles := make([]*pb.Profile, 0, endEpoch-startEpoch+1)
+
+	// Setup loop-related variables.
+	pageSize := defaultPageSize
+	epoch := startEpoch
+	for epoch <= endEpoch {
+		resp, err := c.cli.ListEntryHistory(ctx, &pb.ListEntryHistoryRequest{
+			UserId:   userID,
+			Start:    epoch,
+			PageSize: pageSize,
+		}, opts...)
+		if err != nil {
+			return nil, err
+		}
+
+		// Iterate of the responses in reverse order.
+		for i := 0; i < len(resp.GetValues()); i++ {
+			// If empty profile, skip.
+			if resp.GetValues()[i].GetCommitted() == nil {
+				continue
+			}
+
+			pData := resp.GetValues()[i].GetCommitted().Data
+			profile := new(pb.Profile)
+			if err := proto.Unmarshal(pData, profile); err != nil {
+				log.Printf("Error unmarshaling profile: %v", err)
+				return nil, err
+			}
+			// Ignore the extracted profile if it is nil or similar
+			// to the current one. Nil profiles can occur in epochs
+			// before the user updates his profile for the first
+			// time.
+			if bytes.Equal(currentProfile, pData) {
+				continue
+			}
+
+			// Verify the response.
+			err = c.verifyGetEntryResponse(userID, resp.GetValues()[i])
+			if err != nil {
+				return nil, err
+			}
+
+			// Append the slice and update currentProfile.
+			profiles = append(profiles, profile)
+			currentProfile = pData
+		}
+
+		epoch = resp.NextStart
+	}
+
+	return profiles, nil
 }
 
 // Update creates an UpdateEntryRequest for a user, attempt to submit it multiple
@@ -125,10 +180,6 @@ func (c *Client) GetEntry(ctx context.Context, userID string, opts ...grpc.CallO
 func (c *Client) Update(ctx context.Context, userID string, profile *pb.Profile, opts ...grpc.CallOption) (*pb.UpdateEntryRequest, error) {
 	getResp, err := c.cli.GetEntry(ctx, &pb.GetEntryRequest{UserId: userID}, opts...)
 	if err != nil {
-		return nil, err
-	}
-
-	if err := c.verifyGetEntryResponse(userID, getResp); err != nil {
 		return nil, err
 	}
 
@@ -197,11 +248,6 @@ func (c *Client) Update(ctx context.Context, userID string, profile *pb.Profile,
 func (c *Client) Retry(ctx context.Context, req *pb.UpdateEntryRequest) error {
 	updateResp, err := c.cli.UpdateEntry(ctx, req)
 	if err != nil {
-		return err
-	}
-
-	// Validate response.
-	if err := c.verifyGetEntryResponse(req.UserId, updateResp.GetProof()); err != nil {
 		return err
 	}
 

--- a/core/client/verify.go
+++ b/core/client/verify.go
@@ -69,5 +69,7 @@ func (c *Client) verifyGetEntryResponse(userID string, in *pb.GetEntryResponse) 
 	if err := c.VerifySMH(in.GetSmh()); err != nil {
 		return err
 	}
+
+	// TODO: Verify SCT.
 	return nil
 }

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/key-transparency/core/client"
 
 	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	pb "github.com/google/key-transparency/core/proto/keytransparency_v1"
 )
@@ -32,6 +34,11 @@ var (
 		"foo": []byte("bar"),
 	}
 )
+
+type UserInfo struct {
+	userID string
+	ctx    context.Context
+}
 
 func TestEmptyGetAndUpdate(t *testing.T) {
 	auth := authentication.NewFake()
@@ -137,6 +144,164 @@ func TestUpdateValidation(t *testing.T) {
 				t.Errorf("Retry(%v): %v, want nil", req, err)
 			}
 		}
+	}
+}
+
+func TestListHistory(t *testing.T) {
+	auth := authentication.NewFake()
+	userInfo := []UserInfo{
+		{"alice", auth.NewContext("alice")},
+		{"bob", auth.NewContext("bob")},
+		{"dave", auth.NewContext("dave")},
+	}
+
+	for _, tc := range []struct {
+		// The length of users and profiles *must* match.
+		users    []int
+		profiles []int
+		listUser int
+		end      int64
+		// History profiles are in reversed order.
+		wantHistory []int
+		err         codes.Code
+	}{
+		{
+			[]int{0},
+			[]int{0},
+			0,
+			1,
+			[]int{0},
+			codes.OK,
+		}, // Single user, single profile
+		{
+			[]int{0, 0},
+			[]int{0, 1},
+			0,
+			1,
+			[]int{0, 1},
+			codes.OK,
+		}, // Single user, multiple profiles, no filtering
+		{
+			[]int{0, 0, 1, 0, 1, 0, 0, 1, 1},
+			[]int{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			0,
+			9,
+			[]int{1, 2, 4, 6, 7},
+			codes.OK,
+		}, // Two users, multiple profiles
+		{
+			[]int{0, 0, 1, 0, 1},
+			[]int{1, 2, 3, 4, 5},
+			1,
+			5,
+			[]int{3, 5},
+			codes.OK,
+		}, // Two users, multiple profiles, test 'nil' first profile(s)
+		{
+			[]int{1, 2, 0, 0, 1, 1, 2, 0, 0, 0, 1, 1, 2, 0, 1},
+			[]int{1, 2, 3, 2, 4, 6, 4, 5, 4, 3, 3, 7, 5, 1, 4},
+			2,
+			15,
+			[]int{2, 4, 5},
+			codes.OK,
+		}, // Three users, multiple profiles (filtering should work)
+		{
+			[]int{1, 2, 0, 0, 1, 1, 2, 0, 2, 0, 0, 1, 1, 2, 0, 1},
+			[]int{1, 2, 3, 2, 4, 6, 4, 5, 4, 4, 3, 3, 7, 5, 1, 4},
+			2,
+			16,
+			[]int{2, 4, 5},
+			codes.OK,
+		}, // Three users, multiple (consecutive resubmission) profiles
+		{
+			[]int{1, 2, 0, 0, 2, 0, 1, 2, 2, 1, 1, 1, 0, 0, 2, 1},
+			[]int{9, 3, 5, 3, 6, 1, 3, 5, 6, 7, 2, 6, 9, 8, 5, 9},
+			1,
+			16,
+			[]int{9, 3, 7, 2, 6, 9},
+			codes.OK,
+		}, // Three users, multiple (resubmitted) profiles
+		{
+			[]int{0, 1, 2, 0, 2, 2, 1, 0, 0, 2, 1, 0, 2, 1, 2, 0, 0, 2, 1, 2, 0},
+			[]int{4, 5, 8, 3, 2, 8, 9, 1, 0, 3, 4, 7, 6, 3, 1, 7, 0, 3, 6, 7, 2},
+			1,
+			21,
+			[]int{5, 9, 4, 3, 6},
+			codes.OK,
+		}, // Multiple pages
+		{
+			[]int{0, 1, 2, 0, 2},
+			[]int{4, 5, 8, 3, 2},
+			1,
+			100,
+			[]int{},
+			codes.InvalidArgument,
+		}, // Request beyond current epoch.
+	} {
+		if len(tc.users) != len(tc.profiles) {
+			t.Fatalf("len(tc.users) != len(tc.profiles)", len(tc.users), len(tc.profiles))
+		}
+
+		env := NewEnv(t)
+		defer env.Close(t)
+		env.Client.RetryCount = 0
+
+		// Update profiles.
+		if err := env.prepareHistory(userInfo, tc.users, tc.profiles); err != nil {
+			t.Fatalf("Failed prepareHistory: %v", err)
+		}
+
+		startEpoch := int64(1) // beginning of time.
+		listCtx := userInfo[tc.listUser].ctx
+		listUserID := userInfo[tc.listUser].userID
+
+		// Test history.
+		gotHistory, err := env.Client.ListHistory(listCtx, listUserID, startEpoch, tc.end)
+		if got, want := grpc.Code(err), tc.err; got != want {
+			t.Fatalf("ListHistory(_, %v, %v, %v) failed: %v, want %v", listUserID, startEpoch, tc.end, got, want)
+		}
+
+		// Ensure that history has the correct number of profiles.
+		if got, want := len(gotHistory), len(tc.wantHistory); got != want {
+			t.Fatalf("len(gotHistory)=%v, want %v", got, want)
+		}
+
+		// Ensure that history has the correct profiles in the correct
+		// order.
+		for j := 0; j < len(gotHistory); j++ {
+			if got, want := gotHistory[j], createProfile(tc.wantHistory[j]); !reflect.DeepEqual(got, want) {
+				t.Errorf("Invalid profile: %v, want %v", got, want)
+			}
+		}
+	}
+}
+
+func (e *Env) prepareHistory(userInfo []UserInfo, users []int, profiles []int) error {
+	for j := 0; j < len(users); j++ {
+		ctx := userInfo[users[j]].ctx
+		userID := userInfo[users[j]].userID
+		profile := createProfile(profiles[j])
+		_, err := e.Client.Update(ctx, userID, profile)
+		// The first update response is always a retry.
+		if got, want := err, client.ErrRetry; got != want {
+			return fmt.Errorf("Update(%v)=(_, %v), want (_, %v)", userID, got, want)
+		}
+		if err := e.Signer.Sequence(); err != nil {
+			return fmt.Errorf("Failed to sequence: %v", err)
+		}
+		if err := e.Signer.CreateEpoch(); err != nil {
+			return fmt.Errorf("Failed to CreateEpoch: %v", err)
+		}
+	}
+	return nil
+}
+
+// createProfile creates a dummy profile using the passed tag.
+func createProfile(tag int) *pb.Profile {
+	return &pb.Profile{
+		Keys: map[string][]byte{
+			fmt.Sprintf("foo%v", tag): []byte(fmt.Sprintf("bar%v", tag)),
+		},
 	}
 }
 


### PR DESCRIPTION
- Client `ListHistory()` output is compact, it filters out consecutive identical profiles.
- Integration test for `ListHistory()` is added.

Closes #209.
