### PR TITLE
Update Go Version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7.3
+  - 1.8
 
 dist: trusty
 sudo: false


### PR DESCRIPTION
Update Go version in Travis to 1.8.

This fixes and error seen in this build:
https://travis-ci.org/google/keytransparency/builds/216732454