### PR TITLE
Keep DB table names consistent

### DIFF
--- a/impl/sql/appender/ct.go
+++ b/impl/sql/appender/ct.go
@@ -30,16 +30,16 @@ import (
 
 const (
 	mapRowExpr = `
-	REPLACE INTO Maps (MapId) VALUES (?);`
+	REPLACE INTO Maps (MapID) VALUES (?);`
 	insertExpr = `
-	INSERT INTO SMH (MapId, Epoch, Data, SCT)
+	INSERT INTO SMH (MapID, Epoch, Data, SCT)
 	VALUES (?, ?, ?, ?);`
 	readExpr = `
 	SELECT Data, SCT FROM SMH
-	WHERE MapId = ? AND Epoch = ?;`
+	WHERE MapID = ? AND Epoch = ?;`
 	latestExpr = `
 	SELECT Epoch, Data, SCT FROM SMH
-	WHERE MapId = ? 
+	WHERE MapID = ? 
 	ORDER BY Epoch DESC LIMIT 1;`
 )
 
@@ -47,17 +47,17 @@ var (
 	createStmt = []string{
 		`
 	CREATE TABLE IF NOT EXISTS Maps (
-		MapId   VARCHAR(32) NOT NULL,
+		MapID   VARCHAR(32) NOT NULL,
 		PRIMARY KEY(MapID)
 	);`,
 		`
 	CREATE TABLE IF NOT EXISTS SMH (
-		MapId   VARCHAR(32) NOT NULL,
+		MapID   VARCHAR(32) NOT NULL,
 		Epoch   INTEGER     NOT NULL,
 		Data    BLOB(1024)  NOT NULL,
 		SCT     BLOB(1024)  NOT NULL,
 		PRIMARY KEY(MapID, Epoch),
-		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
+		FOREIGN KEY(MapID) REFERENCES Maps(MapID) ON DELETE CASCADE
 	);`,
 	}
 	// ErrNotSupported occurs when performing an operaion that has been disabled.

--- a/impl/sql/commitments/sql.go
+++ b/impl/sql/commitments/sql.go
@@ -26,29 +26,29 @@ import (
 
 const (
 	mapRowExpr = `
-	REPLACE INTO Maps (MapId) VALUES (?);`
+	REPLACE INTO Maps (MapID) VALUES (?);`
 	insertExpr = `
-	INSERT INTO Commitments (MapId, Commitment, Value)
+	INSERT INTO Commitments (MapID, Commitment, Value)
 	VALUES (?, ?, ?);`
 	readExpr = `
 	SELECT Value FROM Commitments
-	WHERE MapId = ? AND Commitment = ?;`
+	WHERE MapID = ? AND Commitment = ?;`
 )
 
 var (
 	createStmt = []string{
 		`
 	CREATE TABLE IF NOT EXISTS Maps (
-		MapId   VARCHAR(32) NOT NULL,
+		MapID   VARCHAR(32) NOT NULL,
 		PRIMARY KEY(MapID)
 	);`,
 		`
 	CREATE TABLE IF NOT EXISTS Commitments (
-		MapId      VARCHAR(32)   NOT NULL,
+		MapID      VARCHAR(32)   NOT NULL,
 		Commitment VARBINARY(32) NOT NULL,
 		Value      BLOB(1024)    NOT NULL,
 		PRIMARY KEY(MapID, Commitment),
-		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
+		FOREIGN KEY(MapID) REFERENCES Maps(MapID) ON DELETE CASCADE
 	);`,
 	}
 	errDoubleCommitment = errors.New("Commitment to different key-value")

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -34,26 +34,26 @@ var (
 	createStmt = []string{
 		`
 	CREATE TABLE IF NOT EXISTS Maps (
-		MapId   VARCHAR(32) NOT NULL,
+		MapID   VARCHAR(32) NOT NULL,
 		PRIMARY KEY(MapID)
 	);`,
 		`
 	CREATE TABLE IF NOT EXISTS Leaves (
-		MapId   VARCHAR(32)   NOT NULL,
-		LeafId  VARBINARY(32) NOT NULL,
+		MapID   VARCHAR(32)   NOT NULL,
+		LeafID  VARBINARY(32) NOT NULL,
 		Version INTEGER       NOT NULL,
 		Data    BLOB          NOT NULL,
-		PRIMARY KEY(MapID, LeafId, Version),
-		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
+		PRIMARY KEY(MapID, LeafID, Version),
+		FOREIGN KEY(MapID) REFERENCES Maps(MapID) ON DELETE CASCADE
 	);`,
 		`
 	CREATE TABLE IF NOT EXISTS Nodes (
-		MapId   VARCHAR(32)   NOT NULL,
-		NodeId  VARBINARY(32) NOT NULL,
+		MapID   VARCHAR(32)   NOT NULL,
+		NodeID  VARBINARY(32) NOT NULL,
 		Version	INTEGER       NOT NULL,
 		Value	BLOB(32)      NOT NULL,
-		PRIMARY KEY(MapId, NodeId, Version),
-		FOREIGN KEY(MapId) REFERENCES Maps(MapId) ON DELETE CASCADE
+		PRIMARY KEY(MapID, NodeID, Version),
+		FOREIGN KEY(MapID) REFERENCES Maps(MapID) ON DELETE CASCADE
 	);`,
 	}
 	hasher          = sparse.CONIKSHasher
@@ -67,25 +67,25 @@ const (
 	size     = sparse.HashSize
 	readExpr = `
 	SELECT Value FROM Nodes
-	WHERE MapId = ? AND NodeId = ? and Version <= ?
+	WHERE MapID = ? AND NodeID = ? and Version <= ?
 	ORDER BY Version DESC LIMIT 1;`
 	leafExpr = `
 	SELECT Data FROM Leaves
-	WHERE MapId = ? AND LeafId = ? and Version <= ?
+	WHERE MapID = ? AND LeafID = ? and Version <= ?
 	ORDER BY Version DESC LIMIT 1;`
 	queueExpr = `
-	REPLACE INTO Leaves (MapId, LeafId, Version, Data)
+	REPLACE INTO Leaves (MapID, LeafID, Version, Data)
 	VALUES (?, ?, ?, ?);`
 	pendingLeafsExpr = `
-	SELECT LeafId, Version, Data FROM Leaves 
-	WHERE MapId = ? AND Version >= ?;`
+	SELECT LeafID, Version, Data FROM Leaves 
+	WHERE MapID = ? AND Version >= ?;`
 	setNodeExpr = `
-	REPLACE INTO Nodes (MapId, NodeId, Version, Value)
+	REPLACE INTO Nodes (MapID, NodeID, Version, Value)
 	VALUES (?, ?, ?, ?);`
-	mapRowExpr    = `REPLACE INTO Maps (MapId) VALUES (?);`
+	mapRowExpr    = `REPLACE INTO Maps (MapID) VALUES (?);`
 	readEpochExpr = `
 	SELECT Version FROM Nodes
-	WHERE MapId = ? AND NodeId = ?
+	WHERE MapID = ? AND NodeID = ?
 	ORDER BY Version DESC LIMIT 1;`
 )
 


### PR DESCRIPTION
In _most_ cases SQLite and MySQL table names are not case sensitive. This PR ensures consistency of all DB table names to avoid problems when case sensitivity is enforced.
