### PR TITLE
Fix VRF Bugs

### DIFF
--- a/vrf/p256/p256.go
+++ b/vrf/p256/p256.go
@@ -97,8 +97,7 @@ func H2(m []byte) *big.Int {
 	byteLen := (params.BitSize + 7) >> 3
 	h := sha512.New()
 	buf := make([]byte, 4)
-	var i uint32
-	for {
+	for i := uint32(0); ; i++ {
 		// TODO: Use a NIST specified DRBG.
 		binary.BigEndian.PutUint32(buf[:], i)
 		h.Reset()
@@ -138,9 +137,12 @@ func (k PrivateKey) Evaluate(m []byte) (vrf, proof []byte) {
 	t := new(big.Int).Sub(ri, new(big.Int).Mul(s, k.D))
 	t.Mod(t, params.N)
 
-	//Write s,t as proof blob.
+	// Write s and t to a proof blob. Also write leading zeros before s and t
+	// if needed.
 	var buf bytes.Buffer
+	buf.Write(make([]byte, 32-len(s.Bytes())))
 	buf.Write(s.Bytes())
+	buf.Write(make([]byte, 32-len(t.Bytes())))
 	buf.Write(t.Bytes())
 
 	// VRF_k(m) = [k]H

--- a/vrf/p256/p256_test.go
+++ b/vrf/p256/p256_test.go
@@ -16,43 +16,34 @@ package p256
 
 import (
 	"crypto/ecdsa"
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"testing"
 )
 
 func TestH1(t *testing.T) {
-	tests := []struct {
-		m string
-	}{
-		{""},
-		{"a"},
-		{"bbbbbbbbbbbbbbbbbbbbbbb"},
-	}
-	for _, tc := range tests {
-		x, y := H1([]byte(tc.m))
+	for i := 0; i < 10000; i++ {
+		m := make([]byte, 100)
+		rand.Read(m)
+		x, y := H1([]byte(m))
 		if x == nil {
-			t.Errorf("H1(%v)=%v, want curve point", tc.m, x)
+			t.Errorf("H1(%v)=%v, want curve point", m, x)
 		}
 		if got := curve.Params().IsOnCurve(x, y); got != true {
-			t.Errorf("H1(%v)=%v, is not on curve", tc.m)
+			t.Errorf("H1(%v)=%v, is not on curve", m)
 		}
 	}
 }
 
 func TestH2(t *testing.T) {
-	tests := []struct {
-		m string
-		l int
-	}{
-		{"", 32},
-		{"a", 32},
-		{"bbbbbbbbbbbbbbbbbbbbbbb", 32},
-	}
-	for _, tc := range tests {
-		x := H2([]byte(tc.m))
-		if got := len(x.Bytes()); got != tc.l {
-			t.Errorf("len(h2(%v)) = %v, want %v", tc.m, got, tc.l)
+	l := 32
+	for i := 0; i < 10000; i++ {
+		m := make([]byte, 100)
+		rand.Read(m)
+		x := H2([]byte(m))
+		if got := len(x.Bytes()); got < 1 && got > l {
+			t.Errorf("len(h2(%v)) = %v, want %v", m, got, l)
 		}
 	}
 }
@@ -79,9 +70,9 @@ func TestVRF(t *testing.T) {
 		{m3, vrf3, proof1, ErrInvalidVRF},
 	}
 
-	for _, tc := range tests {
+	for i, tc := range tests {
 		if got, want := pk.Verify(tc.m, tc.vrf[:], tc.proof), tc.err; got != want {
-			t.Errorf("Verify(%v, %v, %v): got %v, want %v", tc.m, tc.vrf, tc.proof, got, want)
+			t.Errorf("%v: Verify(%v, %v, %v): got %v, want %v", i, tc.m, tc.vrf, tc.proof, got, want)
 		}
 	}
 }


### PR DESCRIPTION
In `vrf/p256/p256.go` and `vrf/p256/p256_test.go`:
- Make `H2()` increase `i` in the `for` loop.
- Make `Verify()` always return a fixed-size 64-byte proofs.
- Make `TestH1` create a lot of random input values and run them against `H1`.
- Make `TestH2` create a lot of random input values and run them against `H2`.
- Fix `TestH2` to expect an output of size between 1 and 32 bytes.

Closes #243.
