### PR TITLE
Add SignerFromRawKey and VerifierFromRawKey functions in signatures

### DIFF
--- a/core/signatures/factory/factory.go
+++ b/core/signatures/factory/factory.go
@@ -20,6 +20,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"io"
 	"time"
 
 	"github.com/google/key-transparency/core/signatures"
@@ -45,6 +46,11 @@ func SignerFromPEM(pemKey []byte) (signatures.Signer, error) {
 	return NewSigner(pemKey, time.Now(), "Signer created from PEM", kmpb.SigningKey_ACTIVE)
 }
 
+// SignerFromRawKey creates a signer object from given raw key bytes.
+func SignerFromRawKey(rand io.Reader, b []byte) (Signer, error) {
+	return signerFromBytes(rand, b, time.Now(), "Signer created from raw key", kmpb.SigningKey_ACTIVE)
+}
+
 func signerFromBytes(b []byte, addedAt time.Time, description string, status kmpb.SigningKey_KeyStatus) (signatures.Signer, error) {
 	if _, err := x509.ParsePKCS1PrivateKey(b); err == nil {
 		return nil, signatures.ErrUnimplemented
@@ -68,6 +74,11 @@ func NewVerifier(pemKey []byte, addedAt time.Time, description string, status km
 // created using that block.
 func VerifierFromPEM(pemKey []byte) (signatures.Verifier, error) {
 	return NewVerifier(pemKey, time.Now(), "Verifier created from PEM", kmpb.VerifyingKey_ACTIVE)
+}
+
+// VerifierFromRawKey creates a verifier object from given raw key bytes.
+func VerifierFromRawKey(b []byte) (Verifier, error) {
+	return verifierFromBytes(b, time.Now(), "Verifier created from raw key", kmpb.VerifyingKey_ACTIVE)
 }
 
 // VerifierFromKey creates a verifier object from a PublicKey proto object.


### PR DESCRIPTION
This allows creating signer and verifier objects using their raw respective keys.