### PR TITLE
Fix CT Client Test based on Latest CT Version

### DIFF
--- a/core/client/ctlog/client_ct_test.go
+++ b/core/client/ctlog/client_ct_test.go
@@ -158,7 +158,7 @@ func TestVerifySCT(t *testing.T) {
 			`{ "sct_version": 0, "id": "3xwuwRUAlFJHqWFoMl3cXHlZ6PfG04j8AC4LvT9012Q=", "timestamp": 1469818883686, "extensions": "", "signature": "BAMARjBEAiBRH\/bZrc4Fl6B6pTWsj0vo9elzbWzgpDKpczEod4pRDwIga03DUchNDRWwtv2xHi7v9kzestFGkEpyMn1jYTsk9nc=" }`,
 			`{ "tree_size": 29, "timestamp": 1470441152103, "sha256_root_hash": "KtOs5kyiH2mf4xSuREERqIbC4wsuwm6e7EXqXKc\/FLM=", "tree_head_signature": "BAMARzBFAiEAvgi7ETkLQTwCXR1rePmyj2CxDLnGIcS5kOoH770btzICIAw5yjO8oYR+yf\/QK4Ks59YOnkQA+I1OywGPrZIvPuU0" }`,
 			`{ "leaf_index": 26, "audit_path": [ "z6OXtl3FHCwSIDfNAwj\/5HY\/vXMgN5u3Y2LlfWmrHgY=", "grgSU6rjELf4Dff+LJ\/AjdgFt2SW85KW+Qfx3i9LSRk=", "MxibgM+03nha\/k4sbUrUgvgQ50lCYHDH6f8IzTCNYgE=", "BYB0BDK4jX6UPmSboGtIUMe9SwqLaJe6X0BkSWXCGOc=", "t9rD1TCqf2B1s8z15+fPmkRe1JVvjf2VNPhRzt\/m8nM=" ] }`,
-			"t0A8H7hDbMSFIYZSaez/JxZhhuCySpUvz4iw6RpECO0=",
+			"t0A8H7hDbMSFIYZSaez%2FJxZhhuCySpUvz4iw6RpECO0%3D",
 			"",
 			0,
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -635,47 +635,59 @@
 			"revisionTime": "2016-10-05T20:09:59Z"
 		},
 		{
-			"checksumSHA1": "YrEY+8GoQjULjuB2Fk3Rq8TRI98=",
+			"checksumSHA1": "Cvrz7kX3+5CJ7XggM9LuqkGEj0E=",
 			"path": "github.com/google/certificate-transparency/cpp",
-			"revision": "d90e65c3a07988180c5b1ece71791c0b6506826e",
-			"revisionTime": "2016-10-25T09:38:37Z",
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z",
 			"tree": true
 		},
 		{
-			"checksumSHA1": "otIZ0qrxQBwCI0x2uZF5IhuPPiU=",
+			"checksumSHA1": "0lR2nqusGkDmsAu/A1edutFa0VQ=",
 			"path": "github.com/google/certificate-transparency/go",
-			"revision": "4be8cae1e72273f69195357ce2eb3b291f36c123",
-			"revisionTime": "2016-10-18T15:33:04Z"
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
 		},
 		{
-			"checksumSHA1": "l2hfhClo5DB4MybCgXfS3n6dhCc=",
+			"checksumSHA1": "8qeVOyWflR8IMBXe5CPJPhvmnh4=",
 			"path": "github.com/google/certificate-transparency/go/asn1",
-			"revision": "4be8cae1e72273f69195357ce2eb3b291f36c123",
-			"revisionTime": "2016-10-18T15:33:04Z"
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
 		},
 		{
-			"checksumSHA1": "juwGtafOMJCEAr9OQ/IyI2f11JQ=",
+			"checksumSHA1": "N6RPi0mvjtHkncoX3ySHVdqBync=",
 			"path": "github.com/google/certificate-transparency/go/client",
-			"revision": "4be8cae1e72273f69195357ce2eb3b291f36c123",
-			"revisionTime": "2016-10-18T15:33:04Z"
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
+		},
+		{
+			"checksumSHA1": "bpeOVNCPWnnKjATWt48SoFEH2Mg=",
+			"path": "github.com/google/certificate-transparency/go/jsonclient",
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
 		},
 		{
 			"checksumSHA1": "uPx27/A4r6xpCp7SmURXZaKl4bI=",
 			"path": "github.com/google/certificate-transparency/go/merkletree",
-			"revision": "4be8cae1e72273f69195357ce2eb3b291f36c123",
-			"revisionTime": "2016-10-18T15:33:04Z"
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
 		},
 		{
-			"checksumSHA1": "5giGRbKHERH6cK68AqjTprGqe18=",
+			"checksumSHA1": "CBEdVkRCOrx/Pa64R2A9xXnEC1c=",
+			"path": "github.com/google/certificate-transparency/go/tls",
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
+		},
+		{
+			"checksumSHA1": "iu+5IFQpzb3jZ0ND9AtGdwU+754=",
 			"path": "github.com/google/certificate-transparency/go/x509",
-			"revision": "4be8cae1e72273f69195357ce2eb3b291f36c123",
-			"revisionTime": "2016-10-18T15:33:04Z"
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
 		},
 		{
-			"checksumSHA1": "uezPktTXlVvMZ13HIKl40bl/QIE=",
+			"checksumSHA1": "eyrpGZtaev40pGE0SsF+pCUVSi8=",
 			"path": "github.com/google/certificate-transparency/go/x509/pkix",
-			"revision": "4be8cae1e72273f69195357ce2eb3b291f36c123",
-			"revisionTime": "2016-10-18T15:33:04Z"
+			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
+			"revisionTime": "2016-11-08T14:09:39Z"
 		},
 		{
 			"checksumSHA1": "mJuOZXdE9GBhUTHeQ/Wm8U1rR4I=",


### PR DESCRIPTION
* Update Certificate Transparency to the latest version in `vendor`.
* Fix `client_ct_test.go` based on the latest CT version. The difference is that request hash values are URL encoded.