### PR TITLE
Allow multiple queued updates to leaf in same epoch

### DIFF
--- a/cmd/backend/backend.go
+++ b/cmd/backend/backend.go
@@ -101,7 +101,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create STH appender: %v", err)
 	}
-	mutations, err := appender.New(sqldb, *mapID, *mapLogURL)
+	mutations, err := appender.New(nil, *mapID, *mapLogURL)
 	if err != nil {
 		log.Fatalf("Failed to create mutation appender: %v", err)
 	}

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -44,7 +44,7 @@ const (
 	WHERE MapId = $1 AND NodeId = $2 and Version <= $3
 	ORDER BY Version DESC LIMIT 1;`
 	queueExpr = `
-	INSERT INTO Leaves (MapId, LeafId, Version, Data)
+	INSERT OR REPLACE INTO Leaves (MapId, LeafId, Version, Data)
 	VALUES ($1, $2, $3, $4);`
 	pendingLeafsExpr = `
 	SELECT LeafId, Version, Data FROM Leaves 


### PR DESCRIPTION
Client update behavior is as follows:
1. Fetch current value
2. Apply and send mutation
3. Fetch current value to see if the mutation has been applied.
4. Retry by going to 2 and repeating as needed.

This allows multiple retries in the same epoch to succeed. The last one
will "stick". If multiple clients are updating, one of them will succeed,
the other will fail, and retry again.
