### PR TITLE
Fix tree hashes size

### DIFF
--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/key-transparency/core/client/ctlog"
 	"github.com/google/key-transparency/core/commitments"
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/tree/sparse"
 	tv "github.com/google/key-transparency/core/tree/sparse/verifier"
 	"github.com/google/key-transparency/core/vrf"
 
@@ -97,7 +98,7 @@ func (v *Verifier) VerifyGetEntryResponse(userID string, in *tpb.GetEntryRespons
 		return ErrNilProof
 	}
 
-	if err := v.tree.VerifyProof(leafProof.Neighbors, index[:], leafProof.LeafData, in.GetSmh().MapHead.Root); err != nil {
+	if err := v.tree.VerifyProof(leafProof.Neighbors, index[:], leafProof.LeafData, sparse.FromBytes(in.GetSmh().MapHead.Root)); err != nil {
 		Vlog.Printf("✗ Sparse tree proof verification failed.")
 		return err
 	}

--- a/core/tree/sparse/common_test.go
+++ b/core/tree/sparse/common_test.go
@@ -22,10 +22,10 @@ func TestComputeNodeValues(t *testing.T) {
 	for _, tc := range []struct {
 		bindex    string
 		leafHash  []byte
-		neighbors [][]byte
+		neighbors []Hash
 		expected  []string
 	}{
-		{"0100", []byte(""), make([][]byte, 4), []string{"0100", "010", "01", "0", ""}},
+		{"0100", []byte(""), make([]Hash, 4), []string{"0100", "010", "01", "0", ""}},
 	} {
 		actual := NodeValues([]byte("mapID"), CONIKSHasher, tc.bindex, tc.leafHash, tc.neighbors)
 		if got, want := len(actual), len(tc.expected); got != want {

--- a/core/tree/sparse/verifier/verifier_test.go
+++ b/core/tree/sparse/verifier/verifier_test.go
@@ -103,7 +103,7 @@ func TestVerifyProof(t *testing.T) {
 				nbrs[256-len(leaf.nbrs)+k] = nbr
 			}
 
-			if err := verifier.VerifyProof(nbrs, leaf.index, leaf.value, tc.root); err != nil {
+			if err := verifier.VerifyProof(nbrs, leaf.index, leaf.value, sparse.FromBytes(tc.root)); err != nil {
 				t.Errorf("VerifyProof(_, %v, _, _)=%v", leaf.index, err)
 			}
 		}


### PR DESCRIPTION
Specify all hashes length used in tree core and implementation, including the tree root.

Closes #239.
Closes #297.
