### PR TITLE
Don't Run 'go generate' With 'make'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,10 @@
 # authentication information, which can be resolved to user information and
 # associated scopes on the backend.
 
-#include $(GOHOME)/src/pkg/github.com/golang/protobuf/Make.protobuf
 DEPS:= $(shell find . -type f -name '*.proto' | sed 's/proto$$/pb.go/')
 GATEWAY_DEPS:= $(shell find . -type f -name '*.proto' | sed 's/proto$$/pb.gw.go/')
 
-main: proto
+main:
 	go build ./cmd/key-transparency-server
 	go build ./cmd/key-transparency-signer
 	go build ./cmd/key-transparency-client


### PR DESCRIPTION
`go generate` forces the compiler to run `protoc` and regenerate proto files. This causes file descriptors in `*.pb.go` files to change and show in every commit. Also, it is not necessary to regenerate protos unless the wire protocol is changed. In that case, developers should explicitly run `make proto`.
