### PR TITLE
Minor fix

### DIFF
--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -263,7 +263,7 @@ func (s *Server) UpdateEntry(ctx context.Context, in *tpb.UpdateEntryRequest) (*
 		log.Printf("Enqueue error: %v", err)
 		return nil, grpc.Errorf(codes.Internal, "Write error")
 	}
-	return &tpb.UpdateEntryResponse{Proof: resp}, err
+	return &tpb.UpdateEntryResponse{Proof: resp}, nil
 }
 
 func (s *Server) saveCommitment(ctx context.Context, kv *tpb.KeyValue, committed *tpb.Committed) error {


### PR DESCRIPTION
This PR changes the following:
* All RPC call handlers return gRPC errors after logging the actual error.
* All functions that are called by RPC call handlers return standard `error` objects.

In other words, all exported functions (which are indeed gRPC handlers) return gRPC errors. All unexported functions don't return gRPC errors.