### PR TITLE
Move gRPC client to cmd/client

### DIFF
--- a/cmd/client/cmd/root.go
+++ b/cmd/client/cmd/root.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/google/key-transparency/core/client"
+	"github.com/google/key-transparency/cmd/client/grpcc"
 	"github.com/google/key-transparency/core/client/ctlog"
 	"github.com/google/key-transparency/core/signatures"
 	"github.com/google/key-transparency/core/vrf"
@@ -165,7 +165,7 @@ func readSignatureVerifier(ktPEM string) (*signatures.Verifier, error) {
 	return ver, nil
 }
 
-func getClient(cc *grpc.ClientConn, vrfPubFile, ktSig, ctURL, ctPEM string) (*client.Client, error) {
+func getClient(cc *grpc.ClientConn, vrfPubFile, ktSig, ctURL, ctPEM string) (*grpcc.Client, error) {
 	// Create CT client.
 	pem, err := ioutil.ReadFile(ctPEM)
 	if err != nil {
@@ -186,7 +186,7 @@ func getClient(cc *grpc.ClientConn, vrfPubFile, ktSig, ctURL, ctPEM string) (*cl
 		return nil, fmt.Errorf("error reading key transparency PEM: %v", err)
 	}
 	cli := pb.NewKeyTransparencyServiceClient(cc)
-	return client.New(cli, vrfKey, verifier, ctClient), nil
+	return grpcc.New(cli, vrfKey, verifier, ctClient), nil
 }
 
 func dial(ktURL, caFile, clientSecretFile string) (*grpc.ClientConn, error) {
@@ -226,7 +226,7 @@ func dial(ktURL, caFile, clientSecretFile string) (*grpc.ClientConn, error) {
 
 // GetClient connects to the server and returns a key transpency verification
 // client.
-func GetClient(clientSecretFile string) (*client.Client, error) {
+func GetClient(clientSecretFile string) (*grpcc.Client, error) {
 	ktURL := viper.GetString("kt-url")
 	ktPEM := viper.GetString("kt-key")
 	ktSig := viper.GetString("kt-sig")

--- a/cmd/client/grpcc/grpc_client.go
+++ b/cmd/client/grpcc/grpc_client.go
@@ -15,7 +15,7 @@
 // Client for communicating with the Key Server.
 // Implements verification and convenience functions.
 
-package client
+package grpcc
 
 import (
 	"bytes"

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/key-transparency/cmd/client/grpcc"
 	"github.com/google/key-transparency/core/authentication"
-	"github.com/google/key-transparency/core/client"
 
 	"golang.org/x/net/context"
 
@@ -58,7 +58,7 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 		// Update profile.
 		if tc.insert {
 			req, err := env.Client.Update(tc.ctx, tc.userID, &tpb.Profile{Keys: primaryKeys})
-			if got, want := err, client.ErrRetry; got != want {
+			if got, want := err, grpcc.ErrRetry; got != want {
 				t.Fatalf("Update(%v): %v, want %v", tc.userID, got, want)
 			}
 			if err := env.Signer.Sequence(); err != nil {
@@ -121,7 +121,7 @@ func TestUpdateValidation(t *testing.T) {
 		req, err := env.Client.Update(tc.ctx, tc.userID, tc.profile)
 
 		// The first update response is always a retry.
-		if got, want := err, client.ErrRetry; (got == want) != tc.want {
+		if got, want := err, grpcc.ErrRetry; (got == want) != tc.want {
 			t.Fatalf("Update(%v): %v != %v, want %v", tc.userID, err, want, tc.want)
 		}
 		if tc.want {
@@ -202,7 +202,7 @@ func (e *Env) setupHistory(ctx context.Context, userID string) error {
 		if p != nil {
 			_, err := e.Client.Update(ctx, userID, p)
 			// The first update response is always a retry.
-			if got, want := err, client.ErrRetry; got != want {
+			if got, want := err, grpcc.ErrRetry; got != want {
 				return fmt.Errorf("Update(%v)=(_, %v), want (_, %v)", userID, got, want)
 			}
 			if err := e.Signer.Sequence(); err != nil {

--- a/integration/hkp_test.go
+++ b/integration/hkp_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/key-transparency/cmd/client/grpcc"
 	"github.com/google/key-transparency/core/authentication"
-	"github.com/google/key-transparency/core/client"
 
 	"golang.org/x/net/context"
 
@@ -68,7 +68,7 @@ func CreateDefaultUser(env *Env, t testing.TB) {
 	keyring, _ := hex.DecodeString(strings.Replace(defaultKeyring, "\n", "", -1))
 	profile := &tpb.Profile{Keys: map[string][]byte{"pgp": keyring}}
 	req, err := env.Client.Update(authCtx, defaultUserID, profile)
-	if got, want := err, client.ErrRetry; got != want {
+	if got, want := err, grpcc.ErrRetry; got != want {
 		t.Fatalf("Update(%v): %v, want %v", defaultUserID, got, want)
 	}
 	if err := env.Signer.Sequence(); err != nil {

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -20,8 +20,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/key-transparency/cmd/client/grpcc"
 	"github.com/google/key-transparency/core/authentication"
-	"github.com/google/key-transparency/core/client"
 	"github.com/google/key-transparency/core/keyserver"
 	"github.com/google/key-transparency/core/mutator/entry"
 	"github.com/google/key-transparency/core/signatures"
@@ -74,7 +74,7 @@ type Env struct {
 	GRPCServer *grpc.Server
 	V2Server   *keyserver.Server
 	Conn       *grpc.ClientConn
-	Client     *client.Client
+	Client     *grpcc.Client
 	Signer     *signer.Signer
 	db         *sql.DB
 	clus       *integration.ClusterV3
@@ -201,7 +201,7 @@ func NewEnv(t *testing.T) *Env {
 		t.Fatalf("Dial(%v) = %v", addr, err)
 	}
 	cli := pb.NewKeyTransparencyServiceClient(cc)
-	client := client.New(cli, vrfPub, verifier, fakeLog{})
+	client := grpcc.New(cli, vrfPub, verifier, fakeLog{})
 	client.RetryCount = 0
 
 	return &Env{s, server, cc, client, signer, sqldb, clus, vrfPriv, cli, hs}


### PR DESCRIPTION
Move the gRPC client in `core/client/client.go` out of the core module to ensure that `core` is not dependent on `impl`.
