### PR TITLE
Create transaction Factory interface

### DIFF
--- a/core/transaction/txn.go
+++ b/core/transaction/txn.go
@@ -16,7 +16,15 @@ package transaction
 
 import (
 	"database/sql"
+
+	"golang.org/x/net/context"
 )
+
+// Factory represents a transaction factory object.
+type Factory interface {
+	// NewDBTxn creates a new transaction object for database operations.
+	NewDBTxn(ctx context.Context) (Txn, error)
+}
 
 // Txn represents a transaction interface that provides atomic SQL database and
 // queue operations.


### PR DESCRIPTION
Transaction `Factory` is an object created in `impl/transaction` but does not have a matching interface. Such interface is needed in `core/keyserver/keyserver_test.go` when the factory is added as an input to the `Server` in `core/keyserver/keyserver.go`. This PR creates that interface.
