### PR TITLE
Update grpc metadata API

### DIFF
--- a/core/authentication/fake.go
+++ b/core/authentication/fake.go
@@ -33,12 +33,12 @@ func NewFake() *FakeAuth {
 func (a *FakeAuth) NewContext(userID string) context.Context {
 	md := make(map[string][]string)
 	md["userid"] = []string{userID}
-	return metadata.NewContext(context.TODO(), md)
+	return metadata.NewOutgoingContext(context.TODO(), md)
 }
 
 // ValidateCreds verifies that the requiredUserID is present in ctx.
 func (a *FakeAuth) ValidateCreds(ctx context.Context, requiredUserID string) error {
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return ErrMissingAuth
 	}

--- a/core/mapserver/mapserver.go
+++ b/core/mapserver/mapserver.go
@@ -52,7 +52,7 @@ func New(mapID int64, tree tree.Sparse, factory transaction.Factory, sths sequen
 		tree:    tree,
 		factory: factory,
 		sths:    sths,
-		signer:  tcrypto.NewSigner(signer),
+		signer:  tcrypto.NewSHA256Signer(signer),
 		clock:   clock,
 	}
 }

--- a/impl/google/authentication/google.go
+++ b/impl/google/authentication/google.go
@@ -134,7 +134,7 @@ func (a *GAuth) validateToken(ctx context.Context) (*gAPI.Tokeninfo, error) {
 // getIDTokenAuthorizationHeader pulls the bearer token from the "authorization"
 // header in gRPC.
 func getIDTokenAuthorizationHeader(ctx context.Context) (*oauth2.Token, error) {
-	md, ok := metadata.FromContext(ctx)
+	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		return nil, authentication.ErrMissingAuth
 	}


### PR DESCRIPTION
NewContext and FromContext have been deprecated in favor of
NewIncomingContext NewOutgoingContext and
FromIncomingContext and FromOutgoingContext.

This follows google/grpc-go#1157