### PR TITLE
Generate Keys in signatures Library

### DIFF
--- a/core/signatures/p256/ecdsa_p256_test.go
+++ b/core/signatures/p256/ecdsa_p256_test.go
@@ -230,3 +230,20 @@ func flipBit(a []byte, pos uint) []byte {
 	buf.Write(a[index+1:])
 	return buf.Bytes()
 }
+
+func TestGeneratePEMs(t *testing.T) {
+	signatures.Rand = DevZero{}
+	skPEM, pkPEM, err := GeneratePEMs()
+
+	// Ensure that the generated keys are valid.
+	signer := newSigner(t, skPEM)
+	verifier := newVerifier(t, pkPEM)
+	data := struct{ Foo string }{"bar"}
+	sig, err := signer.Sign(data)
+	if err != nil {
+		t.Fatalf("signer.Sign(%v) failed: %v", data, err)
+	}
+	if err := verifier.Verify(data, sig); err != nil {
+		t.Errorf("verifier.Verify() failed: %v", err)
+	}
+}


### PR DESCRIPTION
Add `GenerateKeys` function to internal types of the signatures library. This step is necessary before adding the capabilities of generating keys in client `authorized-keys` command.

Should merge #454 first.