### PR TITLE
Use Common Transaction Object for DB and Queue Operations

### DIFF
--- a/cmd/key-transparency-signer/backend.go
+++ b/cmd/key-transparency-signer/backend.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/key-transparency/impl/etcd/queue"
 	"github.com/google/key-transparency/impl/sql/appender"
 	"github.com/google/key-transparency/impl/sql/sqlhist"
+	"github.com/google/key-transparency/impl/transaction"
 
 	"github.com/coreos/etcd/clientv3"
 	_ "github.com/mattn/go-sqlite3"
@@ -91,9 +92,11 @@ func main() {
 	defer sqldb.Close()
 	etcdCli := openEtcd()
 	defer etcdCli.Close()
+	factory := transaction.NewFactory(sqldb, etcdCli)
 
-	queue := queue.New(context.Background(), etcdCli, *mapID)
-	tree, err := sqlhist.New(sqldb, *mapID)
+	// Create signer helper objects.
+	queue := queue.New(context.Background(), etcdCli, *mapID, factory)
+	tree, err := sqlhist.New(context.Background(), sqldb, *mapID, factory)
 	if err != nil {
 		log.Fatalf("Failed to create SQL history: %v", err)
 	}

--- a/core/appender/appender.go
+++ b/core/appender/appender.go
@@ -15,13 +15,15 @@
 package appender
 
 import (
+	"github.com/google/key-transparency/core/transaction"
+
 	"golang.org/x/net/context"
 )
 
 // Appender is an append only interface into a data structure.
 type Appender interface {
 	// Adds an object to the append-only data structure.
-	Append(ctx context.Context, epoch int64, obj interface{}) error
+	Append(txn transaction.Txn, epoch int64, obj interface{}) error
 
 	// Epoch retrieves a specific object.
 	// Returns obj and a serialized ct.SignedCertificateTimestamp

--- a/core/queue/queue.go
+++ b/core/queue/queue.go
@@ -15,6 +15,10 @@
 // Package queue implements a single-reader, multi-writer distributed queue.
 package queue
 
+import (
+	"github.com/google/key-transparency/core/transaction"
+)
+
 // Queuer submits new mutations to be processed.
 type Queuer interface {
 	// Enqueue submits a key, value pair for processing.
@@ -37,7 +41,7 @@ type Receiver interface {
 }
 
 // ProcessKeyValueFunc is a function that processes a mutation.
-type ProcessKeyValueFunc func(key, value []byte) error
+type ProcessKeyValueFunc func(txn transaction.Txn, key, value []byte) error
 
 // AdvanceEpochFunc is a function that advances the epoch.
-type AdvanceEpochFunc func() error
+type AdvanceEpochFunc func(txn transaction.Txn) error

--- a/core/tree/tree.go
+++ b/core/tree/tree.go
@@ -17,19 +17,21 @@ package tree
 
 import (
 	"golang.org/x/net/context"
+
+	"github.com/google/key-transparency/core/transaction"
 )
 
 // Sparse is a temporal sparse merkle tree.
 type Sparse interface {
 	// QueueLeaf queues a leaf to be written on the next Commit().
-	QueueLeaf(ctx context.Context, index, leaf []byte) error
+	QueueLeaf(txn transaction.Txn, index, leaf []byte) error
 	// Commit takes all the Queued values since the last Commmit() and writes them.
 	// Commit is NOT multi-process safe. It should only be called from the sequencer.
 	Commit(ctx context.Context) (epoch int64, err error)
 	// ReadRootAt returns the root value at epoch.
-	ReadRootAt(ctx context.Context, epoch int64) ([]byte, error)
+	ReadRootAt(txn transaction.Txn, epoch int64) ([]byte, error)
 	// ReadLeafAt returns the leaf value at epoch.
-	ReadLeafAt(ctx context.Context, index []byte, epoch int64) ([]byte, error)
+	ReadLeafAt(txn transaction.Txn, index []byte, epoch int64) ([]byte, error)
 	// Neighbors returns the list of neighbors from the neighbor leaf to just below the root at epoch.
 	NeighborsAt(ctx context.Context, index []byte, epoch int64) ([][]byte, error)
 	// Epoch returns the current epoch of the merkle tree.

--- a/impl/sql/appender/ct.go
+++ b/impl/sql/appender/ct.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/key-transparency/core/transaction"
+
 	ct "github.com/google/certificate-transparency/go"
 	"github.com/google/certificate-transparency/go/client"
 	"golang.org/x/net/context"
@@ -128,7 +130,7 @@ func (a *CTAppender) insertMapRow() error {
 }
 
 // Append adds an object to the append-only data structure.
-func (a *CTAppender) Append(ctx context.Context, epoch int64, obj interface{}) error {
+func (a *CTAppender) Append(txn transaction.Txn, epoch int64, obj interface{}) error {
 	if a.send {
 		sct, err := a.ctlog.AddJSON(obj)
 		if err != nil {
@@ -143,7 +145,7 @@ func (a *CTAppender) Append(ctx context.Context, epoch int64, obj interface{}) e
 			if err := gob.NewEncoder(&data).Encode(obj); err != nil {
 				return err
 			}
-			writeStmt, err := a.db.Prepare(insertExpr)
+			writeStmt, err := txn.Prepare(insertExpr)
 			if err != nil {
 				return fmt.Errorf("CT: DB save failure: %v", err)
 			}

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -66,8 +66,15 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 			if got, want := err, grpcc.ErrRetry; got != want {
 				t.Fatalf("Update(%v): %v, want %v", tc.userID, got, want)
 			}
-			if err := env.Signer.CreateEpoch(); err != nil {
+			txn, err := env.Factory.NewDBTxn(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to create transaction: %v", err)
+			}
+			if err := env.Signer.CreateEpoch(txn); err != nil {
 				t.Fatalf("Failed to CreateEpoch: %v", err)
+			}
+			if err := txn.Commit(); err != nil {
+				t.Fatalf("Failed to commit transaction: %v", err)
 			}
 			if err := env.Client.Retry(tc.ctx, req); err != nil {
 				t.Errorf("Retry(%v): %v, want nil", req, err)
@@ -130,8 +137,15 @@ func TestUpdateValidation(t *testing.T) {
 			t.Fatalf("Update(%v): %v != %v, want %v", tc.userID, err, want, tc.want)
 		}
 		if tc.want {
-			if err := env.Signer.CreateEpoch(); err != nil {
+			txn, err := env.Factory.NewDBTxn(context.Background())
+			if err != nil {
+				t.Fatalf("Failed to create transaction: %v", err)
+			}
+			if err := env.Signer.CreateEpoch(txn); err != nil {
 				t.Fatalf("Failed to CreateEpoch: %v", err)
+			}
+			if err := txn.Commit(); err != nil {
+				t.Fatalf("Failed to commit transaction: %v", err)
 			}
 			if err := env.Client.Retry(tc.ctx, req); err != nil {
 				t.Errorf("Retry(%v): %v, want nil", req, err)
@@ -203,8 +217,16 @@ func (e *Env) setupHistory(ctx context.Context, userID string) error {
 				return fmt.Errorf("Update(%v)=(_, %v), want (_, %v)", userID, got, want)
 			}
 		}
-		if err := e.Signer.CreateEpoch(); err != nil {
+
+		txn, err := e.Factory.NewDBTxn(context.Background())
+		if err != nil {
+			return fmt.Errorf("Failed to create transaction: %v", err)
+		}
+		if err := e.Signer.CreateEpoch(txn); err != nil {
 			return fmt.Errorf("Failed to CreateEpoch: %v", err)
+		}
+		if err := txn.Commit(); err != nil {
+			return fmt.Errorf("Failed to commit transaction: %v", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
This PR utilize the transaction object created in #356 in both the database and the queue. The signer's `StartReceiving` loop creates a transaction object and pass it down the call stack to tree and queue involved functions. All tree functions that accepts a transaction may also receive a `nil` object. In this case, the operation they carry will not run in a transaction.

Closes #354.
Should merge #356 and #359 first.

This PR was created as a replacement to #357 after making the repo public and then private.
