### PR TITLE
Pass HTTP Client to Certificate Transparency Client

### DIFF
--- a/cmd/key-transparency-server/frontend.go
+++ b/cmd/key-transparency-server/frontend.go
@@ -192,7 +192,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create SQL history: %v", err)
 	}
-	sths, err := appender.New(sqldb, *mapID, *mapLogURL)
+	sths, err := appender.New(sqldb, *mapID, *mapLogURL, nil)
 	if err != nil {
 		log.Fatalf("Failed to create appender: %v", err)
 	}

--- a/cmd/key-transparency-signer/backend.go
+++ b/cmd/key-transparency-signer/backend.go
@@ -101,11 +101,11 @@ func main() {
 		log.Fatalf("Failed to create SQL history: %v", err)
 	}
 	mutator := entry.New()
-	sths, err := appender.New(sqldb, *mapID, *mapLogURL)
+	sths, err := appender.New(sqldb, *mapID, *mapLogURL, nil)
 	if err != nil {
 		log.Fatalf("Failed to create STH appender: %v", err)
 	}
-	mutations, err := appender.New(nil, *mapID, *mapLogURL)
+	mutations, err := appender.New(nil, *mapID, *mapLogURL, nil)
 	if err != nil {
 		log.Fatalf("Failed to create mutation appender: %v", err)
 	}

--- a/impl/sql/appender/ct_test.go
+++ b/impl/sql/appender/ct_test.go
@@ -45,7 +45,7 @@ func TestGetLatest(t *testing.T) {
 	db := NewDB(t)
 	factory := testutil.NewFakeFactory(db)
 
-	a, err := New(db, mapID, hs.URL)
+	a, err := New(db, mapID, hs.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create appender: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestAppend(t *testing.T) {
 	db := NewDB(t)
 	factory := testutil.NewFakeFactory(db)
 
-	a, err := New(db, mapID, hs.URL)
+	a, err := New(db, mapID, hs.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create appender: %v", err)
 	}

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -169,11 +169,11 @@ func NewEnv(t *testing.T) *Env {
 	if err != nil {
 		t.Fatalf("Failed to create SQL history: %v", err)
 	}
-	sths, err := appender.New(sqldb, mapID, hs.URL)
+	sths, err := appender.New(sqldb, mapID, hs.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create STH appender: %v", err)
 	}
-	mutations, err := appender.New(nil, mapID, "")
+	mutations, err := appender.New(nil, mapID, "", nil)
 	if err != nil {
 		t.Fatalf("Failed to create mutation appender: %v", err)
 	}


### PR DESCRIPTION
This provides more flexibility on the use HTTP client than triggering certificate transparency to create a default one.

Closes #416.