### PR TITLE
Fix Presubmit Errors

### DIFF
--- a/core/crypto/signatures/p256/ecdsa_p256_test.go
+++ b/core/crypto/signatures/p256/ecdsa_p256_test.go
@@ -231,6 +231,9 @@ func flipBit(a []byte, pos uint) []byte {
 func TestGeneratePEMs(t *testing.T) {
 	signatures.Rand = DevZero{}
 	skPEM, pkPEM, err := GeneratePEMs()
+	if err != nil {
+		t.Fatalf("GeneratePEMs() failed: %v", err)
+	}
 
 	// Ensure that the generated keys are valid.
 	signer := newSigner(t, skPEM)

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -108,7 +108,9 @@ func (s *Server) getEntry(ctx context.Context, userID string, epoch int64) (*tpb
 	neighbors, err := s.tree.NeighborsAt(txn, index[:], epoch)
 	if err != nil {
 		log.Printf("Cannot get neighbors list: %v", err)
-		txn.Rollback()
+		if err := txn.Rollback(); err != nil {
+			log.Printf("Cannot rollback the transaction: %v", err)
+		}
 		return nil, grpc.Errorf(codes.Internal, "Cannot get neighbors list")
 	}
 
@@ -116,7 +118,9 @@ func (s *Server) getEntry(ctx context.Context, userID string, epoch int64) (*tpb
 	leaf, err := s.tree.ReadLeafAt(txn, index[:], epoch)
 	if err != nil {
 		log.Printf("Cannot read leaf entry: %v", err)
-		txn.Rollback()
+		if err := txn.Rollback(); err != nil {
+			log.Printf("Cannot rollback the transaction: %v", err)
+		}
 		return nil, grpc.Errorf(codes.Internal, "Cannot read leaf entry")
 	}
 


### PR DESCRIPTION
This PR fixes `make presubmit` errors after updating the presubmit tools: `golint`, `errcheck`, `gocyclo`, `ineffassign`, and `misspell`.

The following is the only outstanding error left. A fix is already included in #524.
```
./impl/sql/mutations/mutations_test.go:38:1: context.Context should be the first parameter of a function
```