### PR TITLE
Store Mutations in Local Database

### DIFF
--- a/cmd/keytransparency-signer/backend.go
+++ b/cmd/keytransparency-signer/backend.go
@@ -30,6 +30,7 @@ import (
 	"github.com/google/keytransparency/impl/etcd/queue"
 	"github.com/google/keytransparency/impl/sql/appender"
 	"github.com/google/keytransparency/impl/sql/engine"
+	"github.com/google/keytransparency/impl/sql/mutations"
 	"github.com/google/keytransparency/impl/sql/sqlhist"
 	"github.com/google/keytransparency/impl/transaction"
 
@@ -101,9 +102,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create STH appender: %v", err)
 	}
-	mutations, err := appender.New(context.Background(), nil, *mapID, *mapLogURL, nil)
+	mutations, err := mutations.New(sqldb, *mapID)
 	if err != nil {
-		log.Fatalf("Failed to create mutation appender: %v", err)
+		log.Fatalf("Failed to create mutations object: %v", err)
 	}
 
 	signer := signer.New(*mapID, queue, tree, mutator, sths, mutations, openPrivateKey())

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -187,8 +187,8 @@ type fakeSparseHist struct {
 	M map[int64][]byte
 }
 
-func (*fakeSparseHist) QueueLeaf(txn transaction.Txn, index, leaf []byte) error {
-	return nil
+func (*fakeSparseHist) QueueLeaf(txn transaction.Txn, index, leaf []byte) (int64, error) {
+	return 0, nil
 }
 
 func (*fakeSparseHist) Commit(ctx context.Context) (epoch int64, err error) {

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -55,7 +55,7 @@ type Mutator interface {
 // Mutation reads and writes mutations to the database.
 type Mutation interface {
 	// Read reads all mutations for a specific given mapID, epoch, and index.
-	Read(ctx context.Context, txn transaction.Txn, epoch int64, index []byte) ([][]byte, error)
+	Read(ctx context.Context, txn transaction.Txn, epoch int64, index []byte) ([]byte, error)
 	// Write saves the mutation in the database.
 	Write(ctx context.Context, txn transaction.Txn, epoch int64, index, mutation []byte) error
 }

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -13,10 +13,16 @@
 // limitations under the License.
 
 // Package mutator defines the operations to transform mutations into changes in
-// the map.
+// the map as well as operations to write and read mutations to and from the
+// database.
 package mutator
 
-import "errors"
+import (
+	"context"
+	"errors"
+
+	"github.com/google/keytransparency/core/transaction"
+)
 
 var (
 	// MaxMutationSize represent the maximum allowed mutation size in bytes.
@@ -44,4 +50,12 @@ type Mutator interface {
 	CheckMutation(value, mutation []byte) error
 	// Mutate applies mutation to value
 	Mutate(value, mutation []byte) ([]byte, error)
+}
+
+// Mutation reads and writes mutations to the database.
+type Mutation interface {
+	// Read reads all mutations for a specific given mapID, epoch, and index.
+	Read(ctx context.Context, txn transaction.Txn, epoch int64, index []byte) ([][]byte, error)
+	// Write saves the mutation in the database.
+	Write(ctx context.Context, txn transaction.Txn, epoch int64, index, mutation []byte) error
 }

--- a/core/tree/tree.go
+++ b/core/tree/tree.go
@@ -23,8 +23,9 @@ import (
 
 // Sparse is a temporal sparse merkle tree.
 type Sparse interface {
-	// QueueLeaf queues a leaf to be written on the next Commit().
-	QueueLeaf(txn transaction.Txn, index, leaf []byte) error
+	// QueueLeaf queues a leaf to be written on the next Commit(). QueueLeaf
+	// returns the epoch at which the leaf is queued.
+	QueueLeaf(txn transaction.Txn, index, leaf []byte) (int64, error)
 	// Commit takes all the Queued values since the last Commmit() and writes them.
 	// Commit is NOT multi-process safe. It should only be called from the sequencer.
 	Commit(ctx context.Context) (epoch int64, err error)

--- a/impl/sql/mutations/mutations.go
+++ b/impl/sql/mutations/mutations.go
@@ -1,0 +1,151 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mutations defines operations to write and read mutations to and from
+// the database.
+package mutations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/google/keytransparency/core/mutator"
+	"github.com/google/keytransparency/core/transaction"
+)
+
+const (
+	insertMapRowExpr = `INSERT INTO Maps (MapID) VALUES (?);`
+	countMapRowExpr  = `SELECT COUNT(*) AS count FROM Maps WHERE MapID = ?;`
+	insertExpr       = `
+	INSERT INTO Mutations (MapID, Epoch, MutationID, Mutation)
+	VALUES (?, ?, ?, ?);`
+	readExpr = `
+	SELECT Mutation FROM Mutations
+	WHERE MapID = ? AND Epoch = ? AND MutationID = ?;`
+)
+
+var (
+	createStmt = []string{
+		`
+	CREATE TABLE IF NOT EXISTS Maps (
+		MapID   VARCHAR(32) NOT NULL,
+		PRIMARY KEY(MapID)
+	);`,
+		`
+	CREATE TABLE IF NOT EXISTS Mutations (
+		MapID      VARCHAR(32)   NOT NULL,
+		Epoch      INTEGER       NOT NULL,
+                MutationID VARBINARY(32) NOT NULL,
+		Mutation   BLOB          NOT NULL,
+		FOREIGN KEY(MapID) REFERENCES Maps(MapID) ON DELETE CASCADE
+	);`,
+	}
+)
+
+type mutations struct {
+	mapID []byte
+	db    *sql.DB
+}
+
+// New creates a new mutations instance.
+func New(db *sql.DB, mapID string) (mutator.Mutation, error) {
+	m := &mutations{
+		mapID: []byte(mapID),
+		db:    db,
+	}
+
+	// Create tables and map entry.
+	if err := m.create(); err != nil {
+		return nil, err
+	}
+	if err := m.insertMapRow(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// Read reads all mutations for a specific given mapID, epoch, and index.
+func (m *mutations) Read(ctx context.Context, txn transaction.Txn, epoch int64, index []byte) ([][]byte, error) {
+	readStmt, err := txn.Prepare(readExpr)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := readStmt.Query(m.mapID, epoch, index)
+	defer rows.Close()
+	if err != nil {
+		return nil, err
+	}
+	ms := make([][]byte, 0, 10)
+	for rows.Next() {
+		var mutation []byte
+		if err = rows.Scan(&mutation); err != nil {
+			return nil, err
+		}
+		ms = append(ms, mutation)
+	}
+	return ms, nil
+}
+
+// Write saves the mutation in the database.
+func (m *mutations) Write(ctx context.Context, txn transaction.Txn, epoch int64, index, mutation []byte) error {
+	writeStmt, err := txn.Prepare(insertExpr)
+	if err != nil {
+		return err
+	}
+	defer writeStmt.Close()
+	if _, err := writeStmt.Exec(m.mapID, epoch, index, mutation); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Create creates new database tables.
+func (m *mutations) create() error {
+	for _, stmt := range createStmt {
+		_, err := m.db.Exec(stmt)
+		if err != nil {
+			return fmt.Errorf("Failed to create mutation tables: %v", err)
+		}
+	}
+	return nil
+}
+
+func (m *mutations) insertMapRow() error {
+	// Check if a map row does not exist for the same MapID.
+	countStmt, err := m.db.Prepare(countMapRowExpr)
+	if err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	defer countStmt.Close()
+	var count int
+	if err := countStmt.QueryRow(m.mapID).Scan(&count); err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	if count >= 1 {
+		return nil
+	}
+
+	// Insert a map row if it does not exist already.
+	insertStmt, err := m.db.Prepare(insertMapRowExpr)
+	if err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	defer insertStmt.Close()
+	_, err = insertStmt.Exec(m.mapID)
+	if err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	return nil
+}

--- a/impl/sql/mutations/mutations_test.go
+++ b/impl/sql/mutations/mutations_test.go
@@ -16,6 +16,7 @@ package mutations
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -44,20 +45,40 @@ func fillDB(t *testing.T, ctx context.Context, m mutator.Mutation, factory *test
 	}{
 		{1, []byte("index1"), []byte("mutation1")},
 		{2, []byte("index2"), []byte("mutation2")},
-		{2, []byte("index2"), []byte("mutation3")},
 	} {
-		wtxn, err := factory.NewDBTxn(ctx)
-		if err != nil {
-			t.Errorf("failed to create write transaction: %v", err)
-			continue
-		}
-		if err := m.Write(ctx, wtxn, mtn.epoch, mtn.index, mtn.mutation); err != nil {
-			t.Errorf("Write(%v, %v, %v): %v, want nil", mtn.epoch, mtn.index, mtn.mutation, err)
-		}
-		if err := wtxn.Commit(); err != nil {
-			t.Errorf("wtxn.Commit() failed: %v", err)
+		if err := write(ctx, m, factory, mtn.epoch, mtn.index, mtn.mutation); err != nil {
+			t.Errorf("failed to write mutation to database, epoch=%v, mutation=%v, mutation=%v: %v", mtn.epoch, mtn.index, mtn.mutation, err)
 		}
 	}
+}
+
+func write(ctx context.Context, m mutator.Mutation, factory *testutil.FakeFactory, epoch int64, index []byte, mutation []byte) error {
+	wtxn, err := factory.NewDBTxn(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create write transaction: %v", err)
+	}
+	if err := m.Write(ctx, wtxn, epoch, index, mutation); err != nil {
+		return fmt.Errorf("Write(%v, %v, %v): %v, want nil", epoch, index, mutation, err)
+	}
+	if err := wtxn.Commit(); err != nil {
+		return fmt.Errorf("wtxn.Commit() failed: %v", err)
+	}
+	return nil
+}
+
+func read(ctx context.Context, m mutator.Mutation, factory *testutil.FakeFactory, epoch int64, index []byte) ([]byte, error) {
+	rtxn, err := factory.NewDBTxn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create write transaction: %v", err)
+	}
+	mutation, err := m.Read(ctx, rtxn, epoch, index)
+	if err != nil {
+		return nil, fmt.Errorf("Read(%v, %v): %v, want nil", epoch, index, err)
+	}
+	if err := rtxn.Commit(); err != nil {
+		return nil, fmt.Errorf("rtxn.Commit() failed: %v", err)
+	}
+	return mutation, nil
 }
 
 func TestRead(t *testing.T) {
@@ -74,32 +95,52 @@ func TestRead(t *testing.T) {
 		description string
 		epoch       int64
 		index       []byte
-		mutations   [][]byte
+		rMutation   []byte
 	}{
-		{"read a single mutation", 1, []byte("index1"), [][]byte{[]byte("mutation1")}},
-		{"read multiple mutations", 2, []byte("index2"), [][]byte{[]byte("mutation2"), []byte("mutation3")}},
-		{"non-existing epoch", 100, []byte("index1"), [][]byte{}},
-		{"non-existing index", 1, []byte("index100"), [][]byte{}},
+		{"read a single mutation", 1, []byte("index1"), []byte("mutation1")},
+		{"non-existing epoch", 100, []byte("index1"), nil},
+		{"non-existing index", 1, []byte("index100"), nil},
 	} {
-		rtxn, err := factory.NewDBTxn(ctx)
+		mutation, err := read(ctx, m, factory, tc.epoch, tc.index)
 		if err != nil {
-			t.Errorf("failed %v: to create write transaction: %v", tc.description, err)
-			continue
+			t.Errorf("%v: failed to read mutations: %v", tc.description, err)
 		}
-		ms, err := m.Read(ctx, rtxn, tc.epoch, tc.index)
+		if got, want := mutation, tc.rMutation; !reflect.DeepEqual(got, want) {
+			t.Errorf("%v: mutation=%v, want %v", tc.description, got, want)
+		}
+	}
+}
+
+func TestOverwriteMutation(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(t)
+	factory := testutil.NewFakeFactory(db)
+	m, err := New(db, mapID)
+	if err != nil {
+		t.Fatalf("Failed to create mutations: %v", err)
+	}
+	fillDB(t, ctx, m, factory)
+
+	for _, tc := range []struct {
+		description string
+		epoch       int64
+		index       []byte
+		wMutation   []byte
+		rMutation   []byte
+	}{
+		{"overwrite epoch 2 mutation", 2, []byte("index2"), []byte("mutation3"), []byte("mutation3")},
+		{"overwrite epoch 2 mutation again", 2, []byte("index2"), []byte("mutation4"), []byte("mutation4")},
+	} {
+		if err := write(ctx, m, factory, tc.epoch, tc.index, tc.wMutation); err != nil {
+			t.Errorf("%v: failed to write mutation: %v", tc.description, err)
+		}
+
+		mutation, err := read(ctx, m, factory, tc.epoch, tc.index)
 		if err != nil {
-			t.Errorf("%v: Read(%v, %v): %v, want nil", tc.description, tc.epoch, tc.index, err)
+			t.Errorf("%v: failed to read mutations: %v", tc.description, err)
 		}
-		if err := rtxn.Commit(); err != nil {
-			t.Errorf("%v: rtxn.Commit() failed: %v", tc.description, err)
-		}
-		if got, want := len(ms), len(tc.mutations); got != want {
-			t.Errorf("%v: len(ms)=%v, want %v", tc.description, got, want)
-		}
-		for i := 0; i < len(ms); i++ {
-			if got, want := ms[i], tc.mutations[i]; !reflect.DeepEqual(got, want) {
-				t.Errorf("%v: ms[%v]=%v, want %v", tc.description, i, got, want)
-			}
+		if got, want := mutation, tc.rMutation; !reflect.DeepEqual(got, want) {
+			t.Errorf("%v: mutation=%v, want %v", tc.description, got, want)
 		}
 	}
 }

--- a/impl/sql/mutations/mutations_test.go
+++ b/impl/sql/mutations/mutations_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package mutations
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+
+	"github.com/google/keytransparency/core/mutator"
+	"github.com/google/keytransparency/impl/sql/testutil"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+const (
+	mapID = "test"
+)
+
+func NewDB(t testing.TB) *sql.DB {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open(): %v", err)
+	}
+	return db
+}
+
+func fillDB(t *testing.T, ctx context.Context, m mutator.Mutation, factory *testutil.FakeFactory) {
+	for _, mtn := range []struct {
+		epoch    int64
+		index    []byte
+		mutation []byte
+	}{
+		{1, []byte("index1"), []byte("mutation1")},
+		{2, []byte("index2"), []byte("mutation2")},
+		{2, []byte("index2"), []byte("mutation3")},
+	} {
+		wtxn, err := factory.NewDBTxn(ctx)
+		if err != nil {
+			t.Errorf("failed to create write transaction: %v", err)
+			continue
+		}
+		if err := m.Write(ctx, wtxn, mtn.epoch, mtn.index, mtn.mutation); err != nil {
+			t.Errorf("Write(%v, %v, %v): %v, want nil", mtn.epoch, mtn.index, mtn.mutation, err)
+		}
+		if err := wtxn.Commit(); err != nil {
+			t.Errorf("wtxn.Commit() failed: %v", err)
+		}
+	}
+}
+
+func TestRead(t *testing.T) {
+	ctx := context.Background()
+	db := NewDB(t)
+	factory := testutil.NewFakeFactory(db)
+	m, err := New(db, mapID)
+	if err != nil {
+		t.Fatalf("Failed to create mutations: %v", err)
+	}
+	fillDB(t, ctx, m, factory)
+
+	for _, tc := range []struct {
+		description string
+		epoch       int64
+		index       []byte
+		mutations   [][]byte
+	}{
+		{"read a single mutation", 1, []byte("index1"), [][]byte{[]byte("mutation1")}},
+		{"read multiple mutations", 2, []byte("index2"), [][]byte{[]byte("mutation2"), []byte("mutation3")}},
+		{"non-existing epoch", 100, []byte("index1"), [][]byte{}},
+		{"non-existing index", 1, []byte("index100"), [][]byte{}},
+	} {
+		rtxn, err := factory.NewDBTxn(ctx)
+		if err != nil {
+			t.Errorf("failed %v: to create write transaction: %v", tc.description, err)
+			continue
+		}
+		ms, err := m.Read(ctx, rtxn, tc.epoch, tc.index)
+		if err != nil {
+			t.Errorf("%v: Read(%v, %v): %v, want nil", tc.description, tc.epoch, tc.index, err)
+		}
+		if err := rtxn.Commit(); err != nil {
+			t.Errorf("%v: rtxn.Commit() failed: %v", tc.description, err)
+		}
+		if got, want := len(ms), len(tc.mutations); got != want {
+			t.Errorf("%v: len(ms)=%v, want %v", tc.description, got, want)
+		}
+		for i := 0; i < len(ms); i++ {
+			if got, want := ms[i], tc.mutations[i]; !reflect.DeepEqual(got, want) {
+				t.Errorf("%v: ms[%v]=%v, want %v", tc.description, i, got, want)
+			}
+		}
+	}
+}

--- a/impl/sql/sqlhist/sqlhist_test.go
+++ b/impl/sql/sqlhist/sqlhist_test.go
@@ -80,7 +80,7 @@ func TestQueueLeaf(t *testing.T) {
 			t.Errorf("factory.NewDBTxn() failed: %v", err)
 			continue
 		}
-		err = tree.QueueLeaf(txn, []byte(tc.index), tc.leaf)
+		_, err = tree.QueueLeaf(txn, []byte(tc.index), tc.leaf)
 		if got := err == nil; got != tc.want {
 			t.Errorf("QueueLeaf(%v, %v): %v, want %v", tc.index, tc.leaf, got, tc.want)
 			continue
@@ -122,7 +122,7 @@ func TestEpochNumAdvance(t *testing.T) {
 				t.Errorf("factory.NewDBTxn() failed: %v", err)
 				continue
 			}
-			if err := tree.QueueLeaf(txn, []byte(tc.index), []byte(tc.leaf)); err != nil {
+			if _, err := tree.QueueLeaf(txn, []byte(tc.index), []byte(tc.leaf)); err != nil {
 				t.Errorf("QueueLeaf(%v, %v): %v", tc.index, tc.leaf, err)
 				continue
 			}
@@ -164,7 +164,7 @@ func TestQueueCommitRead(t *testing.T) {
 			t.Errorf("factory.NewDBTxn() failed: %v", err)
 			continue
 		}
-		if err := m.QueueLeaf(txn, index, data); err != nil {
+		if _, err := m.QueueLeaf(txn, index, data); err != nil {
 			t.Errorf("WriteLeaf(%v, %v)=%v", index, data, err)
 			continue
 		}
@@ -266,7 +266,7 @@ func TestReadPreviousEpochs(t *testing.T) {
 			t.Errorf("factory.NewDBTxn() failed: %v", err)
 			continue
 		}
-		if err := m.QueueLeaf(txn, tc.index, data); err != nil {
+		if _, err := m.QueueLeaf(txn, tc.index, data); err != nil {
 			t.Errorf("WriteLeaf(%v, %v)=%v", tc.index, data, err)
 			continue
 		}
@@ -332,7 +332,7 @@ func TestAribtrayInsertOrder(t *testing.T) {
 				t.Errorf("factory.NewDBTxn() failed: %v", err)
 				continue
 			}
-			if err := m.QueueLeaf(txn, leaf.index, []byte(leaf.data)); err != nil {
+			if _, err := m.QueueLeaf(txn, leaf.index, []byte(leaf.data)); err != nil {
 				t.Errorf("WriteLeaf(%v, %v)=%v", leaf.index, leaf.data, err)
 				continue
 			}
@@ -434,7 +434,7 @@ func createTree(db *sql.DB, mapID string, leafs []leaf) (*Map, error) {
 			return nil, fmt.Errorf("factory.NewDBTxn() failed: %v", err)
 		}
 		value := []byte(l.value)
-		if err := m.QueueLeaf(txn, l.index, value); err != nil {
+		if _, err := m.QueueLeaf(txn, l.index, value); err != nil {
 			return nil, fmt.Errorf("QueueLeaf(%v)=%v", l.index, err)
 		}
 		if err := txn.Commit(); err != nil {

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/keytransparency/impl/etcd/queue"
 	"github.com/google/keytransparency/impl/sql/appender"
 	"github.com/google/keytransparency/impl/sql/commitments"
+	"github.com/google/keytransparency/impl/sql/mutations"
 	"github.com/google/keytransparency/impl/sql/sqlhist"
 	"github.com/google/keytransparency/impl/transaction"
 
@@ -167,9 +168,9 @@ func NewEnv(t *testing.T) *Env {
 	if err != nil {
 		t.Fatalf("Failed to create STH appender: %v", err)
 	}
-	mutations, err := appender.New(context.Background(), nil, mapID, "", nil)
+	mutations, err := mutations.New(sqldb, mapID)
 	if err != nil {
-		t.Fatalf("Failed to create mutation appender: %v", err)
+		t.Fatalf("Failed to create mutations object: %v", err)
 	}
 	vrfPriv, vrfPub, err := staticVRF()
 	if err != nil {


### PR DESCRIPTION
This PR stores mutations in the local database after being processed by the queue/signer. It also stop sending mutations to a CT log.

Partial #507.