### PR TITLE
Refactor signatures Library

### DIFF
--- a/cmd/key-transparency-client/cmd/root.go
+++ b/cmd/key-transparency-client/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/key-transparency/core/client/ctlog"
 	"github.com/google/key-transparency/core/client/kt"
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/factory"
 	"github.com/google/key-transparency/core/vrf"
 	"github.com/google/key-transparency/core/vrf/p256"
 	"github.com/google/key-transparency/impl/google/authentication"
@@ -170,7 +171,7 @@ func readSignatureVerifier(ktPEM string) (signatures.Verifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	ver, err := signatures.VerifierFromPEM(pem)
+	ver, err := factory.VerifierFromPEM(pem)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/key-transparency-signer/backend.go
+++ b/cmd/key-transparency-signer/backend.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/key-transparency/core/mutator/entry"
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/factory"
 	"github.com/google/key-transparency/core/signer"
 	"github.com/google/key-transparency/impl/etcd/queue"
 	"github.com/google/key-transparency/impl/sql/appender"
@@ -73,7 +74,7 @@ func openPrivateKey() signatures.Signer {
 	if err != nil {
 		log.Fatalf("Failed to read file %v: %v", *signingKey, err)
 	}
-	sig, err := signatures.SignerFromPEM(rand.Reader, pem)
+	sig, err := factory.SignerFromPEM(rand.Reader, pem)
 	if err != nil {
 		log.Fatalf("Failed to create signer: %v", err)
 	}

--- a/core/keystore/keystore.go
+++ b/core/keystore/keystore.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/factory"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -65,7 +66,7 @@ func Unmarshal(buf []byte, store *KeyStore) error {
 		if err != nil {
 			return err
 		}
-		signer, err := signatures.NewSigner(rand.Reader, key.KeyMaterial, addedAt, key.Metadata.Description, key.Status)
+		signer, err := factory.NewSigner(rand.Reader, key.KeyMaterial, addedAt, key.Metadata.Description, key.Status)
 		if err != nil {
 			return err
 		}
@@ -82,7 +83,7 @@ func Unmarshal(buf []byte, store *KeyStore) error {
 		if err != nil {
 			return err
 		}
-		verifier, err := signatures.NewVerifier(key.KeyMaterial, addedAt, key.Metadata.Description, key.Status)
+		verifier, err := factory.NewVerifier(key.KeyMaterial, addedAt, key.Metadata.Description, key.Status)
 		if err != nil {
 			return err
 		}
@@ -130,7 +131,7 @@ func (s *KeyStore) Marshal() ([]byte, error) {
 
 // AddSigningKey adds a new private key to the store.
 func (s *KeyStore) AddSigningKey(status kmpb.SigningKey_KeyStatus, description string, key []byte) (string, error) {
-	signer, err := signatures.NewSigner(rand.Reader, key, time.Now(), description, status)
+	signer, err := factory.NewSigner(rand.Reader, key, time.Now(), description, status)
 	if err != nil {
 		return "", nil
 	}
@@ -152,7 +153,7 @@ func (s *KeyStore) AddSigningKey(status kmpb.SigningKey_KeyStatus, description s
 
 // AddVerifyingKey adds a new public key to the store.
 func (s *KeyStore) AddVerifyingKey(description string, key []byte) (string, error) {
-	verifier, err := signatures.NewVerifier(key, time.Now(), description, kmpb.VerifyingKey_ACTIVE)
+	verifier, err := factory.NewVerifier(key, time.Now(), description, kmpb.VerifyingKey_ACTIVE)
 	if err != nil {
 		return "", err
 	}

--- a/core/mutator/entry/entry.go
+++ b/core/mutator/entry/entry.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/key-transparency/core/mutator"
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/factory"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/golang/protobuf/proto"
@@ -116,7 +117,7 @@ func verifyKeys(oldValue []byte, data interface{}, update *tpb.SignedKV, entry *
 func verifiersFromKeys(keys []*tpb.PublicKey) (map[string]signatures.Verifier, error) {
 	verifiers := make(map[string]signatures.Verifier)
 	for _, key := range keys {
-		verifier, err := signatures.VerifierFromKey(key)
+		verifier, err := factory.VerifierFromKey(key)
 		if err != nil {
 			return nil, err
 		}

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/key-transparency/core/mutator"
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/factory"
 
 	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/golang/protobuf/proto"
@@ -112,7 +113,7 @@ func prepareMutation(key []byte, entryData []byte, previous []byte, signers []si
 func signersFromPEMs(t *testing.T, keys [][]byte) []signatures.Signer {
 	signers := make([]signatures.Signer, 0, len(keys))
 	for _, key := range keys {
-		signer, err := signatures.SignerFromPEM(rand.Reader, key)
+		signer, err := factory.SignerFromPEM(rand.Reader, key)
 		if err != nil {
 			t.Fatalf("NewSigner(): %v", err)
 		}

--- a/core/signatures/factory/factory.go
+++ b/core/signatures/factory/factory.go
@@ -1,0 +1,101 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factory
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/p256"
+
+	kmpb "github.com/google/key-transparency/core/proto/keymaster"
+	tpb "github.com/google/key-transparency/core/proto/keytransparency_v1_types"
+)
+
+// NewSigner creates a signer object based on information in given
+// keymaster-related parameters.
+func NewSigner(rand io.Reader, pemKey []byte, addedAt time.Time, description string, status kmpb.SigningKey_KeyStatus) (signatures.Signer, error) {
+	p, _ := pem.Decode(pemKey)
+	if p == nil {
+		return nil, signatures.ErrNoPEMFound
+	}
+	return signerFromBytes(rand, p.Bytes, addedAt, description, status)
+}
+
+// SignerFromPEM parses a PEM formatted block and returns a signer object created
+// using that block.
+func SignerFromPEM(rand io.Reader, pemKey []byte) (signatures.Signer, error) {
+	return NewSigner(rand, pemKey, time.Now(), "Signer created from PEM", kmpb.SigningKey_ACTIVE)
+}
+
+func signerFromBytes(rand io.Reader, b []byte, addedAt time.Time, description string, status kmpb.SigningKey_KeyStatus) (signatures.Signer, error) {
+	if _, err := x509.ParsePKCS1PrivateKey(b); err == nil {
+		return nil, signatures.ErrUnimplemented
+	} else if k, err := x509.ParseECPrivateKey(b); err == nil {
+		return p256.NewSigner(rand, k, addedAt, description, status)
+	}
+	return nil, signatures.ErrUnimplemented
+}
+
+// NewVerifier creates a verifier object based on information in given
+// keymaster-related parameters.
+func NewVerifier(pemKey []byte, addedAt time.Time, description string, status kmpb.VerifyingKey_KeyStatus) (signatures.Verifier, error) {
+	p, _ := pem.Decode(pemKey)
+	if p == nil {
+		return nil, signatures.ErrNoPEMFound
+	}
+	return verifierFromBytes(p.Bytes, addedAt, description, status)
+}
+
+// VerifierFromPEM parses a PEM formatted block and returns a verifier object
+// created using that block.
+func VerifierFromPEM(pemKey []byte) (signatures.Verifier, error) {
+	return NewVerifier(pemKey, time.Now(), "Verifier created from PEM", kmpb.VerifyingKey_ACTIVE)
+}
+
+// VerifierFromKey creates a verifier object from a PublicKey proto object.
+func VerifierFromKey(key *tpb.PublicKey) (signatures.Verifier, error) {
+	switch {
+	case key.GetEd25519() != nil:
+		return nil, signatures.ErrUnimplemented
+	case key.GetRsaVerifyingSha256_3072() != nil:
+		return nil, signatures.ErrUnimplemented
+	case key.GetEcdsaVerifyingP256() != nil:
+		return verifierFromBytes(key.GetEcdsaVerifyingP256(), time.Now(), "Verifier created from PublicKey", kmpb.VerifyingKey_ACTIVE)
+	default:
+		return nil, errors.New("public key not found")
+	}
+}
+
+func verifierFromBytes(b []byte, addedAt time.Time, description string, status kmpb.VerifyingKey_KeyStatus) (signatures.Verifier, error) {
+	k, err := x509.ParsePKIXPublicKey(b)
+	if err != nil {
+		return nil, err
+	}
+
+	switch pkType := k.(type) {
+	case *rsa.PublicKey:
+		return nil, signatures.ErrUnimplemented
+	case *ecdsa.PublicKey:
+		return p256.NewVerifier(pkType, addedAt, description, status)
+	}
+	return nil, signatures.ErrUnimplemented
+}

--- a/core/signatures/factory/factory_test.go
+++ b/core/signatures/factory/factory_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package signatures
+package factory
 
 import (
 	"crypto/rand"

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/key-transparency/cmd/key-transparency-client/grpcc"
 	"github.com/google/key-transparency/core/authentication"
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/factory"
 
 	"golang.org/x/net/context"
 
@@ -63,9 +64,9 @@ var (
 )
 
 func createSigner(t *testing.T, privKey string) signatures.Signer {
-	signer, err := signatures.SignerFromPEM(DevZero{}, []byte(privKey))
+	signer, err := factory.SignerFromPEM(DevZero{}, []byte(privKey))
 	if err != nil {
-		t.Fatalf("signatures.NewSigner failed: %v", err)
+		t.Fatalf("factory.NewSigner failed: %v", err)
 	}
 	return signer
 }

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/key-transparency/core/keyserver"
 	"github.com/google/key-transparency/core/mutator/entry"
 	"github.com/google/key-transparency/core/signatures"
+	"github.com/google/key-transparency/core/signatures/factory"
 	"github.com/google/key-transparency/core/signer"
 	"github.com/google/key-transparency/core/testutil/ctutil"
 	"github.com/google/key-transparency/core/vrf"
@@ -97,12 +98,12 @@ K8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5AV2WCmStBt4N2Dx+7BrycJFbxhW
 f5JqSoyp0uiL8LeNYyj5vgklK8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 -----END PUBLIC KEY-----`
-	sig, err := signatures.SignerFromPEM(DevZero{}, []byte(sigPriv))
+	sig, err := factory.SignerFromPEM(DevZero{}, []byte(sigPriv))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ver, err := signatures.VerifierFromPEM([]byte(sigPub))
+	ver, err := factory.VerifierFromPEM([]byte(sigPub))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
- Move signatures library objects (`p256Signer` and `p256Verifier`) into separate package, `core/signatures/p256`.
- Move all signer/verifier creation functionality into `core/signatures/factory`. This gets rid of circular dependency issue.
