### PR TITLE
Make SQL queries work for Sqlite and MySQL

### DIFF
--- a/impl/sql/appender/ct.go
+++ b/impl/sql/appender/ct.go
@@ -42,6 +42,22 @@ const (
 )
 
 var (
+	createStmt = []string{
+		`
+	CREATE TABLE IF NOT EXISTS Maps (
+		MapId   VARCHAR(32) NOT NULL,
+		PRIMARY KEY(MapID)
+	);`,
+		`
+	CREATE TABLE IF NOT EXISTS SMH (
+		MapId   VARCHAR(32) NOT NULL,
+		Epoch   INTEGER     NOT NULL,
+		Data    BLOB(1024)  NOT NULL,
+		SCT     BLOB(1024)  NOT NULL,
+		PRIMARY KEY(MapID, Epoch),
+		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
+	);`,
+	}
 	// ErrNotSupported occurs when performing an operaion that has been disabled.
 	ErrNotSupported = errors.New("operation not supported")
 )
@@ -89,22 +105,6 @@ func New(db *sql.DB, mapID, logURL string) (*CTAppender, error) {
 
 // Create creates a new database.
 func (a *CTAppender) create() error {
-	createStmt := []string{
-		`
-	CREATE TABLE IF NOT EXISTS Maps (
-		MapId   VARCHAR(32) NOT NULL,
-		PRIMARY KEY(MapID)
-	);`,
-		`
-	CREATE TABLE IF NOT EXISTS SMH (
-		MapId   VARCHAR(32) NOT NULL,
-		Epoch   INTEGER     NOT NULL,
-		Data    BLOB(1024)  NOT NULL,
-		SCT     BLOB(1024)  NOT NULL,
-		PRIMARY KEY(MapID, Epoch),
-		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
-	);`,
-	}
 	for _, stmt := range createStmt {
 		_, err := a.db.Exec(stmt)
 		if err != nil {

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -29,6 +29,31 @@ import (
 )
 
 var (
+	createStmt = []string{
+		`
+	CREATE TABLE IF NOT EXISTS Maps (
+		MapId   VARCHAR(32) NOT NULL,
+		PRIMARY KEY(MapID)
+	);`,
+		`
+	CREATE TABLE IF NOT EXISTS Leaves (
+		MapId   VARCHAR(32) NOT NULL,
+		LeafId  VARCHAR(32) NOT NULL,
+		Version INTEGER     NOT NULL,
+		Data    BLOB        NOT NULL,
+		PRIMARY KEY(MapID, LeafId, Version),
+		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
+	);`,
+		`
+	CREATE TABLE IF NOT EXISTS Nodes (
+		MapId   VARCHAR(32) NOT NULL,
+		NodeId  VARCHAR(32) NOT NULL,
+		Version	INTEGER     NOT NULL,
+		Value	BLOB(32)    NOT NULL,
+		PRIMARY KEY(MapId, NodeId, Version),
+		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
+	);`,
+	}
 	hasher          = sparse.CONIKSHasher
 	errNilLeaf      = errors.New("nil leaf")
 	errIndexLen     = errors.New("index len != 32")
@@ -337,31 +362,6 @@ func (m *Map) setRootAt(ctx context.Context, value sparse.Hash, epoch int64) err
 
 // Create creates a new database.
 func (m *Map) create() error {
-	createStmt := []string{
-		`
-	CREATE TABLE IF NOT EXISTS Maps (
-		MapId   VARCHAR(32) NOT NULL,
-		PRIMARY KEY(MapID)
-	);`,
-		`
-	CREATE TABLE IF NOT EXISTS Leaves (
-		MapId   VARCHAR(32) NOT NULL,
-		LeafId  VARCHAR(32) NOT NULL,
-		Version INTEGER     NOT NULL,
-		Data    BLOB        NOT NULL,
-		PRIMARY KEY(MapID, LeafId, Version),
-		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
-	);`,
-		`
-	CREATE TABLE IF NOT EXISTS Nodes (
-		MapId   VARCHAR(32) NOT NULL,
-		NodeId  VARCHAR(32) NOT NULL,
-		Version	INTEGER     NOT NULL,
-		Value	BLOB(32)    NOT NULL,
-		PRIMARY KEY(MapId, NodeId, Version),
-		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
-	);`,
-	}
 	for _, stmt := range createStmt {
 		_, err := m.db.Exec(stmt)
 		if err != nil {


### PR DESCRIPTION
This PR makes all SQL queries compatible for both Sqlite and MySQL. Key changes:
- Use `VARCHAR(32)` instead of `BLOB(32)` for table primary key fields. MySQL can't deal with `BLOB/TEXT` fields as keys.
- Split the single `CREATE TABLE` statement into multiple ones.
- Use `REPLACE` instead of `INSERT OR IGNORE` and `INSERT OR REPLACE`.
