### PR TITLE
Create trillian.MapServer inside Key Transparency

### DIFF
--- a/core/mapserver/mapserver.go
+++ b/core/mapserver/mapserver.go
@@ -1,0 +1,207 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mapserver implements the TrillianMapClient interface.
+// To start with, this will use KT's internal utilities to accomplish the same functions.
+// Later this will be replaced with a simple RPC to Trillian Maps.
+package mapserver
+
+import (
+	"crypto"
+	"fmt"
+	"log"
+
+	"github.com/google/keytransparency/core/sequenced"
+	"github.com/google/keytransparency/core/transaction"
+	"github.com/google/keytransparency/core/tree"
+	"github.com/google/trillian"
+	tcrypto "github.com/google/trillian/crypto"
+	"github.com/google/trillian/util"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// MapServer implements TrilianMap functionality.
+type MapServer struct {
+	mapID   int64
+	tree    tree.Sparse
+	factory transaction.Factory
+	sths    sequenced.Sequenced
+	signer  *tcrypto.Signer
+	clock   util.TimeSource
+}
+
+// New returns a MapServer.
+func New(mapID int64, tree tree.Sparse, factory transaction.Factory, sths sequenced.Sequenced,
+	signer crypto.Signer, clock util.TimeSource) trillian.TrillianMapClient {
+	if _, err := tree.Commit(context.Background()); err != nil {
+		log.Printf("tree.Commit(): %v", err)
+		panic("foo")
+	}
+
+	return &MapServer{
+		mapID:   mapID,
+		tree:    tree,
+		factory: factory,
+		sths:    sths,
+		signer:  tcrypto.NewSigner(signer),
+		clock:   clock,
+	}
+}
+
+func (m *MapServer) signRoot(ctx context.Context) (*trillian.SignedMapRoot, error) {
+	// TODO: I think Commit should also take a txn so we can support
+	// reading pending leaves, writing the new root, and saving the SignedTreeHead
+	// all in one transaction.
+	epoch, err := m.tree.Commit(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("tree.Commit(): %v", err)
+	}
+
+	txn, err := m.factory.NewDBTxn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	root, err := m.tree.ReadRootAt(txn, epoch)
+	if err != nil {
+		return nil, fmt.Errorf("ReadRootAt err: %v", err)
+	}
+
+	smr := &trillian.SignedMapRoot{
+		MapId:          m.mapID,
+		MapRevision:    epoch,
+		RootHash:       root,
+		TimestampNanos: m.clock.Now().Unix(),
+		// TODO: Add mutation high watermark?
+	}
+	sig, err := m.signer.SignObject(smr)
+	if err != nil {
+		return nil, err
+	}
+	smr.Signature = sig
+
+	// Save signed map head.
+	if err := m.sths.Write(txn, m.mapID, epoch, smr); err != nil {
+		return nil, fmt.Errorf("Append SMH failure %v", err)
+	}
+	if err := txn.Commit(); err != nil {
+		return nil, err
+	}
+
+	log.Printf("Created epoch %v. SMH: %#x", epoch, root)
+	return smr, nil
+}
+
+// SetLeaves adds the leaves and commits them in a single transaction, returning the new MapRoot.
+func (m *MapServer) SetLeaves(ctx context.Context, in *trillian.SetMapLeavesRequest, opts ...grpc.CallOption) (*trillian.SetMapLeavesResponse, error) {
+
+	if got, want := in.MapId, m.mapID; got != want {
+		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
+	}
+	txn, err := m.factory.NewDBTxn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, l := range in.Leaves {
+		if _, err := m.tree.QueueLeaf(txn, l.Index, l.LeafValue); err != nil {
+			return nil, fmt.Errorf("QueueLeaf(): %v", err)
+		}
+	}
+	if err := txn.Commit(); err != nil {
+		return nil, err
+	}
+
+	smh, err := m.signRoot(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("signRoot(): %v", err)
+	}
+
+	return &trillian.SetMapLeavesResponse{
+		MapRoot: smh,
+	}, nil
+}
+
+// GetLeaves returns the requested leaves.
+func (m *MapServer) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesRequest, opts ...grpc.CallOption) (*trillian.GetMapLeavesResponse, error) {
+	if got, want := in.MapId, m.mapID; got != want {
+		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
+	}
+
+	txn, err := m.factory.NewDBTxn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current epoch.
+	var root trillian.SignedMapRoot
+	if _, err := m.sths.Latest(txn, in.MapId, &root); err != nil {
+		return nil, err
+	}
+
+	// ReadLeavesAtEpoch.
+	inclusions := make([]*trillian.MapLeafInclusion, 0, len(in.Index))
+	for _, index := range in.Index {
+		leafData, err := m.tree.ReadLeafAt(txn, index, root.MapRevision)
+		if err != nil {
+			return nil, err
+		}
+		nbrs, err := m.tree.NeighborsAt(txn, index, root.MapRevision)
+		if err != nil {
+			return nil, err
+		}
+		inclusions = append(inclusions, &trillian.MapLeafInclusion{
+			Leaf: &trillian.MapLeaf{
+				Index:     index,
+				LeafValue: leafData,
+			},
+			Inclusion: nbrs,
+		})
+	}
+
+	if err := txn.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &trillian.GetMapLeavesResponse{
+		MapLeafInclusion: inclusions,
+		MapRoot:          &root,
+	}, nil
+}
+
+// GetSignedMapRoot returns the requested MapRoot.
+func (m *MapServer) GetSignedMapRoot(ctx context.Context, in *trillian.GetSignedMapRootRequest, opts ...grpc.CallOption) (*trillian.GetSignedMapRootResponse, error) {
+	if got, want := in.MapId, m.mapID; got != want {
+		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
+	}
+
+	txn, err := m.factory.NewDBTxn(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get current epoch.
+	var root trillian.SignedMapRoot
+	if _, err := m.sths.Latest(txn, in.MapId, &root); err != nil {
+		return nil, err
+	}
+
+	if err := txn.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &trillian.GetSignedMapRootResponse{
+		MapRoot: &root,
+	}, nil
+}

--- a/core/mapserver/mapserver_test.go
+++ b/core/mapserver/mapserver_test.go
@@ -79,6 +79,7 @@ func index(i int) []byte {
 }
 
 func TestSetGet(t *testing.T) {
+	ctx := context.Background()
 	env, err := newEnv()
 	if err != nil {
 		t.Fatalf("Error creating env: %v", err)
@@ -102,7 +103,6 @@ func TestSetGet(t *testing.T) {
 				&trillian.MapLeaf{Index: index(1), LeafValue: []byte("bar1")},
 			}},
 	} {
-		ctx := context.Background()
 		resp, err := env.m.SetLeaves(ctx, &trillian.SetMapLeavesRequest{
 			MapId:  env.mapID,
 			Leaves: tc.leaves,
@@ -144,6 +144,7 @@ func TestSetGet(t *testing.T) {
 }
 
 func TestGetSignedMapRoot(t *testing.T) {
+	ctx := context.Background()
 	env, err := newEnv()
 	if err != nil {
 		t.Fatalf("Error creating env: %v", err)
@@ -167,7 +168,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 				&trillian.MapLeaf{Index: index(1), LeafValue: []byte("bar1")},
 			}},
 	} {
-		resp, err := env.m.SetLeaves(context.Background(), &trillian.SetMapLeavesRequest{
+		resp, err := env.m.SetLeaves(ctx, &trillian.SetMapLeavesRequest{
 			MapId:  env.mapID,
 			Leaves: tc.leaves,
 		})
@@ -179,7 +180,7 @@ func TestGetSignedMapRoot(t *testing.T) {
 			t.Errorf("SetLeaves(%v).MapRevision: %v, want %v", i, got, want)
 		}
 
-		rootResp, err := env.m.GetSignedMapRoot(context.Background(), &trillian.GetSignedMapRootRequest{
+		rootResp, err := env.m.GetSignedMapRoot(ctx, &trillian.GetSignedMapRootRequest{
 			MapId: env.mapID,
 		})
 		if err != nil {

--- a/core/mapserver/mapserver_test.go
+++ b/core/mapserver/mapserver_test.go
@@ -1,0 +1,139 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapserver
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/google/keytransparency/impl/sql/sequenced"
+	"github.com/google/keytransparency/impl/sql/sqlhist"
+	"github.com/google/keytransparency/impl/sql/testutil"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keys"
+	"github.com/google/trillian/util"
+)
+
+type env struct {
+	mapID int64
+	db    *sql.DB
+	m     trillian.TrillianMapClient
+}
+
+func newEnv() (*env, error) {
+	mapID := int64(0)
+	sqldb, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		return nil, fmt.Errorf("sql.Open(): %v", err)
+	}
+	factory := testutil.NewFakeFactory(sqldb)
+	tree, err := sqlhist.New(context.Background(), sqldb, mapID, factory)
+	if err != nil {
+		return nil, err
+	}
+	sths, err := sequenced.New(sqldb, mapID)
+	if err != nil {
+		return nil, err
+	}
+	signer, err := keys.NewFromPrivatePEM(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIHgSC8WzQK0bxSmfJWUeMP5GdndqUw8zS1dCHQ+3otj/oAoGCCqGSM49
+AwEHoUQDQgAE5AV2WCmStBt4N2Dx+7BrycJFbxhWf5JqSoyp0uiL8LeNYyj5vgkl
+K8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
+-----END EC PRIVATE KEY-----`, "")
+	if err != nil {
+		return nil, err
+	}
+	clock := util.FakeTimeSource{FakeTime: time.Now()}
+	m := New(mapID, tree, factory, sths, signer, clock)
+
+	return &env{
+		mapID: mapID,
+		db:    sqldb,
+		m:     m,
+	}, nil
+}
+
+func index(i int) []byte {
+	idx := make([]byte, 32)
+	idx[0] = byte(i)
+	return idx
+}
+
+func TestSetGet(t *testing.T) {
+	env, err := newEnv()
+	if err != nil {
+		t.Fatalf("Error creating env: %v", err)
+	}
+	defer env.db.Close()
+
+	for i, tc := range []struct {
+		epoch  int64
+		leaves []*trillian.MapLeaf
+	}{
+		{
+			epoch: 1,
+			leaves: []*trillian.MapLeaf{
+				&trillian.MapLeaf{Index: index(0), LeafValue: []byte("foo")},
+				&trillian.MapLeaf{Index: index(1), LeafValue: []byte("bar")},
+			}},
+		{
+			epoch: 2,
+			leaves: []*trillian.MapLeaf{
+				&trillian.MapLeaf{Index: index(0), LeafValue: []byte("foo1")},
+				&trillian.MapLeaf{Index: index(1), LeafValue: []byte("bar1")},
+			}},
+	} {
+		resp, err := env.m.SetLeaves(context.Background(), &trillian.SetMapLeavesRequest{
+			MapId:  env.mapID,
+			Leaves: tc.leaves,
+		})
+		if err != nil {
+			t.Errorf("SetLeaves(%v): %v", i, err)
+			continue
+		}
+		if got, want := resp.MapRoot.MapRevision, tc.epoch; got != want {
+			t.Errorf("SetLeaves(%v).MapRevision: %v, want %v", i, got, want)
+		}
+
+		indexes := make([][]byte, 0, len(tc.leaves))
+		for _, l := range tc.leaves {
+			indexes = append(indexes, l.Index)
+		}
+		resp2, err := env.m.GetLeaves(context.Background(), &trillian.GetMapLeavesRequest{
+			MapId:    env.mapID,
+			Revision: tc.epoch,
+			Index:    indexes,
+		})
+		if err != nil {
+			t.Errorf("GetLeaves(%v): %v", i, err)
+			continue
+		}
+		if got, want := resp2.MapRoot.MapRevision, tc.epoch; got != want {
+			t.Errorf("GetLeaves(%v).MapRevision: %v, want %v", i, got, want)
+			continue
+		}
+		for k, l := range resp2.MapLeafInclusion {
+			if got, want := l.Leaf.LeafValue, tc.leaves[k].LeafValue; !bytes.Equal(got, want) {
+				t.Errorf("GetLeaves(%v).Leaf[%v]: %s, want %s", i, k, got, want)
+			}
+		}
+	}
+}

--- a/integration/fake/fake_trilian_log.go
+++ b/integration/fake/fake_trilian_log.go
@@ -19,22 +19,23 @@ import (
 	"fmt"
 
 	"github.com/google/trillian"
+	"github.com/google/trillian/client"
 )
 
-// LogClient implements trillian/client.VerifyingLogClient.
-type LogClient struct {
+// logClient implements trillian/client.VerifyingLogClient.
+type logClient struct {
 	leaves []*trillian.LogLeaf
 }
 
 // NewFakeTrillianClient returns a client that mimicks a trillian log.
-func NewFakeTrillianClient() *LogClient {
-	return &LogClient{
+func NewFakeTrillianClient() client.VerifyingLogClient {
+	return &logClient{
 		leaves: make([]*trillian.LogLeaf, 0),
 	}
 }
 
 // AddLeaf adds a leaf to the log.
-func (f *LogClient) AddLeaf(ctx context.Context, data []byte) error {
+func (f *logClient) AddLeaf(ctx context.Context, data []byte) error {
 	f.leaves = append(f.leaves, &trillian.LogLeaf{
 		LeafValue: data,
 	})
@@ -42,7 +43,7 @@ func (f *LogClient) AddLeaf(ctx context.Context, data []byte) error {
 }
 
 // GetByIndex returns the requested leaf.
-func (f *LogClient) GetByIndex(ctx context.Context, index int64) (*trillian.LogLeaf, error) {
+func (f *logClient) GetByIndex(ctx context.Context, index int64) (*trillian.LogLeaf, error) {
 	if got, want := index, int64(len(f.leaves)); got > want {
 		return nil, fmt.Errorf("Index out of range. Got %v, want <= %v", got, want)
 	}
@@ -53,7 +54,7 @@ func (f *LogClient) GetByIndex(ctx context.Context, index int64) (*trillian.LogL
 }
 
 // ListByIndex returns the set of requested leaves.
-func (f *LogClient) ListByIndex(ctx context.Context, start int64, count int64) ([]*trillian.LogLeaf, error) {
+func (f *logClient) ListByIndex(ctx context.Context, start int64, count int64) ([]*trillian.LogLeaf, error) {
 	if got, want := start+count, int64(len(f.leaves)); got > want {
 		return nil, fmt.Errorf("Index out of range. Got %v, want <= %v", got, want)
 	}
@@ -64,13 +65,23 @@ func (f *LogClient) ListByIndex(ctx context.Context, start int64, count int64) (
 }
 
 // UpdateRoot fetches the latest signed tree root.
-func (f *LogClient) UpdateRoot(ctx context.Context) error {
+func (f *logClient) UpdateRoot(ctx context.Context) error {
 	return nil
 }
 
 // Root returns the latest local copy of the signed log root.
-func (f *LogClient) Root() trillian.SignedLogRoot {
+func (f *logClient) Root() trillian.SignedLogRoot {
 	return trillian.SignedLogRoot{
 		TreeSize: int64(len(f.leaves)),
 	}
+}
+
+// VerifyInclusion returns nil.
+func (l *logClient) VerifyInclusion(ctx context.Context, data []byte) error {
+	return nil
+}
+
+// VerifyInclusionAtIndex returns nil.
+func (l *logClient) VerifyInclusionAtIndex(ctx context.Context, data []byte, index int64) error {
+	return nil
 }


### PR DESCRIPTION
This begins the migration to trillian Maps by separating the internal bits of Key Transparency which implement the same functions.

This adds `mapserver` which implements `trillian.MapServerClient` using `tree.Sparse` and several other internal KT modules. 

The next PR will convert the signer to use `mapserver`

#486 #172