### PR TITLE
Use Leaf Hash Instead of Leaf Value

### DIFF
--- a/core/tree/sparse/common.go
+++ b/core/tree/sparse/common.go
@@ -36,11 +36,12 @@ const (
 )
 
 // NodeValues computes the new values for nodes up the tree.
-func NodeValues(hasher TreeHasher, bindex string, value []byte, nbrValues [][]byte) [][]byte {
+func NodeValues(mapID []byte, hasher TreeHasher, bindex string, value []byte, nbrValues [][]byte) [][]byte {
 	levels := len(bindex) + 1
 	steps := len(bindex)
 	nodeValues := make([][]byte, levels)
-	nodeValues[0] = value
+	index, depth := tree.InvertBitString(bindex)
+	nodeValues[0] = hasher.HashLeaf(mapID, index, depth, value)
 	// assert len(nbrValues) == levels - 1
 	for i := 0; i < steps; i++ {
 		// Is the last node 0 or 1?

--- a/core/tree/sparse/common_test.go
+++ b/core/tree/sparse/common_test.go
@@ -27,7 +27,7 @@ func TestComputeNodeValues(t *testing.T) {
 	}{
 		{"0100", []byte(""), make([][]byte, 4), []string{"0100", "010", "01", "0", ""}},
 	} {
-		actual := NodeValues(CONIKSHasher, tc.bindex, tc.leafHash, tc.neighbors)
+		actual := NodeValues([]byte("mapID"), CONIKSHasher, tc.bindex, tc.leafHash, tc.neighbors)
 		if got, want := len(actual), len(tc.expected); got != want {
 			t.Errorf("len(%v)=%v, want %v", actual, got, want)
 		}

--- a/core/tree/sparse/verifier/verifier.go
+++ b/core/tree/sparse/verifier/verifier.go
@@ -71,19 +71,24 @@ func (v *Verifier) VerifyProof(neighbors [][]byte, index, leaf, root []byte) err
 // calculateRoot calculates the root of the tree branch defined by leaf and
 // neighbors.
 func (v *Verifier) calculateRoot(neighbors [][]byte, bindex string, leaf []byte) ([]byte, error) {
+	var leafHash []byte
+
 	// If the leaf is empty, it is a proof of absence.
 	if len(leaf) == 0 {
 		// Trim the neighbors list.
 		neighbors = trimNeighbors(neighbors)
 
-		// Set the value of the empty leaf
+		// Calculate the value of the empty leaf
 		missingBranchBIndex := bindex[:len(neighbors)]
 		index, depth := tree.InvertBitString(missingBranchBIndex)
-		leaf = v.hasher.HashEmpty(v.mapID, index, depth)
+		leafHash = v.hasher.HashEmpty(v.mapID, index, depth)
+	} else {
+		index, depth := tree.InvertBitString(bindex)
+		leafHash = v.hasher.HashLeaf(v.mapID, index, depth, leaf)
 	}
 
-	// calculatedRoot contains the calculated root so far. It starts from the leaf.
-	calculatedRoot := leaf
+	// calculatedRoot holds the calculated root so far, starting from leaf.
+	calculatedRoot := leafHash
 	for i, neighbor := range neighbors {
 		// Get the neighbor bit string index.
 		neighborBIndex := tree.NeighborString(bindex[:len(neighbors)-i])

--- a/core/tree/sparse/verifier/verifier_test.go
+++ b/core/tree/sparse/verifier/verifier_test.go
@@ -57,38 +57,38 @@ func TestVerifyProof(t *testing.T) {
 		// Tree with multiple leaves, each has a single existing neighbor
 		// on the way to the root.
 		{
-			dh("c84c416481ee9610ac80cbcafc000caf0ef9210a3494fe60610339cceb94ca51"),
+			dh("4a1d580869a6ed8949b0035be5bfbd52085749f52b83d7eb7fab2340fdeb6070"),
 			[]Leaf{
 				{dh(defaultIndex[0]), []byte("3"), [][]byte{
-					dh("90a89a487fe9ce56f0d09e10521f49dc359352e6df2e651fd9dfda5576ef301d"),
+					dh("87bf45e808101bfd5e564dd2eed054c0879da7b0407ef895be2c1a99645da454"),
 					[]byte{},
 				}},
 				{dh(defaultIndex[1]), []byte("4"), [][]byte{
-					dh("56bb3dea5b1917f78ceada1e30aa6ef3eb10c92e853a184920bc77ebba880c97"),
+					dh("dfecc3e854af9140e5224942719b5ad23d637612dc146fcd600a1679d6956797"),
 					[]byte{},
 				}},
 				{dh(defaultIndex[2]), nil, [][]byte{
-					dh("a54055bcae7a5b30437a8019d06cc4d3e9bc7ed4ebd61b7788ae6b37c519376e"),
+					dh("cedff4217d4b07261f009ef2331fd286fa1a7a2edbc1b5f4783735aeee02d692"),
 				}},
 				{dh(AllZeros), nil, [][]byte{
-					dh("a54055bcae7a5b30437a8019d06cc4d3e9bc7ed4ebd61b7788ae6b37c519376e"),
+					dh("cedff4217d4b07261f009ef2331fd286fa1a7a2edbc1b5f4783735aeee02d692"),
 				}},
 			},
 		},
 		// Tree with multiple leaves, some have multiple existing
 		// neighbors on the way to the root.
 		{
-			dh("6a4fc1a01ccd5bf4a04d10024caf32f64a6b31ac3abc33ed226f2477c2e1538a"),
+			dh("0930a343db7e987c9635351fb8c03f9cf51cbec8e4bfd2faf5acd3c29eb9a945"),
 			[]Leaf{
 				{dh(defaultIndex[2]), []byte("0"), [][]byte{
-					dh("70d6b51a07afec6df56009534ea66b3d582882b682b2984379e1a1f521d2226f"),
+					dh("a5535c120ea1a8aa2918119d1b8123d447c1e0a95b994671f20e563ac472a7b6"),
 				}},
 				{dh(defaultIndex[0]), []byte("3"), [][]byte{
-					dh("ac94e5c10744333c8fd6cdf4eb7064d10e269ced005659b4c92380eed0606fad"),
+					dh("34b5001fe4bbe7d1454f7d216c51ccb5016f980d94220015124c2d28396205a4"),
 				}},
 				{dh(AllZeros), nil, [][]byte{
-					dh("568fa9c30d8fe3dbe8d7f4dc112d41581e4583a9dc77e61030f36fd22c83247b"),
-					dh("70d6b51a07afec6df56009534ea66b3d582882b682b2984379e1a1f521d2226f"),
+					dh("f98aa36ec5551cd216db932d2ac1d6069690c6d1189aa4dc9185bf2336410ffa"),
+					dh("a5535c120ea1a8aa2918119d1b8123d447c1e0a95b994671f20e563ac472a7b6"),
 				}},
 			},
 		},

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -308,7 +308,7 @@ func (m *Map) setLeafAt(ctx context.Context, index []byte, depth int, value []by
 		return err
 	}
 
-	nodeValues := sparse.NodeValues(hasher, bindex, value, nbrValues)
+	nodeValues := sparse.NodeValues(m.mapID, hasher, bindex, value, nbrValues)
 
 	// Save new nodes.
 	for i, nodeValue := range nodeValues {


### PR DESCRIPTION
When calculating node values after inserting or updating a leaf, the leaf value is used when calculating the new values all the way up to the root (using `NodeValues`). This is inconsistent with CONKIS guidelines. This PR make `NodeValues` uses the leaf hash instead of its value, following these guidelines.

The same applies for tree verifier in `core/tree/sparse/verifier/verifier.go`.

Prerequisite of #239.
Should merge #326 first.
