### PR TITLE
Multi-tenant configuration support

### DIFF
--- a/core/admin/interface.go
+++ b/core/admin/interface.go
@@ -1,0 +1,23 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package admin supports configuing Key Transparency with multiple Trillian backends.
+package admin
+
+import "github.com/google/trillian/client"
+
+// Admin returns objects for specific domains.
+type Admin interface {
+	LogClient(logID int64) (client.VerifyingLogClient, error)
+}

--- a/core/admin/static.go
+++ b/core/admin/static.go
@@ -1,0 +1,56 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"fmt"
+
+	"github.com/google/trillian/client"
+)
+
+// Static implements an admin interface for a static set of backends.
+// Updates require a restart.
+type Static struct {
+	backends map[int64]*row
+}
+
+// row represents one domain backend.
+type row struct {
+	log client.VerifyingLogClient
+}
+
+// NewStatic returns an admin interface which returns trillian objects.
+func NewStatic() *Static {
+	return &Static{
+		backends: make(map[int64]*row),
+	}
+}
+
+// AddLog adds a particular log to Static.
+func (s *Static) AddLog(logID int64, log client.VerifyingLogClient) error {
+	s.backends[logID] = &row{
+		log: log,
+	}
+	return nil
+}
+
+// LogClient returns the log client for logID.
+func (s *Static) LogClient(logID int64) (client.VerifyingLogClient, error) {
+	r, ok := s.backends[logID]
+	if !ok {
+		return nil, fmt.Errorf("No backend found for logID: %v", logID)
+	}
+	return r.log, nil
+}

--- a/core/admin/static_test.go
+++ b/core/admin/static_test.go
@@ -1,0 +1,44 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"testing"
+
+	"github.com/google/keytransparency/integration/fake"
+)
+
+func TestStatic(t *testing.T) {
+	admin := NewStatic()
+	client := fake.NewFakeTrillianClient()
+
+	for _, tc := range []struct {
+		logID     int64
+		add, want bool
+	}{
+		{logID: 0, add: false, want: false},
+		{logID: 1, add: true, want: true},
+	} {
+		if tc.add {
+			if err := admin.AddLog(tc.logID, client); err != nil {
+				t.Errorf("AddLog(): %v, want nil", err)
+			}
+		}
+		_, err := admin.LogClient(tc.logID)
+		if got, want := err == nil, tc.want; got != want {
+			t.Errorf("LogClient(%v): %v, want nil? %v", tc.logID, err, want)
+		}
+	}
+}

--- a/integration/fake/fake_trilian_log.go
+++ b/integration/fake/fake_trilian_log.go
@@ -1,0 +1,70 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/trillian"
+)
+
+// FakeClient implements trillian/client.LogVerifier
+type FakeClient struct {
+	leaves []*trillian.LogLeaf
+}
+
+// NewFakeTrillianClient returns a client that mimicks a trillian log.
+func NewFakeTrillianClient() *FakeClient {
+	return &FakeClient{
+		leaves: make([]*trillian.LogLeaf, 0),
+	}
+}
+
+// AddLeaf adds a leaf to the log.
+func (f *FakeClient) AddLeaf(ctx context.Context, data []byte) error {
+	f.leaves = append(f.leaves, &trillian.LogLeaf{
+		LeafValue: data,
+	})
+	return nil
+}
+
+// GetByIndex returns the requested leaf.
+func (f *FakeClient) GetByIndex(ctx context.Context, index int64) (*trillian.LogLeaf, error) {
+	if got, want := index, int64(len(f.leaves)); got > want {
+		return nil, fmt.Errorf("Index out of range. Got %v, want %v", got, want)
+	}
+	return f.leaves[index], nil
+}
+
+// ListByIndex returns the set of requested leaves.
+func (f *FakeClient) ListByIndex(ctx context.Context, start int64, count int64) ([]*trillian.LogLeaf, error) {
+	if got, want := start+count, int64(len(f.leaves)); got > want {
+		return nil, fmt.Errorf("Index out of range. Got %v, want %v", got, want)
+	}
+	return f.leaves[start : start+count], nil
+}
+
+// UpdateRoot fetches the latest signed tree root.
+func (f *FakeClient) UpdateRoot(ctx context.Context) error {
+	return nil
+}
+
+// Root returns the latest local copy of the signed log root.
+func (f *FakeClient) Root() trillian.SignedLogRoot {
+	return trillian.SignedLogRoot{
+		TreeSize: int64(len(f.leaves)),
+	}
+}


### PR DESCRIPTION
Support multiple backend logs by storing their configuration
in an in-memory table.

In the future, the Add* commands of the Admin interface will perform
the needed setup such as inserting master rows in the various
sub-components.

Further in the future, this in-memory table will be backed by a database
rather than configured in-memory from the commandline.

#534 