### PR TITLE
Update Certificate Transparency to the Latest Version in vendor Directory

### DIFF
--- a/cmd/key-transparency-client/grpcc/grpc_client.go
+++ b/cmd/key-transparency-client/grpcc/grpc_client.go
@@ -106,7 +106,7 @@ func (c *Client) GetEntry(ctx context.Context, userID string, opts ...grpc.CallO
 		return nil, nil, err
 	}
 
-	if err := c.kt.VerifyGetEntryResponse(userID, e); err != nil {
+	if err := c.kt.VerifyGetEntryResponse(ctx, userID, e); err != nil {
 		return nil, nil, err
 	}
 
@@ -146,7 +146,7 @@ func (c *Client) ListHistory(ctx context.Context, userID string, start, end int6
 
 		for i, v := range resp.GetValues() {
 			Vlog.Printf("Processing entry for %v, epoch %v", userID, start+int64(i))
-			err = c.kt.VerifyGetEntryResponse(userID, v)
+			err = c.kt.VerifyGetEntryResponse(ctx, userID, v)
 			if err != nil {
 				return nil, err
 			}
@@ -185,7 +185,7 @@ func (c *Client) Update(ctx context.Context, userID string, profile *tpb.Profile
 	}
 	Vlog.Printf("Got current entry...")
 
-	if err := c.kt.VerifyGetEntryResponse(userID, getResp); err != nil {
+	if err := c.kt.VerifyGetEntryResponse(ctx, userID, getResp); err != nil {
 		return nil, err
 	}
 
@@ -213,7 +213,7 @@ func (c *Client) Retry(ctx context.Context, req *tpb.UpdateEntryRequest) error {
 	Vlog.Printf("Got current entry...")
 
 	// Validate response.
-	if err := c.kt.VerifyGetEntryResponse(req.UserId, updateResp.GetProof()); err != nil {
+	if err := c.kt.VerifyGetEntryResponse(ctx, req.UserId, updateResp.GetProof()); err != nil {
 		return err
 	}
 

--- a/cmd/key-transparency-server/frontend.go
+++ b/cmd/key-transparency-server/frontend.go
@@ -192,7 +192,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create SQL history: %v", err)
 	}
-	sths, err := appender.New(sqldb, *mapID, *mapLogURL, nil)
+	sths, err := appender.New(context.Background(), sqldb, *mapID, *mapLogURL, nil)
 	if err != nil {
 		log.Fatalf("Failed to create appender: %v", err)
 	}

--- a/cmd/key-transparency-signer/backend.go
+++ b/cmd/key-transparency-signer/backend.go
@@ -101,11 +101,11 @@ func main() {
 		log.Fatalf("Failed to create SQL history: %v", err)
 	}
 	mutator := entry.New()
-	sths, err := appender.New(sqldb, *mapID, *mapLogURL, nil)
+	sths, err := appender.New(context.Background(), sqldb, *mapID, *mapLogURL, nil)
 	if err != nil {
 		log.Fatalf("Failed to create STH appender: %v", err)
 	}
-	mutations, err := appender.New(nil, *mapID, *mapLogURL, nil)
+	mutations, err := appender.New(context.Background(), nil, *mapID, *mapLogURL, nil)
 	if err != nil {
 		log.Fatalf("Failed to create mutation appender: %v", err)
 	}

--- a/core/appender/appender.go
+++ b/core/appender/appender.go
@@ -23,7 +23,7 @@ import (
 // Appender is an append only interface into a data structure.
 type Appender interface {
 	// Adds an object to the append-only data structure.
-	Append(txn transaction.Txn, epoch int64, obj interface{}) error
+	Append(ctx context.Context, txn transaction.Txn, epoch int64, obj interface{}) error
 
 	// Epoch retrieves a specific object.
 	// Returns obj and a serialized ct.SignedCertificateTimestamp

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -16,6 +16,7 @@ package kt
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io/ioutil"
 	"log"
@@ -79,7 +80,7 @@ func (Verifier) VerifyCommitment(userID string, in *tpb.GetEntryResponse) error 
 //  - Verify tree proof.
 //  - Verify signature.
 //  - Verify SCT.
-func (v *Verifier) VerifyGetEntryResponse(userID string, in *tpb.GetEntryResponse) error {
+func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, userID string, in *tpb.GetEntryResponse) error {
 	if err := v.VerifyCommitment(userID, in); err != nil {
 		Vlog.Printf("✗ Commitment verification failed.")
 		return err
@@ -115,7 +116,7 @@ func (v *Verifier) VerifyGetEntryResponse(userID string, in *tpb.GetEntryRespons
 	if err != nil {
 		return err
 	}
-	if err := v.log.VerifySCT(in.GetSmh(), sct); err != nil {
+	if err := v.log.VerifySCT(ctx, in.GetSmh(), sct); err != nil {
 		Vlog.Printf("✗ Signed Map Head CT inclusion proof verification failed.")
 		return err
 	}

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -226,7 +226,7 @@ type fakeAppender struct {
 	LatestCount  int
 }
 
-func (*fakeAppender) Append(txn transaction.Txn, epoch int64, obj interface{}) error {
+func (*fakeAppender) Append(ctx context.Context, txn transaction.Txn, epoch int64, obj interface{}) error {
 	return nil
 }
 

--- a/core/queue/queue.go
+++ b/core/queue/queue.go
@@ -17,6 +17,7 @@ package queue
 
 import (
 	"github.com/google/key-transparency/core/transaction"
+	"golang.org/x/net/context"
 )
 
 // Queuer submits new mutations to be processed.
@@ -41,7 +42,7 @@ type Receiver interface {
 }
 
 // ProcessKeyValueFunc is a function that processes a mutation.
-type ProcessKeyValueFunc func(txn transaction.Txn, key, value []byte) error
+type ProcessKeyValueFunc func(ctx context.Context, txn transaction.Txn, key, value []byte) error
 
 // AdvanceEpochFunc is a function that advances the epoch.
-type AdvanceEpochFunc func(txn transaction.Txn) error
+type AdvanceEpochFunc func(ctx context.Context, txn transaction.Txn) error

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -91,9 +91,9 @@ func (s *Signer) StartSigning(interval time.Duration) {
 }
 
 // ProcessMutation saves a mutation and adds it to the append-only log and tree.
-func (s *Signer) ProcessMutation(txn transaction.Txn, index, mutation []byte) error {
+func (s *Signer) ProcessMutation(ctx context.Context, txn transaction.Txn, index, mutation []byte) error {
 	// Send mutation to append-only log.
-	if err := s.mutations.Append(txn, 0, mutation); err != nil {
+	if err := s.mutations.Append(ctx, txn, 0, mutation); err != nil {
 		return fmt.Errorf("Append mutation failure %v", err)
 	}
 
@@ -117,8 +117,7 @@ func (s *Signer) ProcessMutation(txn transaction.Txn, index, mutation []byte) er
 }
 
 // CreateEpoch signs the current map head.
-func (s *Signer) CreateEpoch(txn transaction.Txn) error {
-	ctx := context.Background()
+func (s *Signer) CreateEpoch(ctx context.Context, txn transaction.Txn) error {
 	epoch, err := s.tree.Commit(ctx)
 	if err != nil {
 		return fmt.Errorf("Commit err: %v", err)
@@ -146,7 +145,7 @@ func (s *Signer) CreateEpoch(txn transaction.Txn) error {
 		MapHead:    mh,
 		Signatures: map[string]*ctmap.DigitallySigned{s.signer.KeyName: sig},
 	}
-	if err := s.sths.Append(txn, epoch, smh); err != nil {
+	if err := s.sths.Append(ctx, txn, epoch, smh); err != nil {
 		return fmt.Errorf("Append SMH failure %v", err)
 	}
 	log.Printf("Created epoch %v. SMH: %#x", epoch, root)

--- a/impl/etcd/queue/etcd.go
+++ b/impl/etcd/queue/etcd.go
@@ -145,7 +145,7 @@ func (q *Queue) dequeue(key, value []byte, rev int64, cbs callbacks) error {
 	}
 
 	// Process the received entry.
-	if err := processEntry(txn, cbs, dataKV); err != nil {
+	if err := processEntry(q.ctx, txn, cbs, dataKV); err != nil {
 		return err
 	}
 
@@ -157,12 +157,12 @@ func (q *Queue) dequeue(key, value []byte, rev int64, cbs callbacks) error {
 }
 
 // processEntry processes a given queue item.
-func processEntry(txn ctxn.Txn, cbs callbacks, dataKV kv) error {
+func processEntry(ctx context.Context, txn ctxn.Txn, cbs callbacks, dataKV kv) error {
 	// Process the entry.
 	if dataKV.AdvanceEpoch {
-		return cbs.advanceFunc(txn)
+		return cbs.advanceFunc(ctx, txn)
 	}
-	return cbs.processFunc(txn, dataKV.Key, dataKV.Val)
+	return cbs.processFunc(ctx, txn, dataKV.Key, dataKV.Val)
 }
 
 // Close stops the receiver from receiving items from the queue.

--- a/impl/etcd/queue/etcd_test.go
+++ b/impl/etcd/queue/etcd_test.go
@@ -75,7 +75,7 @@ func TestStartReceiving(t *testing.T) {
 	// StartReceiving setup.
 	var done sync.WaitGroup
 	done.Add(len(mitems))
-	processFunc := func(txn ctxn.Txn, key, value []byte) error {
+	processFunc := func(ctx context.Context, txn ctxn.Txn, key, value []byte) error {
 		if v, ok := mitems[string(key)]; !ok {
 			t.Errorf("Receive key %v was not enqueued", key)
 		} else {
@@ -88,7 +88,7 @@ func TestStartReceiving(t *testing.T) {
 		done.Done()
 		return nil
 	}
-	advanceFunc := func(txn ctxn.Txn) error { return nil }
+	advanceFunc := func(ctx context.Context, txn ctxn.Txn) error { return nil }
 	if _, err := q.StartReceiving(processFunc, advanceFunc); err != nil {
 		t.Fatalf("failed to start queue receiver: %v", err)
 	}
@@ -113,11 +113,11 @@ func TestProcessEntry(t *testing.T) {
 	// Setup
 	var pCounter, aCounter int
 	cbs := callbacks{
-		func(txn ctxn.Txn, key, value []byte) error {
+		func(ctx context.Context, txn ctxn.Txn, key, value []byte) error {
 			pCounter++
 			return nil
 		},
-		func(txn ctxn.Txn) error {
+		func(ctx context.Context, txn ctxn.Txn) error {
 			aCounter++
 			return nil
 		},
@@ -146,7 +146,7 @@ func TestProcessEntry(t *testing.T) {
 		aCounter = 0
 
 		for _, kv := range tc.kvs {
-			_ = processEntry(nil, cbs, kv)
+			_ = processEntry(context.Background(), nil, cbs, kv)
 		}
 
 		if got, want := pCounter, tc.pCounter; got != want {
@@ -180,10 +180,10 @@ func TestKVTimeout(t *testing.T) {
 	}
 
 	cbs := callbacks{
-		func(txn ctxn.Txn, key, value []byte) error {
+		func(ctx context.Context, txn ctxn.Txn, key, value []byte) error {
 			return nil
 		},
-		func(txn ctxn.Txn) error {
+		func(ctx context.Context, txn ctxn.Txn) error {
 			return nil
 		},
 	}

--- a/impl/sql/appender/ct_test.go
+++ b/impl/sql/appender/ct_test.go
@@ -40,12 +40,13 @@ func NewDB(t testing.TB) *sql.DB {
 }
 
 func TestGetLatest(t *testing.T) {
+	ctx := context.Background()
 	hs := ctutil.NewCTServer(t)
 	defer hs.Close()
 	db := NewDB(t)
 	factory := testutil.NewFakeFactory(db)
 
-	a, err := New(db, mapID, hs.URL, nil)
+	a, err := New(ctx, db, mapID, hs.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create appender: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestGetLatest(t *testing.T) {
 			t.Errorf("factory.NewDBTxn() failed: %v", err)
 			continue
 		}
-		if err := a.Append(txn, tc.epoch, tc.data); err != nil {
+		if err := a.Append(ctx, txn, tc.epoch, tc.data); err != nil {
 			t.Errorf("Append(%v, %v): %v, want nil", tc.epoch, tc.data, err)
 		}
 		if err := txn.Commit(); err != nil {
@@ -87,12 +88,13 @@ func TestGetLatest(t *testing.T) {
 }
 
 func TestAppend(t *testing.T) {
+	ctx := context.Background()
 	hs := ctutil.NewCTServer(t)
 	defer hs.Close()
 	db := NewDB(t)
 	factory := testutil.NewFakeFactory(db)
 
-	a, err := New(db, mapID, hs.URL, nil)
+	a, err := New(ctx, db, mapID, hs.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create appender: %v", err)
 	}
@@ -111,7 +113,7 @@ func TestAppend(t *testing.T) {
 			t.Errorf("factory.NewDBTxn() failed: %v", err)
 			continue
 		}
-		err = a.Append(txn, tc.epoch, tc.data)
+		err = a.Append(ctx, txn, tc.epoch, tc.data)
 		if got := err == nil; got != tc.want {
 			t.Errorf("Append(%v, %v): %v, want nil", tc.epoch, tc.data, err)
 		}

--- a/integration/client_ct_fake.go
+++ b/integration/client_ct_fake.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/key-transparency/core/client/ctlog"
 
 	ct "github.com/google/certificate-transparency/go"
+	"golang.org/x/net/context"
 
 	"github.com/google/key-transparency/core/proto/ctmap"
 )
@@ -25,7 +26,7 @@ import (
 type fakeLog struct{}
 
 // VerifySCT ensures that SMH has been properly included in the append only log.
-func (fakeLog) VerifySCT(smh *ctmap.SignedMapHead, sct *ct.SignedCertificateTimestamp) error {
+func (fakeLog) VerifySCT(ctx context.Context, smh *ctmap.SignedMapHead, sct *ct.SignedCertificateTimestamp) error {
 	return nil
 }
 
@@ -33,7 +34,7 @@ func (fakeLog) VerifySCT(smh *ctmap.SignedMapHead, sct *ct.SignedCertificateTime
 func (fakeLog) VerifySavedSCTs() []ctlog.SCTEntry { return nil }
 
 // UpdateSTH ensures that STH is at least 1 MMD from Now().
-func (fakeLog) UpdateSTH() error { return nil }
+func (fakeLog) UpdateSTH(ctx context.Context) error { return nil }
 
 // Save persists unverified SCTs to disk
 func (fakeLog) Save(file string) error { return nil }

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -70,7 +70,7 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}
-			if err := env.Signer.CreateEpoch(txn); err != nil {
+			if err := env.Signer.CreateEpoch(context.Background(), txn); err != nil {
 				t.Fatalf("Failed to CreateEpoch: %v", err)
 			}
 			if err := txn.Commit(); err != nil {
@@ -141,7 +141,7 @@ func TestUpdateValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}
-			if err := env.Signer.CreateEpoch(txn); err != nil {
+			if err := env.Signer.CreateEpoch(context.Background(), txn); err != nil {
 				t.Fatalf("Failed to CreateEpoch: %v", err)
 			}
 			if err := txn.Commit(); err != nil {
@@ -222,7 +222,7 @@ func (e *Env) setupHistory(ctx context.Context, userID string) error {
 		if err != nil {
 			return fmt.Errorf("Failed to create transaction: %v", err)
 		}
-		if err := e.Signer.CreateEpoch(txn); err != nil {
+		if err := e.Signer.CreateEpoch(context.Background(), txn); err != nil {
 			return fmt.Errorf("Failed to CreateEpoch: %v", err)
 		}
 		if err := txn.Commit(); err != nil {

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -169,11 +169,11 @@ func NewEnv(t *testing.T) *Env {
 	if err != nil {
 		t.Fatalf("Failed to create SQL history: %v", err)
 	}
-	sths, err := appender.New(sqldb, mapID, hs.URL, nil)
+	sths, err := appender.New(context.Background(), sqldb, mapID, hs.URL, nil)
 	if err != nil {
 		t.Fatalf("Failed to create STH appender: %v", err)
 	}
-	mutations, err := appender.New(nil, mapID, "", nil)
+	mutations, err := appender.New(context.Background(), nil, mapID, "", nil)
 	if err != nil {
 		t.Fatalf("Failed to create mutation appender: %v", err)
 	}
@@ -198,7 +198,7 @@ func NewEnv(t *testing.T) *Env {
 	if err != nil {
 		t.Fatalf("Failed to create transaction: %v", err)
 	}
-	if err := signer.CreateEpoch(txn); err != nil {
+	if err := signer.CreateEpoch(context.Background(), txn); err != nil {
 		t.Fatalf("Failed to create epoch: %v", err)
 	}
 	if err := txn.Commit(); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -637,57 +637,57 @@
 		{
 			"checksumSHA1": "Cvrz7kX3+5CJ7XggM9LuqkGEj0E=",
 			"path": "github.com/google/certificate-transparency/cpp",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z",
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z",
 			"tree": true
 		},
 		{
 			"checksumSHA1": "0lR2nqusGkDmsAu/A1edutFa0VQ=",
 			"path": "github.com/google/certificate-transparency/go",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
 			"checksumSHA1": "8qeVOyWflR8IMBXe5CPJPhvmnh4=",
 			"path": "github.com/google/certificate-transparency/go/asn1",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
-			"checksumSHA1": "N6RPi0mvjtHkncoX3ySHVdqBync=",
+			"checksumSHA1": "fRtEg8Gin7B/6zXFmKOvZijXkRo=",
 			"path": "github.com/google/certificate-transparency/go/client",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
-			"checksumSHA1": "bpeOVNCPWnnKjATWt48SoFEH2Mg=",
+			"checksumSHA1": "9lfyQuRUbJrrrFGoBJQkmSfxkeM=",
 			"path": "github.com/google/certificate-transparency/go/jsonclient",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
 			"checksumSHA1": "uPx27/A4r6xpCp7SmURXZaKl4bI=",
 			"path": "github.com/google/certificate-transparency/go/merkletree",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
 			"checksumSHA1": "CBEdVkRCOrx/Pa64R2A9xXnEC1c=",
 			"path": "github.com/google/certificate-transparency/go/tls",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
 			"checksumSHA1": "iu+5IFQpzb3jZ0ND9AtGdwU+754=",
 			"path": "github.com/google/certificate-transparency/go/x509",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
 			"checksumSHA1": "eyrpGZtaev40pGE0SsF+pCUVSi8=",
 			"path": "github.com/google/certificate-transparency/go/x509/pkix",
-			"revision": "e346aba6451a2f03ba5d71a1e7a21f1fdcbe1013",
-			"revisionTime": "2016-11-08T14:09:39Z"
+			"revision": "32acc4216ea1f20eca97a1cdbc72b73af9e27d20",
+			"revisionTime": "2016-11-18T09:11:50Z"
 		},
 		{
 			"checksumSHA1": "mJuOZXdE9GBhUTHeQ/Wm8U1rR4I=",


### PR DESCRIPTION
This also include using the new APIs in `github.com/google/certificate-transparency/go/client` and `github.com/google/certificate-transparency/go/jsonclient`.