### PR TITLE
Make NodeValues not return leaf value

### DIFF
--- a/core/tree/sparse/common.go
+++ b/core/tree/sparse/common.go
@@ -35,7 +35,8 @@ const (
 	IndexLen = HashSize * 8
 )
 
-// NodeValues computes the new values for nodes up the tree.
+// NodeValues computes the new values for leafs up the tree. It does not include
+// the passed node value in the returned list. nbrValues must not be compressed.
 func NodeValues(hasher TreeHasher, bindex string, value []byte, nbrValues [][]byte) [][]byte {
 	levels := len(bindex) + 1
 	steps := len(bindex)
@@ -54,5 +55,5 @@ func NodeValues(hasher TreeHasher, bindex string, value []byte, nbrValues [][]by
 		}
 		nodeValues[i+1] = hasher.HashChildren(left, right)
 	}
-	return nodeValues
+	return nodeValues[1:]
 }

--- a/core/tree/sparse/common_test.go
+++ b/core/tree/sparse/common_test.go
@@ -25,7 +25,7 @@ func TestComputeNodeValues(t *testing.T) {
 		neighbors [][]byte
 		expected  []string
 	}{
-		{"0100", []byte(""), make([][]byte, 4), []string{"0100", "010", "01", "0", ""}},
+		{"0100", []byte(""), make([][]byte, 4), []string{"010", "01", "0", ""}},
 	} {
 		actual := NodeValues(CONIKSHasher, tc.bindex, tc.leafHash, tc.neighbors)
 		if got, want := len(actual), len(tc.expected); got != want {

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -306,7 +306,13 @@ func (m *Map) setLeafAt(ctx context.Context, index []byte, depth int, value []by
 
 	nodeValues := sparse.NodeValues(hasher, bindex, value, nbrValues)
 
-	// Save new nodes.
+	// Save the leaf node.
+	_, err = writeStmt.Exec(m.mapID, nodeIDs[0], epoch, value)
+	if err != nil {
+		return err
+	}
+	// Save the rest of the new nodes.
+	nodeIDs = nodeIDs[1:]
 	for i, nodeValue := range nodeValues {
 		_, err = writeStmt.Exec(m.mapID, nodeIDs[i], epoch, nodeValue)
 		if err != nil {


### PR DESCRIPTION
`NodeValues` currently returns all node values starting from a leaf node all the way up to the root, **including** the leaf value. This is not a clean API since returned leaf value can be of an arbitrary  length while all the other returned values are of fixed length. This PR make `NodeValues` only return the calculated values without the leaf value.

Prerequisite of #239.
