### PR TITLE
Use VARBINARY for Binary Data

### DIFF
--- a/impl/sql/commitments/sql.go
+++ b/impl/sql/commitments/sql.go
@@ -44,9 +44,9 @@ var (
 	);`,
 		`
 	CREATE TABLE IF NOT EXISTS Commitments (
-		MapId      VARCHAR(32) NOT NULL,
-		Commitment VARCHAR(32) NOT NULL,
-		Value      BLOB(1024)  NOT NULL,
+		MapId      VARCHAR(32)   NOT NULL,
+		Commitment VARBINARY(32) NOT NULL,
+		Value      BLOB(1024)    NOT NULL,
 		PRIMARY KEY(MapID, Commitment),
 		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
 	);`,

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -37,19 +37,19 @@ var (
 	);`,
 		`
 	CREATE TABLE IF NOT EXISTS Leaves (
-		MapId   VARCHAR(32) NOT NULL,
-		LeafId  VARCHAR(32) NOT NULL,
-		Version INTEGER     NOT NULL,
-		Data    BLOB        NOT NULL,
+		MapId   VARCHAR(32)   NOT NULL,
+		LeafId  VARBINARY(32) NOT NULL,
+		Version INTEGER       NOT NULL,
+		Data    BLOB          NOT NULL,
 		PRIMARY KEY(MapID, LeafId, Version),
 		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
 	);`,
 		`
 	CREATE TABLE IF NOT EXISTS Nodes (
-		MapId   VARCHAR(32) NOT NULL,
-		NodeId  VARCHAR(32) NOT NULL,
-		Version	INTEGER     NOT NULL,
-		Value	BLOB(32)    NOT NULL,
+		MapId   VARCHAR(32)   NOT NULL,
+		NodeId  VARBINARY(32) NOT NULL,
+		Version	INTEGER       NOT NULL,
+		Value	BLOB(32)      NOT NULL,
 		PRIMARY KEY(MapId, NodeId, Version),
 		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
 	);`,


### PR DESCRIPTION
Binary data such as commitment node and leaf IDs are currently stored in `VARCHAR`. Use `VARBINARY` makes more sense and allows the use of MySQL as a database drive. This also avoids any encoding issues.
