### PR TITLE
Separate Signer from Keymaster operations

### DIFF
--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -25,8 +25,8 @@ import (
 	"github.com/google/keytransparency/cmd/keytransparency-client/grpcc"
 	"github.com/google/keytransparency/core/client/ctlog"
 	"github.com/google/keytransparency/core/client/kt"
+	"github.com/google/keytransparency/core/crypto/keymaster"
 	"github.com/google/keytransparency/core/crypto/signatures"
-	"github.com/google/keytransparency/core/crypto/signatures/factory"
 	"github.com/google/keytransparency/core/vrf"
 	"github.com/google/keytransparency/core/vrf/p256"
 	"github.com/google/keytransparency/impl/google/authentication"
@@ -179,7 +179,7 @@ func readSignatureVerifier(ktPEM string) (signatures.Verifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	ver, err := factory.VerifierFromPEM(pem)
+	ver, err := keymaster.VerifierFromPEM(pem)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -179,7 +179,7 @@ func readSignatureVerifier(ktPEM string) (signatures.Verifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	ver, err := keymaster.VerifierFromPEM(pem)
+	ver, err := keymaster.NewVerifierFromPEM(pem)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/keytransparency-signer/backend.go
+++ b/cmd/keytransparency-signer/backend.go
@@ -73,7 +73,7 @@ func openPrivateKey() signatures.Signer {
 	if err != nil {
 		log.Fatalf("Failed to read file %v: %v", *signingKey, err)
 	}
-	sig, err := factory.SignerFromPEM(pem)
+	sig, err := factory.NewSignerFromPEM(pem)
 	if err != nil {
 		log.Fatalf("Failed to create signer: %v", err)
 	}

--- a/core/crypto/keymaster/interface.go
+++ b/core/crypto/keymaster/interface.go
@@ -1,0 +1,51 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keymaster
+
+import (
+	"github.com/google/keytransparency/core/crypto/signatures"
+	kmpb "github.com/google/keytransparency/core/proto/keymaster"
+)
+
+// Signer represents an object that can generate signatures with a single key.
+type Signer interface {
+	signatures.Signer
+	// Status returns the status of the signer.
+	Status() kmpb.SigningKey_KeyStatus
+	// Activate activates the signer.
+	Activate()
+	// Deactivate deactivates the signer.
+	Deactivate()
+	// Deprecate sets the signer status to DEPRECATED.
+	Deprecate()
+	// Marshal marshals a signer object into a keymaster SigningKey message.
+	Marshal() (*kmpb.SigningKey, error)
+	// Clone creates a new instance of the signer object
+	Clone() Signer
+}
+
+// Verifier represents an object that can verify signatures with a single key.
+type Verifier interface {
+	signatures.Verifier
+	// Status returns the status of the verifier.
+	Status() kmpb.VerifyingKey_KeyStatus
+	// Deprecate sets the verifier status to DEPRECATED.
+	Deprecate()
+	// Marshal marshals a verifier object into a keymaster VerifyingKey
+	// message.
+	Marshal() (*kmpb.VerifyingKey, error)
+	// Clone creates a new instance of the verifier object
+	Clone() Verifier
+}

--- a/core/crypto/keymaster/interface.go
+++ b/core/crypto/keymaster/interface.go
@@ -16,6 +16,7 @@ package keymaster
 
 import (
 	"github.com/google/keytransparency/core/crypto/signatures"
+
 	kmpb "github.com/google/keytransparency/core/proto/keymaster"
 )
 

--- a/core/crypto/keymaster/signer.go
+++ b/core/crypto/keymaster/signer.go
@@ -1,0 +1,118 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keymaster
+
+import (
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/keytransparency/core/crypto/signatures"
+	"github.com/google/keytransparency/core/crypto/signatures/factory"
+	kmpb "github.com/google/keytransparency/core/proto/keymaster"
+)
+
+type signer struct {
+	signatures.Signer
+	addedAt     time.Time // time when key is added to keymaster.
+	description string
+	status      kmpb.SigningKey_KeyStatus
+}
+
+// NewSigner creates a signer object from a private key.
+func NewSigner(s signatures.Signer, addedAt time.Time,
+	description string, status kmpb.SigningKey_KeyStatus) Signer {
+	return &signer{
+		Signer:      s,
+		addedAt:     addedAt,
+		description: description,
+		status:      status,
+	}
+}
+
+// NewSignerFromPEM parses a PEM formatted block and returns a signer object created
+// using that block.
+func NewSignerFromPEM(pemKey []byte) (Signer, error) {
+	s, err := factory.NewSignerFromPEM(pemKey)
+	if err != nil {
+		return nil, err
+	}
+	return &signer{
+		Signer:      s,
+		addedAt:     time.Now(),
+		description: "Signer created from PEM",
+		status:      kmpb.SigningKey_ACTIVE,
+	}, nil
+}
+
+// SignerFromRawKey creates a signer object from given raw key bytes.
+func SignerFromRawKey(b []byte) (signatures.Signer, error) {
+	s, err := factory.NewSignerFromBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	return &signer{
+		Signer:      s,
+		addedAt:     time.Now(),
+		description: "Signer created from raw key",
+		status:      kmpb.SigningKey_ACTIVE,
+	}, nil
+}
+
+// Status returns the status of the signer.
+func (s *signer) Status() kmpb.SigningKey_KeyStatus {
+	return s.status
+}
+
+// Activate activates the signer.
+func (s *signer) Activate() {
+	s.status = kmpb.SigningKey_ACTIVE
+}
+
+// Deactivate deactivates the signer.
+func (s *signer) Deactivate() {
+	s.status = kmpb.SigningKey_INACTIVE
+}
+
+// Deprecate sets the signer status to DEPRECATED.
+func (s *signer) Deprecate() {
+	s.status = kmpb.SigningKey_DEPRECATED
+}
+
+// Marshal marshals a signer object into a keymaster SigningKey message.
+func (s *signer) Marshal() (*kmpb.SigningKey, error) {
+	skPEM, err := s.PrivateKeyPEM()
+	if err != nil {
+		return nil, err
+	}
+	timestamp, err := ptypes.TimestampProto(s.addedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &kmpb.SigningKey{
+		Metadata: &kmpb.Metadata{
+			KeyId:       s.KeyID(),
+			AddedAt:     timestamp,
+			Description: s.description,
+		},
+		KeyMaterial: skPEM,
+		Status:      s.status,
+	}, nil
+}
+
+// Clone creates a new instance of the signer object
+func (s *signer) Clone() Signer {
+	clone := *s
+	return &clone
+}

--- a/core/crypto/keymaster/signer.go
+++ b/core/crypto/keymaster/signer.go
@@ -56,8 +56,8 @@ func NewSignerFromPEM(pemKey []byte) (Signer, error) {
 	}, nil
 }
 
-// SignerFromRawKey creates a signer object from given raw key bytes.
-func SignerFromRawKey(b []byte) (signatures.Signer, error) {
+// NewSignerFromRawKey creates a signer object from given raw key bytes.
+func NewSignerFromRawKey(b []byte) (signatures.Signer, error) {
 	s, err := factory.NewSignerFromBytes(b)
 	if err != nil {
 		return nil, err

--- a/core/crypto/keymaster/signer_test.go
+++ b/core/crypto/keymaster/signer_test.go
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package factory
+package keymaster
 
 import (
-	"encoding/pem"
 	"testing"
 
 	"github.com/google/keytransparency/core/crypto/signatures"
-	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 )
 
 const (
@@ -29,62 +27,16 @@ MHcCAQEEIGbhE2+z8d5lHzb0gmkS78d86gm5gHUtXCpXveFbK3pcoAoGCCqGSM49
 AwEHoUQDQgAEUxX42oxJ5voiNfbjoz8UgsGqh1bD1NXK9m8VivPmQSoYUdVFgNav
 csFaQhohkiCEthY51Ga6Xa+ggn+eTZtf9Q==
 -----END EC PRIVATE KEY-----`
-	// openssl ec -in p256-key.pem -pubout -out p256-pubkey.pem
-	testPubKey = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUxX42oxJ5voiNfbjoz8UgsGqh1bD
-1NXK9m8VivPmQSoYUdVFgNavcsFaQhohkiCEthY51Ga6Xa+ggn+eTZtf9Q==
------END PUBLIC KEY-----`
 )
-
-// DevZero is an io.Reader that returns 0's.
-type DevZero struct{}
-
-// Read returns 0's.
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
-}
 
 func TestSignerFromPEM(t *testing.T) {
 	signatures.Rand = DevZero{}
 	for _, priv := range []string{
 		testPrivKey,
 	} {
-		_, err := SignerFromPEM([]byte(priv))
+		_, err := NewSignerFromPEM([]byte(priv))
 		if err != nil {
 			t.Errorf("SignerFromPEM(): %v", err)
-		}
-	}
-}
-
-func TestVerifierFromPEM(t *testing.T) {
-	for _, pub := range []string{
-		testPubKey,
-	} {
-		if _, err := VerifierFromPEM([]byte(pub)); err != nil {
-			t.Errorf("VerifierFromPEM(): %v", err)
-		}
-	}
-}
-
-func TestVerifierFromKey(t *testing.T) {
-	for _, pub := range []string{
-		testPubKey,
-	} {
-		p, _ := pem.Decode([]byte(pub))
-		if p == nil {
-			t.Error("pem.Decode() failed")
-		}
-		pk := &tpb.PublicKey{
-			KeyType: &tpb.PublicKey_EcdsaVerifyingP256{
-				EcdsaVerifyingP256: p.Bytes,
-			},
-		}
-		if _, err := VerifierFromKey(pk); err != nil {
-			t.Errorf("VerifierFromKey(): %v", err)
 		}
 	}
 }

--- a/core/crypto/keymaster/signer_test.go
+++ b/core/crypto/keymaster/signer_test.go
@@ -15,6 +15,7 @@
 package keymaster
 
 import (
+	"encoding/pem"
 	"testing"
 
 	"github.com/google/keytransparency/core/crypto/signatures"
@@ -37,6 +38,21 @@ func TestSignerFromPEM(t *testing.T) {
 		_, err := NewSignerFromPEM([]byte(priv))
 		if err != nil {
 			t.Errorf("SignerFromPEM(): %v", err)
+		}
+	}
+}
+
+func TestSignerFromKey(t *testing.T) {
+	signatures.Rand = DevZero{}
+	for _, priv := range []string{
+		testPrivKey,
+	} {
+		p, _ := pem.Decode([]byte(priv))
+		if p == nil {
+			t.Error("pem.Decode() failed")
+		}
+		if _, err := NewSignerFromRawKey(p.Bytes); err != nil {
+			t.Errorf("SignerFromRawKey(): %v", err)
 		}
 	}
 }

--- a/core/crypto/keymaster/verifier.go
+++ b/core/crypto/keymaster/verifier.go
@@ -1,0 +1,123 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keymaster
+
+import (
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/google/keytransparency/core/crypto/signatures"
+	"github.com/google/keytransparency/core/crypto/signatures/factory"
+	kmpb "github.com/google/keytransparency/core/proto/keymaster"
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+)
+
+type verifier struct {
+	signatures.Verifier
+	addedAt     time.Time // time when key is added to keymaster.
+	description string
+	status      kmpb.VerifyingKey_KeyStatus
+}
+
+// NewVerifier creates a verifier from a ECDSA public key.
+func NewVerifier(v signatures.Verifier, addedAt time.Time,
+	description string, status kmpb.VerifyingKey_KeyStatus) Verifier {
+	return &verifier{
+		Verifier:    v,
+		addedAt:     addedAt,
+		description: description,
+		status:      status,
+	}
+}
+
+// VerifierFromPEM parses a PEM formatted block and returns a verifier object
+// created using that block.
+func VerifierFromPEM(pemKey []byte) (Verifier, error) {
+	v, err := factory.NewVerifierFromPEM(pemKey)
+	if err != nil {
+		return nil, err
+	}
+	return &verifier{
+		Verifier:    v,
+		addedAt:     time.Now(),
+		description: "Verifier created from from PEM",
+		status:      kmpb.VerifyingKey_ACTIVE,
+	}, nil
+}
+
+// VerifierFromKey creates a verifier object from a PublicKey proto object.
+func VerifierFromKey(key *tpb.PublicKey) (Verifier, error) {
+	v, err := factory.NewVerifierFromKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return &verifier{
+		Verifier:    v,
+		addedAt:     time.Now(),
+		description: "Verifier created from PublicKey",
+		status:      kmpb.VerifyingKey_ACTIVE,
+	}, nil
+}
+
+// VerifierFromRawKey creates a verifier object from given raw key bytes.
+func VerifierFromRawKey(b []byte) (Verifier, error) {
+	v, err := factory.NewVerifierFromBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	return &verifier{
+		Verifier:    v,
+		addedAt:     time.Now(),
+		description: "Verifier created from raw key",
+		status:      kmpb.VerifyingKey_ACTIVE,
+	}, nil
+}
+
+// Status returns the status of the verifier.
+func (s *verifier) Status() kmpb.VerifyingKey_KeyStatus {
+	return s.status
+}
+
+// Deprecate sets the verifier status to DEPRECATED.
+func (s *verifier) Deprecate() {
+	s.status = kmpb.VerifyingKey_DEPRECATED
+}
+
+// Marshal marshals a verifier object into a keymaster VerifyingKey message.
+func (s *verifier) Marshal() (*kmpb.VerifyingKey, error) {
+	pkBytes, err := s.PublicKeyPEM()
+	if err != nil {
+		return nil, err
+	}
+	timestamp, err := ptypes.TimestampProto(s.addedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &kmpb.VerifyingKey{
+		Metadata: &kmpb.Metadata{
+			KeyId:       s.KeyID(),
+			AddedAt:     timestamp,
+			Description: s.description,
+		},
+		KeyMaterial: pkBytes,
+		Status:      s.status,
+	}, nil
+}
+
+// Clone creates a new instance of the verifier object
+func (s *verifier) Clone() Verifier {
+	clone := *s
+	return &clone
+}

--- a/core/crypto/keymaster/verifier.go
+++ b/core/crypto/keymaster/verifier.go
@@ -42,9 +42,9 @@ func NewVerifier(v signatures.Verifier, addedAt time.Time,
 	}
 }
 
-// VerifierFromPEM parses a PEM formatted block and returns a verifier object
+// NewVerifierFromPEM parses a PEM formatted block and returns a verifier object
 // created using that block.
-func VerifierFromPEM(pemKey []byte) (Verifier, error) {
+func NewVerifierFromPEM(pemKey []byte) (Verifier, error) {
 	v, err := factory.NewVerifierFromPEM(pemKey)
 	if err != nil {
 		return nil, err
@@ -57,8 +57,8 @@ func VerifierFromPEM(pemKey []byte) (Verifier, error) {
 	}, nil
 }
 
-// VerifierFromKey creates a verifier object from a PublicKey proto object.
-func VerifierFromKey(key *tpb.PublicKey) (Verifier, error) {
+// NewVerifierFromKey creates a verifier object from a PublicKey proto object.
+func NewVerifierFromKey(key *tpb.PublicKey) (Verifier, error) {
 	v, err := factory.NewVerifierFromKey(key)
 	if err != nil {
 		return nil, err
@@ -71,8 +71,8 @@ func VerifierFromKey(key *tpb.PublicKey) (Verifier, error) {
 	}, nil
 }
 
-// VerifierFromRawKey creates a verifier object from given raw key bytes.
-func VerifierFromRawKey(b []byte) (Verifier, error) {
+// NewVerifierFromRawKey creates a verifier object from given raw key bytes.
+func NewVerifierFromRawKey(b []byte) (Verifier, error) {
 	v, err := factory.NewVerifierFromBytes(b)
 	if err != nil {
 		return nil, err

--- a/core/crypto/keymaster/verifier_test.go
+++ b/core/crypto/keymaster/verifier_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keymaster
+
+import (
+	"encoding/pem"
+	"testing"
+
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+)
+
+const (
+	// openssl ec -in p256-key.pem -pubout -out p256-pubkey.pem
+	testPubKey = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUxX42oxJ5voiNfbjoz8UgsGqh1bD
+1NXK9m8VivPmQSoYUdVFgNavcsFaQhohkiCEthY51Ga6Xa+ggn+eTZtf9Q==
+-----END PUBLIC KEY-----`
+)
+
+// DevZero is an io.Reader that returns 0's.
+type DevZero struct{}
+
+// Read returns 0's.
+func (DevZero) Read(b []byte) (n int, err error) {
+	for i := range b {
+		b[i] = 0
+	}
+
+	return len(b), nil
+}
+
+func TestVerifierFromPEM(t *testing.T) {
+	for _, pub := range []string{
+		testPubKey,
+	} {
+		if _, err := VerifierFromPEM([]byte(pub)); err != nil {
+			t.Errorf("VerifierFromPEM(): %v", err)
+		}
+	}
+}
+
+func TestVerifierFromKey(t *testing.T) {
+	for _, pub := range []string{
+		testPubKey,
+	} {
+		p, _ := pem.Decode([]byte(pub))
+		if p == nil {
+			t.Error("pem.Decode() failed")
+		}
+		pk := &tpb.PublicKey{
+			KeyType: &tpb.PublicKey_EcdsaVerifyingP256{
+				EcdsaVerifyingP256: p.Bytes,
+			},
+		}
+		if _, err := VerifierFromKey(pk); err != nil {
+			t.Errorf("VerifierFromKey(): %v", err)
+		}
+	}
+}

--- a/core/crypto/keymaster/verifier_test.go
+++ b/core/crypto/keymaster/verifier_test.go
@@ -45,7 +45,7 @@ func TestVerifierFromPEM(t *testing.T) {
 	for _, pub := range []string{
 		testPubKey,
 	} {
-		if _, err := VerifierFromPEM([]byte(pub)); err != nil {
+		if _, err := NewVerifierFromPEM([]byte(pub)); err != nil {
 			t.Errorf("VerifierFromPEM(): %v", err)
 		}
 	}
@@ -64,8 +64,22 @@ func TestVerifierFromKey(t *testing.T) {
 				EcdsaVerifyingP256: p.Bytes,
 			},
 		}
-		if _, err := VerifierFromKey(pk); err != nil {
+		if _, err := NewVerifierFromKey(pk); err != nil {
 			t.Errorf("VerifierFromKey(): %v", err)
+		}
+	}
+}
+
+func TestVerifierFromRawKey(t *testing.T) {
+	for _, pub := range []string{
+		testPubKey,
+	} {
+		p, _ := pem.Decode([]byte(pub))
+		if p == nil {
+			t.Error("pem.Decode() failed")
+		}
+		if _, err := NewVerifierFromRawKey(p.Bytes); err != nil {
+			t.Errorf("VerifierFromRawKey(): %v", err)
 		}
 	}
 }

--- a/core/crypto/signatures/interface.go
+++ b/core/crypto/signatures/interface.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"errors"
 
-	kmpb "github.com/google/keytransparency/core/proto/keymaster"
 	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 	spb "github.com/google/keytransparency/core/proto/signature"
 )
@@ -55,20 +54,10 @@ type Signer interface {
 	PublicKey() (*tpb.PublicKey, error)
 	// KeyID returns the ID of the associated public key.
 	KeyID() string
-	// Status returns the status of the signer.
-	Status() kmpb.SigningKey_KeyStatus
-	// Activate activates the signer.
-	Activate()
-	// Deactivate deactivates the signer.
-	Deactivate()
-	// Deprecate sets the signer status to DEPRECATED.
-	Deprecate()
 	// Marshal marshals a signer object into a keymaster SigningKey message.
-	Marshal() (*kmpb.SigningKey, error)
+	PrivateKeyPEM() ([]byte, error)
 	// PublicKeyPEM returns the PEM-formatted public key of this signer.
 	PublicKeyPEM() ([]byte, error)
-	// Clone creates a new instance of the signer object
-	Clone() Signer
 }
 
 // Verifier represents an object that can verify signatures with a single key.
@@ -80,15 +69,8 @@ type Verifier interface {
 	PublicKey() (*tpb.PublicKey, error)
 	// KeyID returns the ID of the associated public key.
 	KeyID() string
-	// Status returns the status of the verifier.
-	Status() kmpb.VerifyingKey_KeyStatus
-	// Deprecate sets the verifier status to DEPRECATED.
-	Deprecate()
-	// Marshal marshals a verifier object into a keymaster VerifyingKey
-	// message.
-	Marshal() (*kmpb.VerifyingKey, error)
-	// Clone creates a new instance of the verifier object
-	Clone() Verifier
+	// PublicKeyPEM marshals a verifier object into a keymaster VerifyingKey message.
+	PublicKeyPEM() ([]byte, error)
 }
 
 // KeyID is the hex digits of the SHA256 of the public pem.

--- a/core/crypto/signatures/p256/ecdsa_p256_test.go
+++ b/core/crypto/signatures/p256/ecdsa_p256_test.go
@@ -22,11 +22,8 @@ import (
 	"math"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/google/keytransparency/core/crypto/signatures"
-
-	kmpb "github.com/google/keytransparency/core/proto/keymaster"
 )
 
 const (
@@ -65,7 +62,7 @@ func newSigner(t *testing.T, pemKey []byte) signatures.Signer {
 	if err != nil {
 		t.Fatalf("x509.ParseECPrivateKey failed: %v", err)
 	}
-	signer, err := NewSigner(k, time.Now(), "test_description", kmpb.SigningKey_ACTIVE)
+	signer, err := NewSigner(k)
 	if err != nil {
 		t.Fatalf("NewSigner failed: %v", err)
 	}
@@ -81,7 +78,7 @@ func newVerifier(t *testing.T, pemKey []byte) signatures.Verifier {
 	if err != nil {
 		t.Fatalf("x509.ParsePKIXPublicKey failed: %v", err)
 	}
-	verifier, err := NewVerifier(k.(*ecdsa.PublicKey), time.Now(), "test_description", kmpb.VerifyingKey_ACTIVE)
+	verifier, err := NewVerifier(k.(*ecdsa.PublicKey))
 	if err != nil {
 		t.Fatalf("NewVerifier failed: %v", err)
 	}

--- a/core/crypto/signatures/rsa/rsa_sha256_3072_test.go
+++ b/core/crypto/signatures/rsa/rsa_sha256_3072_test.go
@@ -22,11 +22,8 @@ import (
 	"math"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/google/keytransparency/core/crypto/signatures"
-
-	kmpb "github.com/google/keytransparency/core/proto/keymaster"
 )
 
 const (
@@ -116,7 +113,7 @@ func newSigner(t *testing.T, pemKey []byte) signatures.Signer {
 	if err != nil {
 		t.Fatalf("x509.ParsePKCS1PrivateKey failed: %v", err)
 	}
-	signer, err := NewSigner(k, time.Now(), "test_description", kmpb.SigningKey_ACTIVE)
+	signer, err := NewSigner(k)
 	if err != nil {
 		t.Fatalf("NewSigner failed: %v", err)
 	}
@@ -132,7 +129,7 @@ func newVerifier(t *testing.T, pemKey []byte) signatures.Verifier {
 	if err != nil {
 		t.Fatalf("x509.ParsePKIXPublicKey failed: %v", err)
 	}
-	verifier, err := NewVerifier(k.(*rsa.PublicKey), time.Now(), "test_description", kmpb.VerifyingKey_ACTIVE)
+	verifier, err := NewVerifier(k.(*rsa.PublicKey))
 	if err != nil {
 		t.Fatalf("NewVerifier failed: %v", err)
 	}
@@ -166,7 +163,7 @@ func TestSignerWrongKeySize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("x509.ParsePKCS1PrivateKey failed: %v", err)
 	}
-	_, err = NewSigner(k, time.Now(), "test_description", kmpb.SigningKey_ACTIVE)
+	_, err = NewSigner(k)
 	if got, want := err, signatures.ErrWrongKeyType; got != want {
 		t.Errorf("NewSigner with key size 1024 returned %v, want %v", got, want)
 	}
@@ -182,7 +179,7 @@ func TestVerifierWrongKeySize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("x509.ParsePKIXPublicKey failed: %v", err)
 	}
-	_, err = NewVerifier(k.(*rsa.PublicKey), time.Now(), "test_description", kmpb.VerifyingKey_ACTIVE)
+	_, err = NewVerifier(k.(*rsa.PublicKey))
 	if got, want := err, signatures.ErrWrongKeyType; got != want {
 		t.Errorf("NewVerifier with key size 1024 returned %v, want %v", got, want)
 	}

--- a/core/mutator/entry/entry.go
+++ b/core/mutator/entry/entry.go
@@ -122,7 +122,7 @@ func verifyKeys(oldValue []byte, data interface{}, update *tpb.SignedKV, entry *
 func verifiersFromKeys(keys []*tpb.PublicKey) (map[string]signatures.Verifier, error) {
 	verifiers := make(map[string]signatures.Verifier)
 	for _, key := range keys {
-		verifier, err := factory.VerifierFromKey(key)
+		verifier, err := factory.NewVerifierFromKey(key)
 		if err != nil {
 			return nil, err
 		}

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -125,7 +125,7 @@ func signersFromPEMs(t *testing.T, keys [][]byte) []signatures.Signer {
 	signatures.Rand = DevZero{}
 	signers := make([]signatures.Signer, 0, len(keys))
 	for _, key := range keys {
-		signer, err := factory.SignerFromPEM(key)
+		signer, err := factory.NewSignerFromPEM(key)
 		if err != nil {
 			t.Fatalf("NewSigner(): %v", err)
 		}

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -65,7 +65,7 @@ var (
 
 func createSigner(t *testing.T, privKey string) signatures.Signer {
 	signatures.Rand = DevZero{}
-	signer, err := factory.SignerFromPEM([]byte(privKey))
+	signer, err := factory.NewSignerFromPEM([]byte(privKey))
 	if err != nil {
 		t.Fatalf("factory.NewSigner failed: %v", err)
 	}

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -99,12 +99,12 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5AV2WCmStBt4N2Dx+7BrycJFbxhW
 f5JqSoyp0uiL8LeNYyj5vgklK8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 -----END PUBLIC KEY-----`
 	signatures.Rand = DevZero{}
-	sig, err := factory.SignerFromPEM([]byte(sigPriv))
+	sig, err := factory.NewSignerFromPEM([]byte(sigPriv))
 	if err != nil {
 		return nil, nil, err
 	}
 
-	ver, err := factory.VerifierFromPEM([]byte(sigPub))
+	ver, err := factory.NewVerifierFromPEM([]byte(sigPub))
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Establishes a 1:1 relationship between the signer and
DigitallySigned.

Keymaster operations on groups of signers and verifiers are
in a separate package with a separate protobuf serialization.