### PR TITLE
Execlude vendor directory in make fmt and presubmit labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@
 # authentication information, which can be resolved to user information and
 # associated scopes on the backend.
 
+# TODO: Makefile will be deleted once the repo is public. Check issue #411.
+
 main: client
 	go build ./cmd/key-transparency-server
 	go build ./cmd/key-transparency-signer
@@ -39,15 +41,15 @@ coverage: main
 	go test -cover `find . | grep '_test\.go$$' | sort | xargs -n 1 dirname`
 
 fmt:
-	find . -iregex '.*.go' -exec gofmt -w {} \;
-	find . -iregex '.[^.]*.go' -exec golint {} \;
+	find . -iregex '.*.go' ! -path "./vendor/*" -exec gofmt -w {} \;
+	find . -iregex '.[^.]*.go' ! -path "./vendor/*" -exec golint {} \;
 
 presubmit: coverage fmt
-	-go vet ./...
-	find . ! -path "*/proto/*" -not -iwholename "*.git*" -not -iwholename "." -type d ! -name "proto" -exec errcheck -ignore 'Close|Write,os:Remove,google.golang.org/grpc:Serve' {} \;
-	-find . -type f -name "*.go" ! -name "*.pb*go" -exec gocyclo -over 12 {} \;
+	-go vet ./cmd/... ./core/... ./impl/... ./integration/...
+	find . ! -path "*/proto/*" ! -iwholename "*.git*" ! -iwholename "." ! -iwholename "*vendor*" -type d ! -name "proto" -exec errcheck -ignore 'Close|Write|Serve,os:Remove' {} \;
+	-find . -type f -name "*.go" ! -path "./vendor/*" ! -name "*.pb*go" -exec gocyclo -over 12 {} \;
 	-ineffassign .
-	-find . -type f -name '*.md' -o -name '*.go' -o -name '*.proto' | sort | xargs misspell -locale US
+	-find . -type f -name '*.md' ! -path "./vendor/*" -o -name '*.go' ! -path "./vendor/*" -o -name '*.proto' ! -path "./vendor/*" | sort | xargs misspell -locale US
 
 proto:
 	go generate ./...
@@ -55,4 +57,3 @@ proto:
 clean:
 	rm -f srv key-transparency-server key-transparency-signer key-transparency-client
 	rm -rf infra*
-


### PR DESCRIPTION
`make presubmit` commands should not run against the vendor directory. This PR fixes that.
