### PR TITLE
Ensure Hasher Implementation Matches CONIKS Paper Guidelines

### DIFF
--- a/core/tree/sparse/common.go
+++ b/core/tree/sparse/common.go
@@ -52,7 +52,7 @@ func NodeValues(hasher TreeHasher, bindex string, value []byte, nbrValues [][]by
 			left = nbrValues[i]
 			right = nodeValues[i]
 		}
-		nodeValues[i+1] = hasher.HashChildren(left, right)
+		nodeValues[i+1] = hasher.HashInterior(left, right)
 	}
 	return nodeValues
 }

--- a/core/tree/sparse/verifier/verifier.go
+++ b/core/tree/sparse/verifier/verifier.go
@@ -98,9 +98,9 @@ func (v *Verifier) calculateRoot(neighbors [][]byte, bindex string, leaf []byte)
 		// right, otherwise, neighbor is on the left.
 		switch bindex[len(neighbors)-1-i] {
 		case tree.Zero:
-			calculatedRoot = v.hasher.HashChildren(calculatedRoot, neighbor)
+			calculatedRoot = v.hasher.HashInterior(calculatedRoot, neighbor)
 		case tree.One:
-			calculatedRoot = v.hasher.HashChildren(neighbor, calculatedRoot)
+			calculatedRoot = v.hasher.HashInterior(neighbor, calculatedRoot)
 		default:
 			return nil, ErrIndexBit
 		}

--- a/core/tree/sparse/verifier/verifier_test.go
+++ b/core/tree/sparse/verifier/verifier_test.go
@@ -57,38 +57,38 @@ func TestVerifyProof(t *testing.T) {
 		// Tree with multiple leaves, each has a single existing neighbor
 		// on the way to the root.
 		{
-			dh("5bb1d793893ec70dd21a83f4faa94232e0ff9d8c74bc928d3479beb9b82608bc"),
+			dh("c84c416481ee9610ac80cbcafc000caf0ef9210a3494fe60610339cceb94ca51"),
 			[]Leaf{
 				{dh(defaultIndex[0]), []byte("3"), [][]byte{
-					dh("d16cfa61bd103aa958da52eccae55715c8a2f2a33663a8397b13d3c2fa31090a"),
+					dh("90a89a487fe9ce56f0d09e10521f49dc359352e6df2e651fd9dfda5576ef301d"),
 					[]byte{},
 				}},
 				{dh(defaultIndex[1]), []byte("4"), [][]byte{
-					dh("30eec702b035570b82889d71db8325b05576a80f327cefeac17c743a7cae88b3"),
+					dh("56bb3dea5b1917f78ceada1e30aa6ef3eb10c92e853a184920bc77ebba880c97"),
 					[]byte{},
 				}},
 				{dh(defaultIndex[2]), nil, [][]byte{
-					dh("7184164d16837c61b15e347d20fb6338c5c437edf7e919e0865a59906557ff98"),
+					dh("a54055bcae7a5b30437a8019d06cc4d3e9bc7ed4ebd61b7788ae6b37c519376e"),
 				}},
 				{dh(AllZeros), nil, [][]byte{
-					dh("7184164d16837c61b15e347d20fb6338c5c437edf7e919e0865a59906557ff98"),
+					dh("a54055bcae7a5b30437a8019d06cc4d3e9bc7ed4ebd61b7788ae6b37c519376e"),
 				}},
 			},
 		},
 		// Tree with multiple leaves, some have multiple existing
 		// neighbors on the way to the root.
 		{
-			dh("84b5275ffa8ac9e9fc7afc3bcfb8e69fff186fb675dd6ee25bf1b46d199daea0"),
+			dh("6a4fc1a01ccd5bf4a04d10024caf32f64a6b31ac3abc33ed226f2477c2e1538a"),
 			[]Leaf{
 				{dh(defaultIndex[2]), []byte("0"), [][]byte{
-					dh("39d08ffc594fab8829d228e6771f85b63d1a4607606739ccf65e89daebe4deb2"),
+					dh("70d6b51a07afec6df56009534ea66b3d582882b682b2984379e1a1f521d2226f"),
 				}},
 				{dh(defaultIndex[0]), []byte("3"), [][]byte{
-					dh("e8d949ff3705218835274fe8a04695d1800e72ecb327f2e266821f0b5c21b904"),
+					dh("ac94e5c10744333c8fd6cdf4eb7064d10e269ced005659b4c92380eed0606fad"),
 				}},
 				{dh(AllZeros), nil, [][]byte{
-					dh("68572f8d1ecbd5fa055ec6eed6d2587ee8f7a661c20ef20e5f74465d116c4f8d"),
-					dh("39d08ffc594fab8829d228e6771f85b63d1a4607606739ccf65e89daebe4deb2"),
+					dh("568fa9c30d8fe3dbe8d7f4dc112d41581e4583a9dc77e61030f36fd22c83247b"),
+					dh("70d6b51a07afec6df56009534ea66b3d582882b682b2984379e1a1f521d2226f"),
 				}},
 			},
 		},


### PR DESCRIPTION
CONIKS hasher implementation hashes the depth before the index, which is not consistent with CONIKS guidelines. This PR fixes this.

Should merge #328 first.
