### PR TITLE
Move client CT into its own package

### DIFF
--- a/cmd/client/client.go
+++ b/cmd/client/client.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/google/key-transparency/core/client"
-	lv "github.com/google/key-transparency/core/client/ct"
+	"github.com/google/key-transparency/core/client/ctlog"
 	"github.com/google/key-transparency/core/signatures"
 	"github.com/google/key-transparency/core/vrf"
 	"github.com/google/key-transparency/core/vrf/p256"
@@ -132,7 +132,7 @@ func getClient(cc *grpc.ClientConn, vrfPubFile, ktSig, ctURL, ctPEM string) (*cl
 	if err != nil {
 		return nil, fmt.Errorf("error reading ctPEM: %v", err)
 	}
-	ctClient, err := lv.NewLogVerifier(pem, ctURL)
+	ctClient, err := ctlog.New(pem, ctURL)
 	if err != nil {
 		return nil, fmt.Errorf("error creating CT client: %v", err)
 	}

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -24,7 +24,7 @@ import (
 	"log"
 	"time"
 
-	lv "github.com/google/key-transparency/core/client/ct"
+	"github.com/google/key-transparency/core/client/ctlog"
 	"github.com/google/key-transparency/core/commitments"
 	"github.com/google/key-transparency/core/signatures"
 	"github.com/google/key-transparency/core/tree/sparse"
@@ -70,11 +70,11 @@ type Client struct {
 	RetryCount   int
 	treeVerifier *tv.Verifier
 	verifier     *signatures.Verifier
-	log          lv.LogVerifier
+	log          ctlog.Verifier
 }
 
 // New creates a new client.
-func New(client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier *signatures.Verifier, log lv.LogVerifier) *Client {
+func New(client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier *signatures.Verifier, log ctlog.Verifier) *Client {
 	return &Client{
 		cli:          client,
 		vrf:          vrf,

--- a/core/client/ctlog/client_ct.go
+++ b/core/client/ctlog/client_ct.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package ct
+package ctlog
 
 import (
 	"bytes"
@@ -33,8 +33,8 @@ var hasher = func(b []byte) []byte {
 	return h[:]
 }
 
-// LogVerifier represents an append-only log.
-type LogVerifier interface {
+// Verifier represents an append-only log.
+type Verifier interface {
 	// VerifySCT ensures that a SignedMapHead has been properly included in
 	// a Certificate Transparency append-only log. If the inclusion proof
 	// cannot be immediately verified, it is added to a list that
@@ -67,8 +67,8 @@ type SCTEntry struct {
 	smh *ctmap.SignedMapHead
 }
 
-// NewLogVerifier produces a new CT log verification client.
-func NewLogVerifier(pem []byte, logURL string) (*Log, error) {
+// New produces a new CT log verification client.
+func New(pem []byte, logURL string) (*Log, error) {
 	pk, _, _, err := ct.PublicKeyFromPEM(pem)
 	if err != nil {
 		return nil, fmt.Errorf("error reading public key from pem: %v", err)

--- a/core/client/ctlog/client_ct_test.go
+++ b/core/client/ctlog/client_ct_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package ctutil implements helper functions for testing against Certificate Transparency.
-package ct
+package ctlog
 
 import (
 	"encoding/json"
@@ -59,11 +59,11 @@ func NewCTServer(t testing.TB) *httptest.Server {
 func TestInclusionProof(t *testing.T) {
 	hs := NewCTServer(t)
 	defer hs.Close()
-	l, err := NewLogVerifier([]byte(pem), hs.URL)
+	l, err := New([]byte(pem), hs.URL)
 	if err != nil {
 		t.Fatalf("Failed to create log client: %v", err)
 	}
-	lnoconn, err := NewLogVerifier([]byte(pem), "")
+	lnoconn, err := New([]byte(pem), "")
 	if err != nil {
 		t.Fatalf("Failed to create log client: %v", err)
 	}
@@ -97,9 +97,9 @@ func TestInclusionProof(t *testing.T) {
 }
 
 func TestUpdateSTH(t *testing.T) {
-	l, err := NewLogVerifier([]byte(pem), "")
+	l, err := New([]byte(pem), "")
 	if err != nil {
-		t.Fatalf("NewLogVerifier(): %v", err)
+		t.Fatalf("New(): %v", err)
 	}
 	for i, tc := range []struct {
 		start, end uint64
@@ -141,9 +141,9 @@ func TestUpdateSTH(t *testing.T) {
 // TestVerifySCT exercises an immediate verification via an inclusion proof as
 // well as a delayed SCT verification where the SCT is stored for later verification.
 func TestVerifySCT(t *testing.T) {
-	l, err := NewLogVerifier([]byte(pem), "")
+	l, err := New([]byte(pem), "")
 	if err != nil {
-		t.Fatalf("NewLogVerifier(): %v", err)
+		t.Fatalf("New(): %v", err)
 	}
 	for _, tc := range []struct {
 		smh, sct, sth, inclusion, hash, consistency string
@@ -211,9 +211,9 @@ func TestVerifySCT(t *testing.T) {
 func TestVerifySCTSig(t *testing.T) {
 	hs := NewCTServer(t)
 	defer hs.Close()
-	l, err := NewLogVerifier([]byte(pem), hs.URL)
+	l, err := New([]byte(pem), hs.URL)
 	if err != nil {
-		t.Fatalf("NewLogVerifier(): %v", err)
+		t.Fatalf("New(): %v", err)
 	}
 
 	var smh ctmap.SignedMapHead
@@ -232,9 +232,9 @@ func TestVerifySCTSig(t *testing.T) {
 
 // TestVerifySavedSCTs ensures that cached SCTs are verified.
 func TestVerifySavedSCTs(t *testing.T) {
-	l, err := NewLogVerifier([]byte(pem), "")
+	l, err := New([]byte(pem), "")
 	if err != nil {
-		t.Fatalf("NewLogVerifier(): %v", err)
+		t.Fatalf("New(): %v", err)
 	}
 	for i, tc := range []struct {
 		smh, sct, sth, inclusion, hash string

--- a/integration/client_ct_fake.go
+++ b/integration/client_ct_fake.go
@@ -15,7 +15,7 @@
 package integration
 
 import (
-	lv "github.com/google/key-transparency/core/client/ct"
+	"github.com/google/key-transparency/core/client/ctlog"
 
 	ct "github.com/google/certificate-transparency/go"
 
@@ -30,7 +30,7 @@ func (fakeLog) VerifySCT(smh *ctmap.SignedMapHead, sct *ct.SignedCertificateTime
 }
 
 // VerifySavedSCTs returns a list of SCTs that failed validation against the current STH.
-func (fakeLog) VerifySavedSCTs() []lv.SCTEntry { return nil }
+func (fakeLog) VerifySavedSCTs() []ctlog.SCTEntry { return nil }
 
 // UpdateSTH ensures that STH is at least 1 MMD from Now().
 func (fakeLog) UpdateSTH() error { return nil }


### PR DESCRIPTION
It makes more sense to have `LogVerifier` into its own package under `core/client`.

Prerequisite for #306.
