### PR TITLE
Implement Client ListHistory

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/golang/protobuf/proto"
+	ct "github.com/google/certificate-transparency/go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -103,6 +104,14 @@ func (c *Client) GetEntry(ctx context.Context, userID string, opts ...grpc.CallO
 	}
 
 	if err := c.verifyGetEntryResponse(userID, e); err != nil {
+		return nil, err
+	}
+
+	sct, err := ct.DeserializeSCT(bytes.NewReader(e.SmhSct))
+	if err != nil {
+		return nil, err
+	}
+	if err := c.log.VerifySCT(e.GetSmh(), sct); err != nil {
 		return nil, err
 	}
 
@@ -192,6 +201,10 @@ func (c *Client) Update(ctx context.Context, userID string, profile *tpb.Profile
 		return nil, err
 	}
 
+	if err := c.verifyGetEntryResponse(userID, getResp); err != nil {
+		return nil, err
+	}
+
 	// Extract index from a prior GetEntry call.
 	index := c.vrf.Index(getResp.Vrf)
 	prevEntry := new(tpb.Entry)
@@ -257,6 +270,11 @@ func (c *Client) Update(ctx context.Context, userID string, profile *tpb.Profile
 func (c *Client) Retry(ctx context.Context, req *tpb.UpdateEntryRequest) error {
 	updateResp, err := c.cli.UpdateEntry(ctx, req)
 	if err != nil {
+		return err
+	}
+
+	// Validate response.
+	if err := c.verifyGetEntryResponse(req.UserId, updateResp.GetProof()); err != nil {
 		return err
 	}
 

--- a/core/client/verify.go
+++ b/core/client/verify.go
@@ -15,13 +15,11 @@
 package client
 
 import (
-	"bytes"
 	"errors"
 
 	"github.com/google/key-transparency/core/commitments"
 
 	"github.com/golang/protobuf/proto"
-	ct "github.com/google/certificate-transparency/go"
 
 	ctmap "github.com/google/key-transparency/core/proto/ctmap"
 	tpb "github.com/google/key-transparency/core/proto/kt_types_v1"
@@ -69,15 +67,6 @@ func (c *Client) verifyGetEntryResponse(userID string, in *tpb.GetEntryResponse)
 	}
 
 	if err := c.VerifySMH(in.GetSmh()); err != nil {
-		return err
-	}
-
-	// Verify SCT.
-	sct, err := ct.DeserializeSCT(bytes.NewReader(in.SmhSct))
-	if err != nil {
-		return err
-	}
-	if err := c.log.VerifySCT(in.GetSmh(), sct); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Client `ListHistory()` output is compact, it filters out consecutive identical profiles.
- Integration test for `ListHistory()` is added.

Closes #209.
