### PR TITLE
Create a Sequenced table

### DIFF
--- a/core/sequenced/sequenced.go
+++ b/core/sequenced/sequenced.go
@@ -1,0 +1,29 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sequenced
+
+import "github.com/google/keytransparency/core/transaction"
+
+// Sequenced stores a list of items that have been sequenced.
+type Sequenced interface {
+	// Write writes an object at a given epoch.
+	Write(txn transaction.Txn, mapID, epoch int64, obj interface{}) error
+
+	// Read retrieves a specific object at a given epoch.
+	Read(txn transaction.Txn, mapID, epoch int64, obj interface{}) error
+
+	// Latest returns the latest object and its epoch.
+	Latest(txn transaction.Txn, mapID int64, obj interface{}) (int64, error)
+}

--- a/impl/sql/sequenced/sequenced.go
+++ b/impl/sql/sequenced/sequenced.go
@@ -30,13 +30,13 @@ const (
 	insertMapRowExpr = `INSERT INTO Maps (MapID) VALUES (?);`
 	countMapRowExpr  = `SELECT COUNT(*) AS count FROM Maps WHERE MapID = ?;`
 	insertExpr       = `
-	INSERT INTO SMH (MapID, Epoch, Data)
+	INSERT INTO Sequenced (MapID, Epoch, Data)
 	VALUES (?, ?, ?);`
 	readExpr = `
-	SELECT Data FROM SMH
+	SELECT Data FROM Sequenced
 	WHERE MapID = ? AND Epoch = ?;`
 	latestExpr = `
-	SELECT Epoch, Data FROM SMH
+	SELECT Epoch, Data FROM Sequenced
 	WHERE MapID = ? 
 	ORDER BY Epoch DESC LIMIT 1;`
 )
@@ -49,7 +49,7 @@ var (
 		PRIMARY KEY(MapID)
 	);`,
 		`
