### PR TITLE
Allow frontend and backend to run without CT server

### DIFF
--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -17,6 +17,7 @@ package kt
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/ioutil"
 	"log"
 
@@ -112,7 +113,10 @@ func (v *Verifier) VerifyGetEntryResponse(userID string, in *tpb.GetEntryRespons
 
 	// Verify SCT.
 	sct, err := ct.DeserializeSCT(bytes.NewReader(in.SmhSct))
-	if err != nil {
+	if err == io.EOF {
+		Vlog.Printf("✗ Signed Map Head CT is missing.")
+		return nil
+	} else if err != nil {
 		return err
 	}
 	if err := v.log.VerifySCT(in.GetSmh(), sct); err != nil {


### PR DESCRIPTION
In cases where CT server is not available or cannot be run, Key Transparency frontend and backend should be allowed to work without it. This is triggered by a missing `maplog` argument passed to their binaries. Moreover, the client specifically indicates that the CT map head is missing during the verification process.

Closes #413.