### PR TITLE
Create Travis presubmit make rule without coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ install:
 
 script:
   - make
-  - make presubmit
+  - make travis-presubmit

--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,16 @@ fmt:
 	find . -iregex '.*.go' ! -path "./vendor/*" -exec gofmt -s -w {} \;
 	find . -iregex '.[^.]*.go' ! -path "./vendor/*" -exec golint {} \;
 
-presubmit: coverage fmt
+tools:
 	-go vet ./cmd/... ./core/... ./impl/... ./integration/...
 	find . ! -path "*/proto/*" ! -iwholename "*.git*" ! -iwholename "." ! -iwholename "*vendor*" -type d ! -name "proto" -exec errcheck -ignore 'Close|Write|Serve,os:Remove' {} \;
 	-find . -type f -name "*.go" ! -path "./vendor/*" ! -name "*.pb*go" -exec gocyclo -over 15 {} \;
 	-ineffassign .
 	-find . -type f -name '*.md' ! -path "./vendor/*" -o -name '*.go' ! -path "./vendor/*" -o -name '*.proto' ! -path "./vendor/*" | sort | xargs misspell -locale US
+
+presubmit: coverage fmt tools
+
+travis-presubmit: test fmt tools
 
 proto:
 	go generate ./...


### PR DESCRIPTION
Travis is failing when running coverage. Coverage is not adding any benefits in Travis so this PR removes it. We still have coverage when running presubmit locally.