### PR TITLE
Update GoogleAPI import path

### DIFF
--- a/impl/proto/keytransparency_v1_service/gen.go
+++ b/impl/proto/keytransparency_v1_service/gen.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:generate protoc -I=. -I=$GOPATH/src/ -I=$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --go_out=Mgoogle/api/annotations.proto=github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api,plugins=grpc:. keytransparency_v1_service.proto
+//go:generate protoc -I=. -I=$GOPATH/src/ -I=$GOPATH/src/github.com/googleapis/googleapis/ --go_out=,plugins=grpc:. keytransparency_v1_service.proto
 
-//go:generate protoc -I=. -I=$GOPATH/src/ -I=$GOPATH/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true:. keytransparency_v1_service.proto
+//go:generate protoc -I=. -I=$GOPATH/src/ -I=$GOPATH/src/github.com/googleapis/googleapis/ --grpc-gateway_out=logtostderr=true:. keytransparency_v1_service.proto
 
 package keytransparency_v1_service

--- a/impl/proto/keytransparency_v1_service/keytransparency_v1_service.pb.go
+++ b/impl/proto/keytransparency_v1_service/keytransparency_v1_service.pb.go
@@ -22,7 +22,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import keytransparency_v1_types "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
-import _ "github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis/google/api"
+import _ "google.golang.org/genproto/googleapis/api/annotations"
 
 import (
 	context "golang.org/x/net/context"


### PR DESCRIPTION
The gRPC ecosystem project updated it's generators to reference
the standard googleapi paths in grpc-ecosystem/grpc-gateway#325

This PR makes the same changes in this repo to follow the standard.