### PR TITLE
Refactor core/signatures

### DIFF
--- a/cmd/key-transparency-client/cmd/post.go
+++ b/cmd/key-transparency-client/cmd/post.go
@@ -74,7 +74,7 @@ User email MUST match the OAuth account used to authorize the update.
 		c.RetryDelay = retryDelay
 
 		// Update.
-		var signers []*signatures.Signer
+		var signers []signatures.Signer
 		var authorizedKeys []*tpb.PublicKey
 		// TODO: fill signers and authorizedKeys.
 		if _, err := c.Update(ctx, userID, &profile, signers, authorizedKeys); err != nil {

--- a/cmd/key-transparency-client/cmd/root.go
+++ b/cmd/key-transparency-client/cmd/root.go
@@ -165,16 +165,12 @@ func getCreds(clientSecretFile string) (credentials.PerRPCCredentials, error) {
 	return oauth.NewOauthAccess(tok), nil
 }
 
-func readSignatureVerifier(ktPEM string) (*signatures.Verifier, error) {
+func readSignatureVerifier(ktPEM string) (signatures.Verifier, error) {
 	pem, err := ioutil.ReadFile(ktPEM)
 	if err != nil {
 		return nil, err
 	}
-	pk, _, err := signatures.PublicKeyFromPEM(pem)
-	if err != nil {
-		return nil, err
-	}
-	ver, err := signatures.NewVerifier(pk)
+	ver, err := signatures.VerifierFromPEM(pem)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/key-transparency-client/grpcc/grpc_client.go
+++ b/cmd/key-transparency-client/grpcc/grpc_client.go
@@ -86,7 +86,7 @@ type Client struct {
 }
 
 // New creates a new client.
-func New(mapID string, client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier *signatures.Verifier, log ctlog.Verifier) *Client {
+func New(mapID string, client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier signatures.Verifier, log ctlog.Verifier) *Client {
 	return &Client{
 		cli:        client,
 		vrf:        vrf,
@@ -178,7 +178,7 @@ func (c *Client) ListHistory(ctx context.Context, userID string, start, end int6
 
 // Update creates an UpdateEntryRequest for a user, attempt to submit it multiple
 // times depending on RetryCount.
-func (c *Client) Update(ctx context.Context, userID string, profile *tpb.Profile, signers []*signatures.Signer, authorizedKeys []*tpb.PublicKey, opts ...grpc.CallOption) (*tpb.UpdateEntryRequest, error) {
+func (c *Client) Update(ctx context.Context, userID string, profile *tpb.Profile, signers []signatures.Signer, authorizedKeys []*tpb.PublicKey, opts ...grpc.CallOption) (*tpb.UpdateEntryRequest, error) {
 	getResp, err := c.cli.GetEntry(ctx, &tpb.GetEntryRequest{UserId: userID}, opts...)
 	if err != nil {
 		return nil, err

--- a/cmd/key-transparency-signer/backend.go
+++ b/cmd/key-transparency-signer/backend.go
@@ -68,16 +68,12 @@ func openEtcd() *clientv3.Client {
 	return cli
 }
 
-func openPrivateKey() *signatures.Signer {
+func openPrivateKey() signatures.Signer {
 	pem, err := ioutil.ReadFile(*signingKey)
 	if err != nil {
 		log.Fatalf("Failed to read file %v: %v", *signingKey, err)
 	}
-	key, _, err := signatures.PrivateKeyFromPEM(pem)
-	if err != nil {
-		log.Fatalf("Read to read private key: %v", err)
-	}
-	sig, err := signatures.NewSigner(rand.Reader, key)
+	sig, err := signatures.SignerFromPEM(rand.Reader, pem)
 	if err != nil {
 		log.Fatalf("Failed to create signer: %v", err)
 	}

--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -30,7 +30,7 @@ import (
 
 // CreateUpdateEntryRequest creates UpdateEntryRequest given GetEntryResponse,
 // user ID and a profile.
-func CreateUpdateEntryRequest(getResp *tpb.GetEntryResponse, vrf vrf.PublicKey, userID string, profile *tpb.Profile, signers []*signatures.Signer, authorizedKeys []*tpb.PublicKey) (*tpb.UpdateEntryRequest, error) {
+func CreateUpdateEntryRequest(getResp *tpb.GetEntryResponse, vrf vrf.PublicKey, userID string, profile *tpb.Profile, signers []signatures.Signer, authorizedKeys []*tpb.PublicKey) (*tpb.UpdateEntryRequest, error) {
 	// Extract index from a prior GetEntry call.
 	index := vrf.Index(getResp.Vrf)
 	prevEntry := new(tpb.Entry)
@@ -87,15 +87,14 @@ func CreateUpdateEntryRequest(getResp *tpb.GetEntryResponse, vrf vrf.PublicKey, 
 	}, err
 }
 
-// TODO: enable multiple algorithms.
-func generateSignatures(data interface{}, signers []*signatures.Signer) (map[string]*ctmap.DigitallySigned, error) {
+func generateSignatures(data interface{}, signers []signatures.Signer) (map[string]*ctmap.DigitallySigned, error) {
 	sigs := make(map[string]*ctmap.DigitallySigned)
 	for _, signer := range signers {
 		sig, err := signer.Sign(data)
 		if err != nil {
 			return nil, err
 		}
-		sigs[signer.KeyName] = sig
+		sigs[signer.KeyID()] = sig
 	}
 	return sigs, nil
 }

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -46,12 +46,12 @@ var (
 type Verifier struct {
 	vrf  vrf.PublicKey
 	tree *tv.Verifier
-	sig  *signatures.Verifier
+	sig  signatures.Verifier
 	log  ctlog.Verifier
 }
 
 // New creates a new instance of the client verifier.
-func New(vrf vrf.PublicKey, tree *tv.Verifier, sig *signatures.Verifier, log ctlog.Verifier) *Verifier {
+func New(vrf vrf.PublicKey, tree *tv.Verifier, sig signatures.Verifier, log ctlog.Verifier) *Verifier {
 	return &Verifier{
 		vrf:  vrf,
 		tree: tree,
@@ -105,7 +105,7 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, userID string, in
 	}
 	Vlog.Printf("✓ Sparse tree proof verified.")
 
-	if err := v.sig.Verify(in.GetSmh().GetMapHead(), in.GetSmh().Signatures[v.sig.KeyName]); err != nil {
+	if err := v.sig.Verify(in.GetSmh().GetMapHead(), in.GetSmh().Signatures[v.sig.KeyID()]); err != nil {
 		Vlog.Printf("✗ Signed Map Head signature verification failed.")
 		return err
 	}

--- a/core/signatures/ecdsa_p256.go
+++ b/core/signatures/ecdsa_p256.go
@@ -1,0 +1,178 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signatures
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"encoding/asn1"
+	"encoding/json"
+	"io"
+	"log"
+	"math/big"
+
+	"github.com/benlaurie/objecthash/go/objecthash"
+	"github.com/google/key-transparency/core/proto/ctmap"
+)
+
+// p256Signer generates signatures with a single key using ECDSA P256.
+type p256Signer struct {
+	privKey crypto.PrivateKey
+	keyID   string
+	rand    io.Reader
+}
+
+// newP256Signer creates a signer object from a private key.
+func newP256Signer(rand io.Reader, pk crypto.Signer) (Signer, error) {
+	switch pkType := pk.(type) {
+	case *ecdsa.PrivateKey:
+		params := *(pkType.Params())
+		if params != *elliptic.P256().Params() {
+			return nil, ErrPointNotOnCurve
+		}
+		if !elliptic.P256().IsOnCurve(pkType.X, pkType.Y) {
+			return nil, ErrPointNotOnCurve
+		}
+	default:
+		return nil, ErrWrongKeyType
+	}
+
+	id, err := keyID(pk.Public())
+	if err != nil {
+		return nil, err
+	}
+
+	return &p256Signer{
+		privKey: pk,
+		keyID:   id,
+		rand:    rand,
+	}, nil
+}
+
+// Sign generates a digital signature object.
+func (s *p256Signer) Sign(data interface{}) (*ctmap.DigitallySigned, error) {
+	j, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	hash := objecthash.CommonJSONHash(string(j))
+
+	ecdsaKey, ok := s.privKey.(*ecdsa.PrivateKey)
+	if !ok {
+		log.Print("not an ECDSA key")
+		return nil, ErrSign
+	}
+	var ecSig struct {
+		R, S *big.Int
+	}
+	ecSig.R, ecSig.S, err = ecdsa.Sign(s.rand, ecdsaKey, hash[:])
+	if err != nil {
+		log.Print("signature generation failed")
+		return nil, ErrSign
+	}
+	sig, err := asn1.Marshal(ecSig)
+	if err != nil {
+		log.Print("failed to marshal ECDSA signature")
+		return nil, ErrSign
+	}
+	return &ctmap.DigitallySigned{
+		HashAlgorithm: ctmap.DigitallySigned_SHA256,
+		SigAlgorithm:  ctmap.DigitallySigned_ECDSA,
+		Signature:     sig,
+	}, nil
+}
+
+// KeyID returns the ID of the associated public key.
+func (s *p256Signer) KeyID() string {
+	return s.keyID
+}
+
+// p256Verifier verifies signatures using ECDSA P256.
+type p256Verifier struct {
+	pubKey crypto.PublicKey
+	keyID  string
+}
+
+// newP256Verifier creates a verifier from a ECDSA public key.
+func newP256Verifier(pk *ecdsa.PublicKey) (Verifier, error) {
+	params := *(pk.Params())
+	if params != *elliptic.P256().Params() {
+		return nil, ErrPointNotOnCurve
+	}
+	if !elliptic.P256().IsOnCurve(pk.X, pk.Y) {
+		return nil, ErrPointNotOnCurve
+	}
+	id, err := keyID(pk)
+	if err != nil {
+		return nil, err
+	}
+
+	return &p256Verifier{
+		pubKey: pk,
+		keyID:  id,
+	}, nil
+}
+
+// Verify checks the digital signature associated applied to data.
+func (s *p256Verifier) Verify(data interface{}, sig *ctmap.DigitallySigned) error {
+	if sig == nil {
+		return ErrMissingSig
+	}
+	if sig.HashAlgorithm != ctmap.DigitallySigned_SHA256 {
+		log.Print("not SHA256 hash algorithm")
+		return ErrVerify
+	}
+	if sig.SigAlgorithm != ctmap.DigitallySigned_ECDSA {
+		log.Print("not ECDSA signature algorithm")
+		return ErrVerify
+	}
+
+	j, err := json.Marshal(data)
+	if err != nil {
+		log.Print("json.Marshal failed")
+		return ErrVerify
+	}
+	hash := objecthash.CommonJSONHash(string(j))
+
+	ecdsaKey, ok := s.pubKey.(*ecdsa.PublicKey)
+	if !ok {
+		log.Print("not an ECDSA key")
+		return ErrVerify
+	}
+	var ecdsaSig struct {
+		R, S *big.Int
+	}
+	rest, err := asn1.Unmarshal(sig.Signature, &ecdsaSig)
+	if err != nil {
+		log.Print("failed to unmarshal ECDSA signature")
+		return ErrVerify
+	}
+	if len(rest) != 0 {
+		log.Print("extra data found after signature")
+		return ErrVerify
+	}
+
+	if !ecdsa.Verify(ecdsaKey, hash[:], ecdsaSig.R, ecdsaSig.S) {
+		log.Print("failed to verify ECDSA signature")
+		return ErrVerify
+	}
+	return nil
+}
+
+// KeyID returns the ID of the associated public key.
+func (s *p256Verifier) KeyID() string {
+	return s.keyID
+}

--- a/core/signatures/ecdsa_p256_test.go
+++ b/core/signatures/ecdsa_p256_test.go
@@ -1,0 +1,149 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signatures
+
+import (
+	"bytes"
+	"crypto/rand"
+	"math"
+	"testing"
+)
+
+func TestConsistentKeyIDs(t *testing.T) {
+	// Verify that the ID generated from from pub and from priv are the same.
+	for _, tc := range []struct {
+		priv string
+		pub  string
+	}{
+		{testPrivKey, testPubKey},
+	} {
+		signer, err := SignerFromPEM(rand.Reader, []byte(tc.priv))
+		if err != nil {
+			t.Fatalf("SignerFromPEM(): %v", err)
+		}
+		verifier, err := VerifierFromPEM([]byte(tc.pub))
+		if err != nil {
+			t.Fatalf("VerifierFromPEM(): %v", err)
+		}
+
+		if got, want := signer.KeyID(), verifier.KeyID(); got != want {
+			t.Errorf("signer.KeyID(): %v, want %v", got, want)
+		}
+	}
+}
+
+type env struct {
+	signer   Signer
+	verifier Verifier
+}
+
+func newEnv(t *testing.T) *env {
+	signer, err := SignerFromPEM(rand.Reader, []byte(testPrivKey))
+	if err != nil {
+		t.Fatalf("SignerFromPEM(): %v", err)
+	}
+	verifier, err := VerifierFromPEM([]byte(testPubKey))
+	if err != nil {
+		t.Fatalf("VerifierFromPEM(): %v", err)
+	}
+
+	return &env{signer, verifier}
+}
+
+func TestSignVerifier(t *testing.T) {
+	e := newEnv(t)
+	for _, tc := range []struct {
+		data interface{}
+	}{
+		{struct{ Foo string }{"bar"}},
+	} {
+		sig, err := e.signer.Sign(tc.data)
+		if err != nil {
+			t.Errorf("Sign(%v): %v", tc.data, err)
+		}
+		if err := e.verifier.Verify(tc.data, sig); err != nil {
+			t.Errorf("Verify(%v, %v): %v", tc.data, sig, err)
+		}
+	}
+}
+
+func TestRightTruncateSignature(t *testing.T) {
+	e := newEnv(t)
+	data := struct{ Foo string }{"bar"}
+
+	// Truncate bytes from the end of sig and try to verify.
+	sig, err := e.signer.Sign(data)
+	if err != nil {
+		t.Errorf("Sign(%v): %v", data, err)
+	}
+	sigLen := len(sig.Signature)
+	for i := 0; i < sigLen; i++ {
+		sig.Signature = sig.Signature[:len(sig.Signature)-1]
+		if err := e.verifier.Verify(data, sig); err == nil {
+			t.Errorf("Verify unexpectedly succeeded after truncating %v bytes from the end of the signature", i)
+		}
+	}
+}
+
+func TestLeftTruncateSignature(t *testing.T) {
+	e := newEnv(t)
+	data := struct{ Foo string }{"bar"}
+
+	// Truncate bytes from the beginning of sig and try to verify.
+	sig, err := e.signer.Sign(data)
+	if err != nil {
+		t.Errorf("Sign(%v): %v", data, err)
+	}
+	sigLen := len(sig.Signature)
+	for i := 0; i < sigLen; i++ {
+		sig.Signature = sig.Signature[1:]
+		if err := e.verifier.Verify(data, sig); err == nil {
+			t.Errorf("Verify unexpectedly succeeded after truncating %v bytes from the beginning of the signature", i)
+		}
+	}
+}
+
+func TestBitFlipSignature(t *testing.T) {
+	e := newEnv(t)
+	data := struct{ Foo string }{"bar"}
+
+	// Truncate bytes from the beginning of sig and try to verify.
+	sig, err := e.signer.Sign(data)
+	if err != nil {
+		t.Errorf("Sign(%v): %v", data, err)
+	}
+	for i := 0; i < len(sig.Signature)*8; i++ {
+		// Flip bit in position i.
+		flippedSig := *sig
+		flippedSig.Signature = flipBit(sig.Signature, uint(i))
+
+		// Verify signature
+		if err := e.verifier.Verify(data, &flippedSig); err == nil {
+			t.Errorf("Verify unexpectedly succeeded after flipping bit %v of the signature", i)
+		}
+	}
+}
+
+func flipBit(a []byte, pos uint) []byte {
+	index := int(math.Floor(float64(pos) / 8))
+	b := byte(a[index])
+	b ^= (1 << uint(math.Mod(float64(pos), 8.0)))
+
+	var buf bytes.Buffer
+	buf.Write(a[:index])
+	buf.Write([]byte{b})
+	buf.Write(a[index+1:])
+	return buf.Bytes()
+}

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -56,14 +56,14 @@ type Signer struct {
 	tree      tree.Sparse
 	mutations appender.Appender
 	sths      appender.Appender
-	signer    *signatures.Signer
+	signer    signatures.Signer
 	clock     Clock
 }
 
 // New creates a new instance of the signer.
 func New(realm string, queue queue.Queuer, tree tree.Sparse,
 	mutator mutator.Mutator, sths, mutations appender.Appender,
-	signer *signatures.Signer) *Signer {
+	signer signatures.Signer) *Signer {
 	return &Signer{
 		realm:     realm,
 		queue:     queue,
@@ -143,7 +143,7 @@ func (s *Signer) CreateEpoch(ctx context.Context, txn transaction.Txn) error {
 	}
 	smh := &ctmap.SignedMapHead{
 		MapHead:    mh,
-		Signatures: map[string]*ctmap.DigitallySigned{s.signer.KeyName: sig},
+		Signatures: map[string]*ctmap.DigitallySigned{s.signer.KeyID(): sig},
 	}
 	if err := s.sths.Append(ctx, txn, epoch, smh); err != nil {
 		return fmt.Errorf("Append SMH failure %v", err)

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -62,9 +62,8 @@ var (
 	}
 )
 
-func createSigner(t *testing.T, privKey string) *signatures.Signer {
-	sk, _, _ := signatures.PrivateKeyFromPEM([]byte(privKey))
-	signer, err := signatures.NewSigner(DevZero{}, sk)
+func createSigner(t *testing.T, privKey string) signatures.Signer {
+	signer, err := signatures.SignerFromPEM(DevZero{}, []byte(privKey))
 	if err != nil {
 		t.Fatalf("signatures.NewSigner failed: %v", err)
 	}
@@ -92,9 +91,9 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 	// Create lists of signers.
 	signer1 := createSigner(t, testPrivKey1)
 	signer2 := createSigner(t, testPrivKey2)
-	signers1 := []*signatures.Signer{signer1}
-	signers2 := []*signatures.Signer{signer1, signer2}
-	signers3 := []*signatures.Signer{signer2}
+	signers1 := []signatures.Signer{signer1}
+	signers2 := []signatures.Signer{signer1, signer2}
+	signers3 := []signatures.Signer{signer2}
 
 	// Create lists of authorized keys
 	authorizedKey1 := getAuthorizedKey(testPubKey1)
@@ -108,7 +107,7 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 		insert         bool
 		ctx            context.Context
 		userID         string
-		signers        []*signatures.Signer
+		signers        []signatures.Signer
 		authorizedKeys []*tpb.PublicKey
 	}{
 		{false, false, context.Background(), "noalice", signers1, authorizedKeys1}, // Empty
@@ -183,7 +182,7 @@ func TestUpdateValidation(t *testing.T) {
 	}
 
 	// Create lists of signers and authorized keys
-	signers := []*signatures.Signer{createSigner(t, testPrivKey1)}
+	signers := []signatures.Signer{createSigner(t, testPrivKey1)}
 	authorizedKeys := []*tpb.PublicKey{getAuthorizedKey(testPubKey1)}
 
 	for _, tc := range []struct {
@@ -191,7 +190,7 @@ func TestUpdateValidation(t *testing.T) {
 		ctx            context.Context
 		userID         string
 		profile        *tpb.Profile
-		signers        []*signatures.Signer
+		signers        []signatures.Signer
 		authorizedKeys []*tpb.PublicKey
 	}{
 		{false, context.Background(), "alice", profile, signers, authorizedKeys},
@@ -235,7 +234,7 @@ func TestListHistory(t *testing.T) {
 	}
 
 	// Create lists of signers and authorized keys
-	signers := []*signatures.Signer{createSigner(t, testPrivKey1)}
+	signers := []signatures.Signer{createSigner(t, testPrivKey1)}
 	authorizedKeys := []*tpb.PublicKey{getAuthorizedKey(testPubKey1)}
 
 	if err := env.setupHistory(ctx, userID, signers, authorizedKeys); err != nil {
@@ -271,7 +270,7 @@ func TestListHistory(t *testing.T) {
 	}
 }
 
-func (e *Env) setupHistory(ctx context.Context, userID string, signers []*signatures.Signer, authorizedKeys []*tpb.PublicKey) error {
+func (e *Env) setupHistory(ctx context.Context, userID string, signers []signatures.Signer, authorizedKeys []*tpb.PublicKey) error {
 	// Setup. Each profile entry is either nil, to indicate that the user
 	// did not submit a new profile in that epoch, or contains the profile
 	// that the user is submitting. The user profile history contains the

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -87,7 +87,7 @@ type Env struct {
 	mapLog     *httptest.Server
 }
 
-func staticKeyPair() (*signatures.Signer, *signatures.Verifier, error) {
+func staticKeyPair() (signatures.Signer, signatures.Verifier, error) {
 	sigPriv := `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIHgSC8WzQK0bxSmfJWUeMP5GdndqUw8zS1dCHQ+3otj/oAoGCCqGSM49
 AwEHoUQDQgAE5AV2WCmStBt4N2Dx+7BrycJFbxhWf5JqSoyp0uiL8LeNYyj5vgkl
@@ -97,20 +97,12 @@ K8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5AV2WCmStBt4N2Dx+7BrycJFbxhW
 f5JqSoyp0uiL8LeNYyj5vgklK8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 -----END PUBLIC KEY-----`
-	signer, _, err := signatures.PrivateKeyFromPEM([]byte(sigPriv))
-	if err != nil {
-		return nil, nil, err
-	}
-	sig, err := signatures.NewSigner(DevZero{}, signer)
+	sig, err := signatures.SignerFromPEM(DevZero{}, []byte(sigPriv))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	verifier, _, err := signatures.PublicKeyFromPEM([]byte(sigPub))
-	if err != nil {
-		return nil, nil, err
-	}
-	ver, err := signatures.NewVerifier(verifier)
+	ver, err := signatures.VerifierFromPEM([]byte(sigPub))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- Convert Signer and Verifier into interfaces.
- Implement those interfaces using ECDSA P256 (using the code that already exists).

I also added place holders where new signature schemes should be integrated after they are implemented.

Closes #432.