### PR TITLE
Remove ssl from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ go:
   - 1.7.3
 
 dist: trusty
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get install build-essential libssl-dev
+sudo: false
 
 install:
   - go get -u github.com/kardianos/govendor


### PR DESCRIPTION
Now that google/certificate-transparency#1362 is merged, we no longer have a dependency on OpenSSL.  Remove this from the build file. 

Closes #465
