### PR TITLE
Remove epoch field from GetEntryRequest

### DIFF
--- a/core/proto/kt_types_v1/kt_types_v1.proto
+++ b/core/proto/kt_types_v1/kt_types_v1.proto
@@ -99,10 +99,8 @@ message SignedKV {
 
 // GetEntryReqyest for a user object.
 message GetEntryRequest {
-  // Absence of the epoch_end field indicates a request for the current value.
-  int64 epoch_end = 1;
   // User identifier. Most commonly an email address.
-  string user_id = 2;
+  string user_id = 1;
 }
 
 // GetEntryResponse returns a requested user entry.


### PR DESCRIPTION
/v1/user/userID should return the current value for user.
Historical values are accessed through /v1/user/userID/history.

This API cleanup has the side effect of making epoch 0 accessable
through the history API.  Previously, we had overloaded epoch 0 to also
mean "current epoch".
