### PR TITLE
Add mapID in CONIKS hasher

### DIFF
--- a/.key-transparency.yaml
+++ b/.key-transparency.yaml
@@ -1,6 +1,7 @@
 ct-key: "../certificate-transparency/test/testdata/ct-server-key-public.pem"
 ct-url: "http://107.178.246.112"
 vrf:    "testdata/vrf-pubkey.pem"
+domain: "example.com"
 kt-key: "testdata/server.crt"
 kt-sig: "testdata/p256-pubkey.pem"
 kt-url: "localhost:5003"

--- a/cmd/client/grpcc/grpc_client.go
+++ b/cmd/client/grpcc/grpc_client.go
@@ -88,11 +88,11 @@ type Client struct {
 }
 
 // New creates a new client.
-func New(client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier *signatures.Verifier, log ctlog.Verifier) *Client {
+func New(mapID string, client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier *signatures.Verifier, log ctlog.Verifier) *Client {
 	return &Client{
 		cli:        client,
 		vrf:        vrf,
-		kt:         kt.New(vrf, tv.New(sparse.CONIKSHasher), verifier, log),
+		kt:         kt.New(vrf, tv.New([]byte(mapID), sparse.CONIKSHasher), verifier, log),
 		CT:         log,
 		RetryCount: 1,
 		RetryDelay: 3 * time.Second,

--- a/core/tree/sparse/hasher.go
+++ b/core/tree/sparse/hasher.go
@@ -21,9 +21,9 @@ import (
 
 // TreeHasher provides hash functions for tree implementations.
 type TreeHasher interface {
-	HashLeaf(index []byte, depth int, dataHash []byte) []byte
+	HashLeaf(mapID, index []byte, depth int, dataHash []byte) []byte
 	HashChildren(left []byte, right []byte) []byte
-	HashEmpty(index []byte, depth int) []byte
+	HashEmpty(mapID, index []byte, depth int) []byte
 }
 
 // CONIKSHasher implements the tree hashes described in CONIKS
@@ -39,9 +39,9 @@ var (
 )
 
 // HashLeaf calculate the merkle tree node value:
-// H(Identifier || depth || index || dataHash)
-func (c coniks) HashLeaf(index []byte, depth int, dataHash []byte) []byte {
-	return c.hashLeaf(leafIdentifier, index, depth, dataHash)
+// H(Identifier || mapID || depth || index || dataHash)
+func (c coniks) HashLeaf(mapID, index []byte, depth int, dataHash []byte) []byte {
+	return c.hashLeaf(mapID, leafIdentifier, index, depth, dataHash)
 }
 
 // HashChildren calculates an interior node's value: H(left || right)
@@ -53,16 +53,21 @@ func (coniks) HashChildren(left []byte, right []byte) []byte {
 }
 
 // HashEmpty computes the value of an empty leaf:
-// H(EmptyIdentifier || depth || index)
-func (c coniks) HashEmpty(index []byte, depth int) []byte {
-	return c.hashLeaf(emptyIdentifier, index, depth, nil)
+// H(EmptyIdentifier || mapID || depth || index)
+func (c coniks) HashEmpty(mapID, index []byte, depth int) []byte {
+	return c.hashLeaf(mapID, emptyIdentifier, index, depth, nil)
 }
 
-func (coniks) hashLeaf(identifier []byte, index []byte, depth int, dataHash []byte) []byte {
+func (coniks) hashLeaf(mapID, identifier []byte, index []byte, depth int, dataHash []byte) []byte {
+	bmapIDLen := make([]byte, 4)
+	binary.BigEndian.PutUint32(bmapIDLen, uint32(len(mapID)))
 	bdepth := make([]byte, 4)
 	binary.BigEndian.PutUint32(bdepth, uint32(depth))
+
 	h := newHash()
 	h.Write(identifier)
+	h.Write(bmapIDLen)
+	h.Write(mapID)
 	h.Write(bdepth)
 	h.Write(index)
 	h.Write(dataHash)

--- a/core/tree/sparse/verifier/verifier.go
+++ b/core/tree/sparse/verifier/verifier.go
@@ -38,12 +38,13 @@ var (
 
 // Verifier represents a sparse tree proof verifier object.
 type Verifier struct {
+	mapID  []byte
 	hasher sparse.TreeHasher
 }
 
 // New returns a new tree proofs verifier object.
-func New(hasher sparse.TreeHasher) *Verifier {
-	return &Verifier{hasher}
+func New(mapID []byte, hasher sparse.TreeHasher) *Verifier {
+	return &Verifier{mapID, hasher}
 }
 
 // VerifyProof verifies a tree proof of a given leaf at a given index based on
@@ -77,7 +78,8 @@ func (v *Verifier) calculateRoot(neighbors [][]byte, bindex string, leaf []byte)
 
 		// Set the value of the empty leaf
 		missingBranchBIndex := bindex[:len(neighbors)]
-		leaf = v.hasher.HashEmpty(tree.InvertBitString(missingBranchBIndex))
+		index, depth := tree.InvertBitString(missingBranchBIndex)
+		leaf = v.hasher.HashEmpty(v.mapID, index, depth)
 	}
 
 	// calculatedRoot contains the calculated root so far. It starts from the leaf.
@@ -87,7 +89,8 @@ func (v *Verifier) calculateRoot(neighbors [][]byte, bindex string, leaf []byte)
 		neighborBIndex := tree.NeighborString(bindex[:len(neighbors)-i])
 		// If the neighbor is empty, set it to HashEmpty output.
 		if len(neighbor) == 0 {
-			neighbor = v.hasher.HashEmpty(tree.InvertBitString(neighborBIndex))
+			nIndex, nDepth := tree.InvertBitString(neighborBIndex)
+			neighbor = v.hasher.HashEmpty(v.mapID, nIndex, nDepth)
 		}
 
 		// The leaf index is processed starting from len(neighbors)-1

--- a/core/tree/sparse/verifier/verifier_test.go
+++ b/core/tree/sparse/verifier/verifier_test.go
@@ -23,6 +23,8 @@ import (
 	"golang.org/x/net/context"
 )
 
+const mapID = "verifyMap"
+
 var (
 	ctx          = context.Background()
 	AllZeros     = strings.Repeat("0", 256/4)
@@ -40,14 +42,14 @@ type Leaf struct {
 }
 
 func TestVerifyProof(t *testing.T) {
-	verifier := New(sparse.CONIKSHasher)
+	verifier := New([]byte(mapID), sparse.CONIKSHasher)
 	for _, tc := range []struct {
 		root   []byte
 		leaves []Leaf
 	}{
 		// Verify proof of absence in an empty tree.
 		{
-			dh("d576e4657c5f86ba33a435d1abd22cff4f61de4df0cc16c50bd653b1360b367c"),
+			dh("36d699dd75f74edb84789d1bf301a9c2ff8dc815b70f5afc8ec156f5ae102c65"),
 			[]Leaf{
 				{dh(AllZeros), nil, [][]byte{}},
 			},
@@ -55,38 +57,38 @@ func TestVerifyProof(t *testing.T) {
 		// Tree with multiple leaves, each has a single existing neighbor
 		// on the way to the root.
 		{
-			dh("376bcc69fda95cea8455224faf8e5a05eaff9ad943e3ef96aaef910649b52806"),
+			dh("5bb1d793893ec70dd21a83f4faa94232e0ff9d8c74bc928d3479beb9b82608bc"),
 			[]Leaf{
 				{dh(defaultIndex[0]), []byte("3"), [][]byte{
-					dh("fe9992d1c917b1362bd4aad7c1dbaa10dcaa2649844aed2e3d3407b6f28ea6c0"),
+					dh("d16cfa61bd103aa958da52eccae55715c8a2f2a33663a8397b13d3c2fa31090a"),
 					[]byte{},
 				}},
 				{dh(defaultIndex[1]), []byte("4"), [][]byte{
-					dh("f9369f6c112ff583212b7ff07342a84e3f41cfda101923db76cc5517b23d9a38"),
+					dh("30eec702b035570b82889d71db8325b05576a80f327cefeac17c743a7cae88b3"),
 					[]byte{},
 				}},
 				{dh(defaultIndex[2]), nil, [][]byte{
-					dh("7987058861eb3fd513c2d00b91f42fc9bb6b2d878b5b298f4d6ef0c38f1c5395"),
+					dh("7184164d16837c61b15e347d20fb6338c5c437edf7e919e0865a59906557ff98"),
 				}},
 				{dh(AllZeros), nil, [][]byte{
-					dh("7987058861eb3fd513c2d00b91f42fc9bb6b2d878b5b298f4d6ef0c38f1c5395"),
+					dh("7184164d16837c61b15e347d20fb6338c5c437edf7e919e0865a59906557ff98"),
 				}},
 			},
 		},
 		// Tree with multiple leaves, some have multiple existing
 		// neighbors on the way to the root.
 		{
-			dh("528044b5a83335c074eb8631fdaeddd96d65e420ad3031d88cfe03b1ed6f33eb"),
+			dh("84b5275ffa8ac9e9fc7afc3bcfb8e69fff186fb675dd6ee25bf1b46d199daea0"),
 			[]Leaf{
 				{dh(defaultIndex[2]), []byte("0"), [][]byte{
-					dh("b2283f973324190e2992523432604a3ce6732aef09d267fbf951840d9a854043"),
+					dh("39d08ffc594fab8829d228e6771f85b63d1a4607606739ccf65e89daebe4deb2"),
 				}},
 				{dh(defaultIndex[0]), []byte("3"), [][]byte{
-					dh("5ff0f6495d23d0be76e524710814c76b55213afe9514d473066f920b5c655ec9"),
+					dh("e8d949ff3705218835274fe8a04695d1800e72ecb327f2e266821f0b5c21b904"),
 				}},
 				{dh(AllZeros), nil, [][]byte{
-					dh("5ad9ddb4579867b9914df56703bd64502397cf02c1f1178393dfee26548d1259"),
-					dh("b2283f973324190e2992523432604a3ce6732aef09d267fbf951840d9a854043"),
+					dh("68572f8d1ecbd5fa055ec6eed6d2587ee8f7a661c20ef20e5f74465d116c4f8d"),
+					dh("39d08ffc594fab8829d228e6771f85b63d1a4607606739ccf65e89daebe4deb2"),
 				}},
 			},
 		},

--- a/impl/sql/sqlhist/sqlhist_test.go
+++ b/impl/sql/sqlhist/sqlhist_test.go
@@ -241,7 +241,7 @@ func TestAribtrayInsertOrder(t *testing.T) {
 	}
 	roots := make([][]byte, len(leafs))
 	for i := range roots {
-		m, err := New(db, fmt.Sprintf("test%v", i))
+		m, err := New(db, "testMap")
 		if err != nil {
 			t.Fatalf("Failed to create SQL history: %v", err)
 		}

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -201,7 +201,7 @@ func NewEnv(t *testing.T) *Env {
 		t.Fatalf("Dial(%v) = %v", addr, err)
 	}
 	cli := pb.NewKeyTransparencyServiceClient(cc)
-	client := grpcc.New(cli, vrfPub, verifier, fakeLog{})
+	client := grpcc.New(mapID, cli, vrfPub, verifier, fakeLog{})
 	client.RetryCount = 0
 
 	return &Env{s, server, cc, client, signer, sqldb, clus, vrfPriv, cli, hs}


### PR DESCRIPTION
Current CONIKS hasher does not include a tree-wide nonce, which is inconsistent with CONIKS guidelines. This PR fixes this issue by using `mapID` as part of the hasher.
