### PR TITLE
Implement Client ListHistory

### DIFF
--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -138,4 +138,91 @@ func TestUpdateValidation(t *testing.T) {
 	}
 }
 
+func TestListHistory(t *testing.T) {
+	userID := "bob"
+	ctx := authentication.NewFake().NewContext("bob")
+
+	env := NewEnv(t)
+	defer env.Close(t)
+	env.Client.RetryCount = 0
+	if err := env.setupHistory(ctx, userID); err != nil {
+		t.Fatalf("setupHistory failed: %v", err)
+	}
+
+	for _, tc := range []struct {
+		start, end  int64
+		wantHistory []*tpb.Profile
+		wantErr     bool
+	}{
+		{3, 3, []*tpb.Profile{cp(1)}, false},                                                   // single profile
+		{3, 4, []*tpb.Profile{cp(1), cp(2)}, false},                                            // multiple profiles
+		{1, 4, []*tpb.Profile{cp(1), cp(2)}, false},                                            // test 'nil' first profile(s)
+		{3, 10, []*tpb.Profile{cp(1), cp(2), cp(3), cp(4), cp(5)}, false},                      // filtering
+		{9, 16, []*tpb.Profile{cp(4), cp(5), cp(6)}, false},                                    // filtering consecutive resubmitted profiles
+		{9, 20, []*tpb.Profile{cp(4), cp(5), cp(6), cp(5), cp(7)}, false},                      // no filtering of resubmitted profiles
+		{1, 20, []*tpb.Profile{cp(1), cp(2), cp(3), cp(4), cp(5), cp(6), cp(5), cp(7)}, false}, // multiple pages
+		{0, 20, []*tpb.Profile{}, true},                                                        // Invalid start epoch
+		{1, 1000, []*tpb.Profile{}, true},                                                      // Invalid end epoch, beyond current epoch
+	} {
+		gotHistory, err := env.Client.ListHistory(ctx, userID, tc.start, tc.end)
+		if got, want := err != nil, tc.wantErr; got != want {
+			t.Fatalf("ListHistory(_, %v, %v, %v) failed: %v, want err %v", userID, tc.start, tc.end, err, want)
+		}
+		// If there's a ListHistory error, skip the rest of the test.
+		if err != nil {
+			continue
+		}
+
+		// Ensure that history has the correct number of profiles.
+		if got, want := len(gotHistory), len(tc.wantHistory); got != want {
+			t.Errorf("len(gotHistory)=%v, want %v", got, want)
+			continue
+		}
+		// Ensure that history has the correct profiles in the correct
+		// order.
+		if !reflect.DeepEqual(gotHistory, tc.wantHistory) {
+			t.Errorf("Invalid history: %v, want %v", gotHistory, tc.wantHistory)
+		}
+	}
+}
+
+func (e *Env) setupHistory(ctx context.Context, userID string) error {
+	// Setup. Each profile entry is either nil, to indicate that the user
+	// did not submit a new profile in that epoch, or contains the profile
+	// that the user is submitting. The user profile history contains the
+	// following profiles:
+	// [nil, nil, 1, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 5, 5, 6, 6, 5, 7, 7].
+	// Note that profile 5 is submitted twice by the user to test that
+	// filtering case.
+	for _, p := range []*tpb.Profile{
+		nil, nil, cp(1), cp(2), nil, nil, cp(3), nil,
+		cp(4), cp(5), cp(5), nil, nil, nil, nil, cp(6),
+		nil, cp(5), cp(7), nil,
+	} {
+		if p != nil {
+			_, err := e.Client.Update(ctx, userID, p)
+			// The first update response is always a retry.
+			if got, want := err, client.ErrRetry; got != want {
+				return fmt.Errorf("Update(%v)=(_, %v), want (_, %v)", userID, got, want)
+			}
+			if err := e.Signer.Sequence(); err != nil {
+				return fmt.Errorf("Failed to sequence: %v", err)
+			}
+		}
+		if err := e.Signer.CreateEpoch(); err != nil {
+			return fmt.Errorf("Failed to CreateEpoch: %v", err)
+		}
+	}
+	return nil
+}
+
+// cp creates a dummy profile using the passed tag.
+func cp(tag int) *tpb.Profile {
+	return &tpb.Profile{
+		Keys: map[string][]byte{
+			fmt.Sprintf("foo%v", tag): []byte(fmt.Sprintf("bar%v", tag)),
+		},
+	}
+}
+
 // TODO: Test AppID filtering when implemented.


### PR DESCRIPTION
- Client `ListHistory()` output is compact, it filters out consecutive identical profiles.
- Integration test for `ListHistory()` is added.

Closes #209.
