### PR TITLE
Add context to tree Commit API

### DIFF
--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -189,7 +189,7 @@ func (*fakeSparseHist) QueueLeaf(ctx context.Context, index, leaf []byte) error 
 	return nil
 }
 
-func (*fakeSparseHist) Commit() (epoch int64, err error) {
+func (*fakeSparseHist) Commit(ctx context.Context) (epoch int64, err error) {
 	return 0, nil
 }
 

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -133,7 +133,7 @@ func (s *Signer) processMutation(index, mutation []byte) error {
 // CreateEpoch signs the current map head.
 func (s *Signer) CreateEpoch() error {
 	ctx := context.Background()
-	epoch, err := s.tree.Commit()
+	epoch, err := s.tree.Commit(ctx)
 	if err != nil {
 		return fmt.Errorf("Commit err: %v", err)
 	}

--- a/core/tree/tree.go
+++ b/core/tree/tree.go
@@ -25,7 +25,7 @@ type SparseHist interface {
 	QueueLeaf(ctx context.Context, index, leaf []byte) error
 	// Commit takes all the Queued values since the last Commmit() and writes them.
 	// Commit is NOT multi-process safe. It should only be called from the sequencer.
-	Commit() (epoch int64, err error)
+	Commit(ctx context.Context) (epoch int64, err error)
 	// ReadRootAt returns the root value at epoch.
 	ReadRootAt(ctx context.Context, epoch int64) ([]byte, error)
 	// ReadLeafAt returns the leaf value at epoch.

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -130,7 +130,7 @@ type leafRow struct {
 
 // Commit takes all the Queued values since the last Commmit() and writes them.
 // Commit is NOT multi-process safe. It should only be called from the sequencer.
-func (m *Map) Commit() (int64, error) {
+func (m *Map) Commit(ctx context.Context) (int64, error) {
 	// Get the list of pending leafs
 	stmt, err := m.db.Prepare(pendingLeafsExpr)
 	if err != nil {

--- a/impl/sql/sqlhist/sqlhist_test.go
+++ b/impl/sql/sqlhist/sqlhist_test.go
@@ -108,7 +108,7 @@ func TestEpochNumAdvance(t *testing.T) {
 				t.Errorf("QueueLeaf(%v, %v): %v", tc.index, tc.leaf, err)
 			}
 		}
-		if got, err := tree.Commit(); err != nil || got != tc.epoch {
+		if got, err := tree.Commit(ctx); err != nil || got != tc.epoch {
 			t.Errorf("Commit(): %v, %v, want %v", got, err, tc.epoch)
 		}
 		if got, _ := tree.readEpoch(); got != tc.epoch {
@@ -138,7 +138,7 @@ func TestQueueCommitRead(t *testing.T) {
 		if err := m.QueueLeaf(ctx, index, data); err != nil {
 			t.Errorf("WriteLeaf(%v, %v)=%v", index, data, err)
 		}
-		epoch, err := m.Commit()
+		epoch, err := m.Commit(ctx)
 		if err != nil {
 			t.Errorf("Commit()=[_, %v], want [_, nil]", err)
 		}
@@ -206,7 +206,7 @@ func TestReadPreviousEpochs(t *testing.T) {
 		if err := m.QueueLeaf(ctx, tc.index, data); err != nil {
 			t.Errorf("WriteLeaf(%v, %v)=%v", tc.index, data, err)
 		}
-		if got, err := m.Commit(); err != nil || got != tc.epoch {
+		if got, err := m.Commit(ctx); err != nil || got != tc.epoch {
 			t.Errorf("Commit()=%v, %v, want %v, nil", got, err, tc.epoch)
 		}
 
@@ -250,7 +250,7 @@ func TestAribtrayInsertOrder(t *testing.T) {
 			if err := m.QueueLeaf(ctx, leaf.index, []byte(leaf.data)); err != nil {
 				t.Errorf("WriteLeaf(%v, %v)=%v", leaf.index, leaf.data, err)
 			}
-			if _, err := m.Commit(); err != nil {
+			if _, err := m.Commit(ctx); err != nil {
 				t.Errorf("Commit()= %v, want nil", err)
 			}
 		}
@@ -332,7 +332,7 @@ func createTree(db *sql.DB, mapID string, leafs []leaf) (*Map, error) {
 			return nil, fmt.Errorf("QueueLeaf(%v)=%v", l.index, err)
 		}
 	}
-	if epoch, err := m.Commit(); err != nil || epoch != 0 {
+	if epoch, err := m.Commit(ctx); err != nil || epoch != 0 {
 		return nil, fmt.Errorf("Commit()=%v, %v, want %v, <nil>", epoch, err, 0)
 	}
 	return m, nil


### PR DESCRIPTION
This PR adds the missing `context.Context` parameter to Tree `Commit()` API.