-	CREATE TABLE IF NOT EXISTS SMH (
+	CREATE TABLE IF NOT EXISTS Sequenced (
 		MapID   BIGINT      NOT NULL,
 		Epoch   BIGINT      NOT NULL,
 		Data    BLOB(1024)  NOT NULL,

--- a/impl/sql/sequenced/sequenced.go
+++ b/impl/sql/sequenced/sequenced.go
@@ -1,0 +1,182 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sequenced stores a list of objects that have been sequenced.
+package sequenced
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/gob"
+	"errors"
+	"fmt"
+
+	"github.com/google/keytransparency/core/sequenced"
+	"github.com/google/keytransparency/core/transaction"
+)
+
+const (
+	insertMapRowExpr = `INSERT INTO Maps (MapID) VALUES (?);`
+	countMapRowExpr  = `SELECT COUNT(*) AS count FROM Maps WHERE MapID = ?;`
+	insertExpr       = `
+	INSERT INTO SMH (MapID, Epoch, Data)
+	VALUES (?, ?, ?);`
+	readExpr = `
+	SELECT Data FROM SMH
+	WHERE MapID = ? AND Epoch = ?;`
+	latestExpr = `
+	SELECT Epoch, Data FROM SMH
+	WHERE MapID = ? 
+	ORDER BY Epoch DESC LIMIT 1;`
+)
+
+var (
+	createStmt = []string{
+		`
+	CREATE TABLE IF NOT EXISTS Maps (
+		MapID   BIGINT NOT NULL,
+		PRIMARY KEY(MapID)
+	);`,
+		`
+	CREATE TABLE IF NOT EXISTS SMH (
+		MapID   BIGINT      NOT NULL,
+		Epoch   BIGINT      NOT NULL,
+		Data    BLOB(1024)  NOT NULL,
+		PRIMARY KEY(MapID, Epoch),
+		FOREIGN KEY(MapID) REFERENCES Maps(MapID) ON DELETE CASCADE
+	);`,
+	}
+	// ErrNotSupported occurs when performing an operaion that has been disabled.
+	ErrNotSupported = errors.New("operation not supported")
+)
+
+// Sequenced stores objects in a table.
+type Sequenced struct {
+	db *sql.DB
+}
+
+// New returns an object that can store sequenced items for multiple maps.
+func New(db *sql.DB) (sequenced.Sequenced, error) {
+	if err := db.Ping(); err != nil {
+		return nil, fmt.Errorf("No DB connection: %v", err)
+	}
+
+	if err := create(db); err != nil {
+		return nil, err
+	}
+	return &Sequenced{
+		db: db,
+	}, nil
+}
+
+// Create creates a new database.
+func create(db *sql.DB) error {
+	for _, stmt := range createStmt {
+		_, err := db.Exec(stmt)
+		if err != nil {
+			return fmt.Errorf("Failed to create appender tables: %v", err)
+		}
+	}
+	return nil
+}
+
+func (s *Sequenced) insertMapRow(txn transaction.Txn, mapID int64) error {
+	// Check if a map row does not exist for the same MapID.
+	countStmt, err := txn.Prepare(countMapRowExpr)
+	if err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	defer countStmt.Close()
+	var count int
+	if err := countStmt.QueryRow(mapID).Scan(&count); err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	if count >= 1 {
+		return nil
+	}
+
+	// Insert a map row if it does not exist already.
+	insertStmt, err := txn.Prepare(insertMapRowExpr)
+	if err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	defer insertStmt.Close()
+	_, err = insertStmt.Exec(mapID)
+	if err != nil {
+		return fmt.Errorf("insertMapRow(): %v", err)
+	}
+	return nil
+}
+
+// Append adds an object to the append-only data structure.
+func (s *Sequenced) Write(txn transaction.Txn, mapID, epoch int64, obj interface{}) error {
+	if err := s.insertMapRow(txn, mapID); err != nil {
+		return err
+	}
+
+	var data bytes.Buffer
+	if err := gob.NewEncoder(&data).Encode(obj); err != nil {
+		return err
+	}
+	writeStmt, err := txn.Prepare(insertExpr)
+	if err != nil {
+		return fmt.Errorf("DB save failure: %v", err)
+	}
+	defer writeStmt.Close()
+	_, err = writeStmt.Exec(mapID, epoch, data.Bytes())
+	if err != nil {
+		return fmt.Errorf("DB commit failure: %v", err)
+	}
+	return nil
+}
+
+// Read retrieves a specific object for a map's epoch.
+func (s *Sequenced) Read(txn transaction.Txn, mapID, epoch int64, obj interface{}) error {
+	readStmt, err := txn.Prepare(readExpr)
+	if err != nil {
+		return err
+	}
+	defer readStmt.Close()
+
+	var data []byte
+	if err := readStmt.QueryRow(mapID, epoch).Scan(&data); err != nil {
+		return err
+	}
+
+	err = gob.NewDecoder(bytes.NewBuffer(data)).Decode(obj)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Latest returns the latest object.
+func (s *Sequenced) Latest(txn transaction.Txn, mapID int64, obj interface{}) (int64, error) {
+	readStmt, err := txn.Prepare(latestExpr)
+	if err != nil {
+		return 0, err
+	}
+	defer readStmt.Close()
+
+	var epoch int64
+	var data []byte
+	if err := readStmt.QueryRow(mapID).Scan(&epoch, &data); err != nil {
+		return 0, err
+	}
+	err = gob.NewDecoder(bytes.NewBuffer(data)).Decode(obj)
+	if err != nil {
+		return 0, err
+	}
+	return epoch, nil
+}

--- a/impl/sql/sequenced/sequenced_test.go
+++ b/impl/sql/sequenced/sequenced_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sequenced
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/google/keytransparency/impl/sql/testutil"
+)
+
+func NewDB(t testing.TB) *sql.DB {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("sql.Open(): %v", err)
+	}
+	return db
+}
+
+func TestGetLatest(t *testing.T) {
+	db := NewDB(t)
+	factory := testutil.NewFakeFactory(db)
+
+	a, err := New(db)
+	if err != nil {
+		t.Fatalf("Failed to create sequenced: %v", err)
+	}
+
+	for _, tc := range []struct {
+		mapID int64
+		epoch int64
+		data  []byte
+		want  int64
+	}{
+		{0, 0, []byte("foo"), 0},
+		{0, 10, []byte("foo"), 10},
+		{0, 5, []byte("foo"), 10},
+
+		{1, 0, []byte("foo"), 0},
+		{1, 10, []byte("foo"), 10},
+		{1, 5, []byte("foo"), 10},
+	} {
+		txn, err := factory.NewDBTxn(context.Background())
+		if err != nil {
+			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			continue
+		}
+		if err := a.Write(txn, tc.mapID, tc.epoch, tc.data); err != nil {
+			t.Errorf("Append(%v, %v): %v, want nil", tc.epoch, tc.data, err)
+		}
+		if err := txn.Commit(); err != nil {
+			t.Errorf("txn.Commit() failed: %v", err)
+		}
+
+		var obj []byte
+		txn2, err := factory.NewDBTxn(context.Background())
+		if err != nil {
+			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			continue
+		}
+		epoch, err := a.Latest(txn2, tc.mapID, &obj)
+		if err != nil {
+			t.Errorf("Latest(): %v, want nil", err)
+		}
+		if err := txn2.Commit(); err != nil {
+			t.Errorf("txn.Commit() failed: %v", err)
+		}
+		if got := epoch; got != tc.want {
+			t.Errorf("Latest(): %v, want %v", got, tc.want)
+		}
+	}
+}
+
+func TestWriteRead(t *testing.T) {
+	db := NewDB(t)
+	factory := testutil.NewFakeFactory(db)
+
+	a, err := New(db)
+	if err != nil {
+		t.Fatalf("Failed to create appender: %v", err)
+	}
+
+	for _, tc := range []struct {
+		mapID int64
+		epoch int64
+		data  []byte
+		want  bool
+	}{
+		{0, 0, []byte("foo"), true},
+		{0, 0, []byte("foo"), false},
+		{0, 1, []byte("foo"), true},
+	} {
+		txn, err := factory.NewDBTxn(context.Background())
+		if err != nil {
+			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			continue
+		}
+		err = a.Write(txn, tc.mapID, tc.epoch, tc.data)
+		if got := err == nil; got != tc.want {
+			t.Errorf("Append(%v, %v): %v, want nil", tc.epoch, tc.data, err)
+		}
+		if err := txn.Commit(); err != nil {
+			t.Errorf("txn.Commit() failed: %v", err)
+		}
+
+		if tc.want {
+			txn2, err := factory.NewDBTxn(context.Background())
+			if err != nil {
+				t.Errorf("factory.NewDBTxn() failed: %v", err)
+				continue
+			}
+			var readData []byte
+			err = a.Read(txn2, tc.mapID, tc.epoch, &readData)
+			if err != nil {
+				t.Errorf("Read(%v, %v): %v, want nil", tc.epoch, tc.data, err)
+			}
+			if err := txn2.Commit(); err != nil {
+				t.Errorf("txn2.Commit() failed: %v", err)
+			}
+			if got := readData; !bytes.Equal(got, tc.data) {
+				t.Errorf("Read(%v, %v): %x, want %x", tc.mapID, tc.epoch, got, tc.data)
+			}
+		}
+	}
+}

