### PR TITLE
Add transaction-related testutil for impl/sql

### DIFF
--- a/impl/sql/appender/ct_test.go
+++ b/impl/sql/appender/ct_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/key-transparency/core/testutil/ctutil"
-	"github.com/google/key-transparency/impl/transaction"
+	"github.com/google/key-transparency/impl/sql/testutil"
 
 	ct "github.com/google/certificate-transparency/go"
 	_ "github.com/mattn/go-sqlite3"
@@ -43,7 +43,7 @@ func TestGetLatest(t *testing.T) {
 	hs := ctutil.NewCTServer(t)
 	defer hs.Close()
 	db := NewDB(t)
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	a, err := New(db, mapID, hs.URL)
 	if err != nil {
@@ -85,11 +85,12 @@ func TestGetLatest(t *testing.T) {
 		}
 	}
 }
+
 func TestAppend(t *testing.T) {
 	hs := ctutil.NewCTServer(t)
 	defer hs.Close()
 	db := NewDB(t)
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	a, err := New(db, mapID, hs.URL)
 	if err != nil {

--- a/impl/sql/sqlhist/sqlhist_test.go
+++ b/impl/sql/sqlhist/sqlhist_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/key-transparency/impl/transaction"
+	"github.com/google/key-transparency/impl/sql/testutil"
 
 	_ "github.com/mattn/go-sqlite3"
 	"golang.org/x/net/context"
@@ -55,7 +55,7 @@ func TestQueueLeaf(t *testing.T) {
 		t.Fatalf("sql.Open(): %v", err)
 	}
 	defer db.Close()
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	tree, err := New(ctx, db, "test", factory)
 	if err != nil {
@@ -97,7 +97,7 @@ func TestEpochNumAdvance(t *testing.T) {
 		t.Fatalf("sql.Open(): %v", err)
 	}
 	defer db.Close()
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	for _, tc := range []struct {
 		index  string
@@ -146,7 +146,7 @@ func TestQueueCommitRead(t *testing.T) {
 		t.Fatalf("sql.Open(): %v", err)
 	}
 	defer db.Close()
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	m, err := New(ctx, db, "test", factory)
 	if err != nil {
@@ -202,7 +202,7 @@ func TestReadNotFound(t *testing.T) {
 		t.Fatalf("sql.Open(): %v", err)
 	}
 	defer db.Close()
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	m, err := New(ctx, db, "test", factory)
 	if err != nil {
@@ -244,7 +244,7 @@ func TestReadPreviousEpochs(t *testing.T) {
 		t.Fatalf("sql.Open(): %v", err)
 	}
 	defer db.Close()
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	m, err := New(ctx, db, "test", factory)
 	if err != nil {
@@ -306,7 +306,7 @@ func TestAribtrayInsertOrder(t *testing.T) {
 		t.Fatalf("sql.Open(): %v", err)
 	}
 	defer db.Close()
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 
 	leafs := []struct {
 		index []byte
@@ -423,7 +423,7 @@ func TestNeighborDepth(t *testing.T) {
 }
 
 func createTree(db *sql.DB, mapID string, leafs []leaf) (*Map, error) {
-	factory := transaction.NewFactory(db, nil)
+	factory := testutil.NewFakeFactory(db)
 	m, err := New(ctx, db, mapID, factory)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create map: %v", err)

--- a/impl/sql/testutil/testutil.go
+++ b/impl/sql/testutil/testutil.go
@@ -1,0 +1,63 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil contains test supporting functionality for 'impl/sql/...'.
+package testutil
+
+import (
+	"database/sql"
+
+	"github.com/google/key-transparency/core/transaction"
+
+	"golang.org/x/net/context"
+)
+
+// FakeFactory is a fake transaction factory
+type FakeFactory struct {
+	db *sql.DB
+}
+
+// NewFakeFactory creates a new FakeFactory instance.
+func NewFakeFactory(db *sql.DB) *FakeFactory {
+	return &FakeFactory{db}
+}
+
+// NewDBTxn creates a new database transaction.
+func (f *FakeFactory) NewDBTxn(ctx context.Context) (transaction.Txn, error) {
+	dbTxn, err := f.db.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	return &txn{dbTxn}, nil
+}
+
+type txn struct {
+	dbTxn *sql.Tx
+}
+
+// Prepare prepares an SQL statement to be executed.
+func (t *txn) Prepare(query string) (*sql.Stmt, error) {
+	return t.dbTxn.Prepare(query)
+}
+
+// Commit commits the transaction.
+func (t *txn) Commit() error {
+	return t.dbTxn.Commit()
+}
+
+// Rollback aborts the transaction.
+func (t *txn) Rollback() error {
+	return t.dbTxn.Rollback()
+}


### PR DESCRIPTION
`impl/sql/sqlhist/sqlhist_test.go` and `impl/sql/appender/ct_test.go` both import `impl/transaction`. Thus, `impl/sql` is not self-dependent. This PR creates test utilities that fake all objects in `impl/transaction`.

This PR was created as a replacement to #376 after making the repo public and then private.
