### PR TITLE
Remove dependency on contrib/recipes

### DIFF
--- a/impl/etcd/queue/etcd.go
+++ b/impl/etcd/queue/etcd.go
@@ -26,10 +26,9 @@ import (
 	ctxn "github.com/google/key-transparency/core/transaction"
 	itxn "github.com/google/key-transparency/impl/transaction"
 
-	"golang.org/x/net/context"
-
 	v3 "github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
+	"golang.org/x/net/context"
 )
 
 // leaseTTL is in seconds.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -95,14 +95,6 @@
 			"versionExact": "v3.1.0-rc.0"
 		},
 		{
-			"checksumSHA1": "/d/xggcY2Nw/SFPdx+jwlJD97IE=",
-			"path": "github.com/coreos/etcd/contrib/recipes",
-			"revision": "83347907774bf36cbb261c594a32fd7b0f5dd9f6",
-			"revisionTime": "2016-10-14T21:40:17Z",
-			"version": "v3.1.0-rc.0",
-			"versionExact": "v3.1.0-rc.0"
-		},
-		{
 			"checksumSHA1": "outzscx0WDBY/3Igx2NucR4a/j8=",
 			"path": "github.com/coreos/etcd/discovery",
 			"revision": "83347907774bf36cbb261c594a32fd7b0f5dd9f6",


### PR DESCRIPTION
Etcd has recently unexported all functions in `key.go` in `github.com/coreos/etcd/contrib/recipes`. This PR removes our dependency on them.

Fixes #408.