--- a/impl/sql/sequenced/sequenced_test.go
+++ b/impl/sql/sequenced/sequenced_test.go
@@ -37,7 +37,7 @@ func TestGetLatest(t *testing.T) {
 	db := NewDB(t)
 	factory := testutil.NewFakeFactory(db)
 
-	a, err := New(db)
+	a, err := New(db, 0)
 	if err != nil {
 		t.Fatalf("Failed to create sequenced: %v", err)
 	}
@@ -51,10 +51,6 @@ func TestGetLatest(t *testing.T) {
 		{0, 0, []byte("foo"), 0},
 		{0, 10, []byte("foo"), 10},
 		{0, 5, []byte("foo"), 10},
-
-		{1, 0, []byte("foo"), 0},
-		{1, 10, []byte("foo"), 10},
-		{1, 5, []byte("foo"), 10},
 	} {
 		txn, err := factory.NewDBTxn(context.Background())
 		if err != nil {
@@ -81,8 +77,8 @@ func TestGetLatest(t *testing.T) {
 		if err := txn2.Commit(); err != nil {
 			t.Errorf("txn.Commit() failed: %v", err)
 		}
-		if got := epoch; got != tc.want {
-			t.Errorf("Latest(): %v, want %v", got, tc.want)
+		if got, want := epoch, tc.want; got != want {
+			t.Errorf("Latest(): %v, want %v", got, want)
 		}
 	}
 }
@@ -91,7 +87,7 @@ func TestWriteRead(t *testing.T) {
 	db := NewDB(t)
 	factory := testutil.NewFakeFactory(db)
 
-	a, err := New(db)
+	a, err := New(db, 0)
 	if err != nil {
 		t.Fatalf("Failed to create appender: %v", err)
 	}
@@ -112,8 +108,8 @@ func TestWriteRead(t *testing.T) {
 			continue
 		}
 		err = a.Write(txn, tc.mapID, tc.epoch, tc.data)
-		if got := err == nil; got != tc.want {
-			t.Errorf("Append(%v, %v): %v, want nil", tc.epoch, tc.data, err)
+		if got, want := err == nil, tc.want; got != want {
+			t.Errorf("Append(%v, %v): %v, want nil? %v", tc.epoch, tc.data, err, want)
 		}
 		if err := txn.Commit(); err != nil {
 			t.Errorf("txn.Commit() failed: %v", err)
@@ -133,8 +129,8 @@ func TestWriteRead(t *testing.T) {
 			if err := txn2.Commit(); err != nil {
 				t.Errorf("txn2.Commit() failed: %v", err)
 			}
-			if got := readData; !bytes.Equal(got, tc.data) {
-				t.Errorf("Read(%v, %v): %x, want %x", tc.mapID, tc.epoch, got, tc.data)
+			if got, want := readData, tc.data; !bytes.Equal(got, want) {
+				t.Errorf("Read(%v, %v): %x, want %x", tc.mapID, tc.epoch, got, want)
 			}
 		}
 	}


### PR DESCRIPTION
Creates a place for storing generic items that have been sequenced.
Particuarly of the form: mapID, epoch.

Technically, a Trillian Log could serve the same purpose, but...
- You can't do an atomic transaction across an API call.
- We need to separate storing signed map heads from putting them in
  an append only log in order to match the trillian Map API.

This API supports the trillian Map function for storing Signed Map Heads.