### PR TITLE
Fix DB locked flakiness in tests

### DIFF
--- a/cmd/keytransparency-server/frontend.go
+++ b/cmd/keytransparency-server/frontend.go
@@ -189,7 +189,7 @@ func main() {
 		log.Fatalf("Failed to create committer: %v", err)
 	}
 	queue := queue.New(context.Background(), etcdCli, *mapID, factory)
-	tree, err := sqlhist.New(context.Background(), sqldb, *mapID, factory)
+	tree, err := sqlhist.New(context.Background(), *mapID, factory)
 	if err != nil {
 		log.Fatalf("Failed to create SQL history: %v", err)
 	}

--- a/cmd/keytransparency-signer/backend.go
+++ b/cmd/keytransparency-signer/backend.go
@@ -94,7 +94,7 @@ func main() {
 
 	// Create signer helper objects.
 	queue := queue.New(context.Background(), etcdCli, *mapID, factory)
-	tree, err := sqlhist.New(context.Background(), sqldb, *mapID, factory)
+	tree, err := sqlhist.New(context.Background(), *mapID, factory)
 	if err != nil {
 		log.Fatalf("Failed to create SQL history: %v", err)
 	}

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -187,15 +187,11 @@ type fakeSparseHist struct {
 	M map[int64][]byte
 }
 
-func (*fakeSparseHist) QueueLeaf(txn transaction.Txn, index, leaf []byte) (int64, error) {
-	return 0, nil
-}
-
-func (*fakeSparseHist) Commit(ctx context.Context) (epoch int64, err error) {
-	return 0, nil
-}
-
-func (*fakeSparseHist) ReadRootAt(txn transaction.Txn, epoch int64) ([]byte, error) {
+func (*fakeSparseHist) QueueLeaf(txn transaction.Txn, index, leaf []byte) error     { return nil }
+func (*fakeSparseHist) Commit(txn transaction.Txn) error                            { return nil }
+func (*fakeSparseHist) ReadRootAt(txn transaction.Txn, epoch int64) ([]byte, error) { return nil, nil }
+func (*fakeSparseHist) Epoch(txn transaction.Txn) (int64, error)                    { return 0, nil }
+func (*fakeSparseHist) NeighborsAt(txn transaction.Txn, index []byte, epoch int64) ([][]byte, error) {
 	return nil, nil
 }
 
@@ -212,14 +208,6 @@ func (f *fakeSparseHist) ReadLeafAt(txn transaction.Txn, index []byte, epoch int
 	return entryData, nil
 }
 
-func (*fakeSparseHist) NeighborsAt(txn transaction.Txn, index []byte, epoch int64) ([][]byte, error) {
-	return nil, nil
-}
-
-func (*fakeSparseHist) Epoch() int64 {
-	return 0
-}
-
 // appender.Appender fake.
 type fakeAppender struct {
 	CurrentEpoch int64
@@ -229,7 +217,6 @@ type fakeAppender struct {
 func (*fakeAppender) Append(ctx context.Context, txn transaction.Txn, epoch int64, obj interface{}) error {
 	return nil
 }
-
 func (*fakeAppender) Epoch(ctx context.Context, epoch int64, obj interface{}) ([]byte, error) {
 	return nil, nil
 }
@@ -240,40 +227,26 @@ func (f *fakeAppender) Latest(ctx context.Context, obj interface{}) (int64, []by
 }
 
 // vrf.PrivateKey fake.
-type fakePrivateKey struct {
-}
+type fakePrivateKey struct{}
 
-func (fakePrivateKey) Evaluate(m []byte) (vrf []byte, proof []byte) {
-	return nil, nil
-}
-
-func (fakePrivateKey) Index(vrf []byte) [32]byte {
-	return [32]byte{}
-}
+func (fakePrivateKey) Evaluate(m []byte) (vrf []byte, proof []byte) { return nil, nil }
+func (fakePrivateKey) Index(vrf []byte) [32]byte                    { return [32]byte{} }
 
 // mutator.Mutator fake.
-type fakeMutator struct {
-}
+type fakeMutator struct{}
 
-func (fakeMutator) CheckMutation(value, mutation []byte) error {
-	return nil
-}
-
-func (fakeMutator) Mutate(value, mutation []byte) ([]byte, error) {
-	return nil, nil
-}
+func (fakeMutator) CheckMutation(value, mutation []byte) error    { return nil }
+func (fakeMutator) Mutate(value, mutation []byte) ([]byte, error) { return nil, nil }
 
 // transaction.Txn fake
-type fakeTxn struct {
-}
+type fakeTxn struct{}
 
 func (*fakeTxn) Prepare(query string) (*sql.Stmt, error) { return nil, nil }
 func (*fakeTxn) Commit() error                           { return nil }
 func (*fakeTxn) Rollback() error                         { return nil }
 
 // transaction.Factory fake
-type fakeFactory struct {
-}
+type fakeFactory struct{}
 
 func (fakeFactory) NewDBTxn(ctx context.Context) (transaction.Txn, error) {
 	return &fakeTxn{}, nil

--- a/core/mapserver/mapserver_test.go
+++ b/core/mapserver/mapserver_test.go
@@ -46,7 +46,7 @@ func newEnv() (*env, error) {
 		return nil, fmt.Errorf("sql.Open(): %v", err)
 	}
 	factory := testutil.NewFakeFactory(sqldb)
-	tree, err := sqlhist.New(context.Background(), sqldb, mapID, factory)
+	tree, err := sqlhist.New(context.Background(), mapID, factory)
 	if err != nil {
 		return nil, err
 	}

--- a/core/tree/tree.go
+++ b/core/tree/tree.go
@@ -15,20 +15,16 @@
 // Package tree contains functions for manipulating generic tree representations.
 package tree
 
-import (
-	"golang.org/x/net/context"
-
-	"github.com/google/keytransparency/core/transaction"
-)
+import "github.com/google/keytransparency/core/transaction"
 
 // Sparse is a temporal sparse merkle tree.
 type Sparse interface {
 	// QueueLeaf queues a leaf to be written on the next Commit(). QueueLeaf
 	// returns the epoch at which the leaf is queued.
-	QueueLeaf(txn transaction.Txn, index, leaf []byte) (int64, error)
+	QueueLeaf(txn transaction.Txn, index, leaf []byte) error
 	// Commit takes all the Queued values since the last Commmit() and writes them.
 	// Commit is NOT multi-process safe. It should only be called from the sequencer.
-	Commit(ctx context.Context) (epoch int64, err error)
+	Commit(txn transaction.Txn) error
 	// ReadRootAt returns the root value at epoch.
 	ReadRootAt(txn transaction.Txn, epoch int64) ([]byte, error)
 	// ReadLeafAt returns the leaf value at epoch.
@@ -36,5 +32,5 @@ type Sparse interface {
 	// Neighbors returns the list of neighbors from the neighbor leaf to just below the root at epoch.
 	NeighborsAt(txn transaction.Txn, index []byte, epoch int64) ([][]byte, error)
 	// Epoch returns the current epoch of the merkle tree.
-	Epoch() int64
+	Epoch(txn transaction.Txn) (int64, error)
 }

--- a/core/tree/tree.go
+++ b/core/tree/tree.go
@@ -19,8 +19,7 @@ import "github.com/google/keytransparency/core/transaction"
 
 // Sparse is a temporal sparse merkle tree.
 type Sparse interface {
-	// QueueLeaf queues a leaf to be written on the next Commit(). QueueLeaf
-	// returns the epoch at which the leaf is queued.
+	// QueueLeaf queues a leaf to be written on the next Commit().
 	QueueLeaf(txn transaction.Txn, index, leaf []byte) error
 	// Commit takes all the Queued values since the last Commmit() and writes them.
 	// Commit is NOT multi-process safe. It should only be called from the sequencer.

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -97,7 +97,7 @@ type Map struct {
 }
 
 // New creates a new map.
-func New(ctx context.Context, db *sql.DB, mapID int64, factory transaction.Factory) (m *Map, returnErr error) {
+func New(ctx context.Context, mapID int64, factory transaction.Factory) (m *Map, returnErr error) {
 	m = &Map{
 		mapID: mapID,
 	}
@@ -151,9 +151,7 @@ func (m *Map) Epoch(txn transaction.Txn) (int64, error) {
 	return epoch.Int64, nil
 }
 
-// QueueLeaf should only be called by the sequencer. If txn is nil, the operation
-// will not run in a transaction. QueueLeaf returns the epoch at which the leaf
-// is queued.
+// QueueLeaf should only be called by the sequencer.
 func (m *Map) QueueLeaf(txn transaction.Txn, index, leaf []byte) error {
 	if got, want := len(index), size; got != want {
 		return errIndexLen
@@ -232,8 +230,7 @@ func (m *Map) Commit(txn transaction.Txn) error {
 	return nil
 }
 
-// ReadRootAt returns the value of the root node in a specific epoch. If txn is
-// nil the operation will not run in a transaction.
+// ReadRootAt returns the value of the root node in a specific epoch.
 func (m *Map) ReadRootAt(txn transaction.Txn, epoch int64) ([]byte, error) {
 	stmt, err := txn.Prepare(readExpr)
 	if err != nil {
@@ -248,8 +245,7 @@ func (m *Map) ReadRootAt(txn transaction.Txn, epoch int64) ([]byte, error) {
 	return value, nil
 }
 
-// ReadLeafAt returns the leaf value at epoch. If txn is nil, the operation will
-// not run in a transaction.
+// ReadLeafAt returns the leaf value at epoch.
 func (m *Map) ReadLeafAt(txn transaction.Txn, index []byte, epoch int64) ([]byte, error) {
 	readStmt, err := txn.Prepare(leafExpr)
 	if err != nil {

--- a/impl/sql/sqlhist/sqlhist_test.go
+++ b/impl/sql/sqlhist/sqlhist_test.go
@@ -57,7 +57,7 @@ func TestQueueLeaf(t *testing.T) {
 	defer db.Close()
 	factory := testutil.NewFakeFactory(db)
 
-	tree, err := New(ctx, db, 0, factory)
+	tree, err := New(ctx, 0, factory)
 	if err != nil {
 		t.Fatalf("Failed to create SQL history: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestEpochNumAdvance(t *testing.T) {
 		{"", "", 4, false},
 		{"", "", 5, false},
 	} {
-		tree, err := New(ctx, db, 0, factory)
+		tree, err := New(ctx, 0, factory)
 		if err != nil {
 			t.Fatalf("Failed to create SQL history: %v", err)
 		}
@@ -148,7 +148,7 @@ func TestQueueCommitRead(t *testing.T) {
 	defer db.Close()
 	factory := testutil.NewFakeFactory(db)
 
-	m, err := New(ctx, db, 0, factory)
+	m, err := New(ctx, 0, factory)
 	if err != nil {
 		t.Fatalf("Failed to create SQL history: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestReadNotFound(t *testing.T) {
 	defer db.Close()
 	factory := testutil.NewFakeFactory(db)
 
-	m, err := New(ctx, db, 0, factory)
+	m, err := New(ctx, 0, factory)
 	if err != nil {
 		t.Fatalf("Failed to create SQL history: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestReadPreviousEpochs(t *testing.T) {
 	defer db.Close()
 	factory := testutil.NewFakeFactory(db)
 
-	m, err := New(ctx, db, 0, factory)
+	m, err := New(ctx, 0, factory)
 	if err != nil {
 		t.Fatalf("Failed to create SQL history: %v", err)
 	}
@@ -329,7 +329,7 @@ func TestAribtrayInsertOrder(t *testing.T) {
 	}
 	roots := make([][]byte, len(leafs))
 	for i := range roots {
-		m, err := New(ctx, db, 0, factory)
+		m, err := New(ctx, 0, factory)
 		if err != nil {
 			t.Fatalf("Failed to create SQL history: %v", err)
 		}
@@ -440,7 +440,7 @@ func TestNeighborDepth(t *testing.T) {
 
 func createTree(db *sql.DB, mapID int64, leafs []leaf) (*Map, error) {
 	factory := testutil.NewFakeFactory(db)
-	m, err := New(ctx, db, mapID, factory)
+	m, err := New(ctx, mapID, factory)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create map: %v", err)
 	}

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -135,7 +135,6 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 				t.Errorf("AdvanceEpoch: %v", err)
 			}
 			<-env.Queue.Epochs() // Wait for new epoch.
-
 			if err := env.Client.Retry(tc.ctx, req); err != nil {
 				t.Errorf("Retry(%v): %v, want nil", req, err)
 			}
@@ -206,6 +205,7 @@ func TestUpdateValidation(t *testing.T) {
 			if err := env.Queue.AdvanceEpoch(); err != nil {
 				t.Errorf("AdvanceEpoch: %v", err)
 			}
+			<-env.Queue.Epochs() // Wait for new epoch.
 			if err := env.Client.Retry(tc.ctx, req); err != nil {
 				t.Errorf("Retry(%v): %v, want nil", req, err)
 			}

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -160,7 +160,7 @@ func NewEnv(t *testing.T) *Env {
 	// Common data structures.
 	factory := transaction.NewFactory(sqldb, etcdCli)
 	queue := queue.New(context.Background(), etcdCli, mapID, factory)
-	tree, err := sqlhist.New(context.Background(), sqldb, mapID, factory)
+	tree, err := sqlhist.New(context.Background(), mapID, factory)
 	if err != nil {
 		t.Fatalf("Failed to create SQL history: %v", err)
 	}


### PR DESCRIPTION
Some integration tests make GET requests while new epochs are being created in the background, using the same *sql.DB connection, producing a transient "database is locked" error. 

Background: 
- Reading while a write is occurring requires multiple *sql.DB connections to the same db. 
- In-memory tests only allow one *sql.DB connection to the test database.
- *sql.DB is [not threadsafe](https://github.com/mattn/go-sqlite3#faq) for write/reads on multiple goroutines.

Solution: 
Synchronize access to sql.DB by waiting for epoch creation to finish before making GET requests.  
It adds a channel for new epoch notifications which allows tests to wait for new epochs before advancing to the next steps in the test. 

This PR resolves this issue by
- Converting all `sqlhist` operations to consistently take Transactions as input. 
  - `Commit` now takes a txn
  - `Epoch` now takes a txn
  - `Commit` and `QueueLeaf` no longer return the current epoch as a return value since it's accuracy is not guaranteed outside of a transaction. 
- Ensuring that `txn.Rollback()` is called on all error paths. 
- `Queue` publishes a channel of events for new epoch creation.
- Tests use `Queue.AdvanceEpoch()` rather than performing the epoch itself. 

Fixes #531 