### PR TITLE
Use transaction.Txn for NeighborsAt

### DIFF
--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -108,6 +108,7 @@ func (s *Server) getEntry(ctx context.Context, userID string, epoch int64) (*tpb
 	neighbors, err := s.tree.NeighborsAt(txn, index[:], epoch)
 	if err != nil {
 		log.Printf("Cannot get neighbors list: %v", err)
+		txn.Rollback()
 		return nil, grpc.Errorf(codes.Internal, "Cannot get neighbors list")
 	}
 
@@ -115,6 +116,7 @@ func (s *Server) getEntry(ctx context.Context, userID string, epoch int64) (*tpb
 	leaf, err := s.tree.ReadLeafAt(txn, index[:], epoch)
 	if err != nil {
 		log.Printf("Cannot read leaf entry: %v", err)
+		txn.Rollback()
 		return nil, grpc.Errorf(codes.Internal, "Cannot read leaf entry")
 	}
 

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -100,16 +100,27 @@ func (s *Server) getEntry(ctx context.Context, userID string, epoch int64) (*tpb
 		return nil, err
 	}
 
-	neighbors, err := s.tree.NeighborsAt(ctx, index[:], epoch)
+	txn, err := s.factory.NewDBTxn(ctx)
+	if err != nil {
+		return nil, grpc.Errorf(codes.Internal, "Cannot commit transaction")
+	}
+
+	neighbors, err := s.tree.NeighborsAt(txn, index[:], epoch)
 	if err != nil {
 		log.Printf("Cannot get neighbors list: %v", err)
 		return nil, grpc.Errorf(codes.Internal, "Cannot get neighbors list")
 	}
 
 	// Retrieve the leaf if this is not a proof of absence.
-	leaf, err := s.getLeaf(ctx, index[:], epoch)
+	leaf, err := s.tree.ReadLeafAt(txn, index[:], epoch)
 	if err != nil {
-		return nil, err
+		log.Printf("Cannot read leaf entry: %v", err)
+		return nil, grpc.Errorf(codes.Internal, "Cannot read leaf entry")
+	}
+
+	if err := txn.Commit(); err != nil {
+		log.Printf("Cannot commit transaction: %v", err)
+		return nil, grpc.Errorf(codes.Internal, "Cannot commit transaction")
 	}
 
 	var committed *tpb.Committed
@@ -142,24 +153,6 @@ func (s *Server) getEntry(ctx context.Context, userID string, epoch int64) (*tpb
 		Smh:    &smh,
 		SmhSct: sct,
 	}, nil
-}
-
-func (s *Server) getLeaf(ctx context.Context, index []byte, epoch int64) ([]byte, error) {
-	txn, err := s.factory.NewDBTxn(ctx)
-	if err != nil {
-		log.Printf("Cannot create transaction: %v", err)
-		return nil, grpc.Errorf(codes.Internal, "Cannot create transaction")
-	}
-	leaf, err := s.tree.ReadLeafAt(txn, index, epoch)
-	if err != nil {
-		log.Printf("Cannot read leaf entry: %v", err)
-		return nil, grpc.Errorf(codes.Internal, "Cannot read leaf entry")
-	}
-	if err := txn.Commit(); err != nil {
-		log.Printf("Cannot commit transaction: %v", err)
-		return nil, grpc.Errorf(codes.Internal, "Cannot commit transaction")
-	}
-	return leaf, nil
 }
 
 // ListEntryHistory returns a list of EntryProofs covering a period of time.

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -212,7 +212,7 @@ func (f *fakeSparseHist) ReadLeafAt(txn transaction.Txn, index []byte, epoch int
 	return entryData, nil
 }
 
-func (*fakeSparseHist) NeighborsAt(ctx context.Context, index []byte, epoch int64) ([][]byte, error) {
+func (*fakeSparseHist) NeighborsAt(txn transaction.Txn, index []byte, epoch int64) ([][]byte, error) {
 	return nil, nil
 }
 

--- a/core/tree/tree.go
+++ b/core/tree/tree.go
@@ -34,7 +34,7 @@ type Sparse interface {
 	// ReadLeafAt returns the leaf value at epoch.
 	ReadLeafAt(txn transaction.Txn, index []byte, epoch int64) ([]byte, error)
 	// Neighbors returns the list of neighbors from the neighbor leaf to just below the root at epoch.
-	NeighborsAt(ctx context.Context, index []byte, epoch int64) ([][]byte, error)
+	NeighborsAt(txn transaction.Txn, index []byte, epoch int64) ([][]byte, error)
 	// Epoch returns the current epoch of the merkle tree.
 	Epoch() int64
 }


### PR DESCRIPTION
This simplifies reading both leaves and their neighbors within the same
transaction.

Contributes to #530