### PR TITLE
Remove etcd Dependency from the Transaction Object

### DIFF
--- a/cmd/keytransparency-server/frontend.go
+++ b/cmd/keytransparency-server/frontend.go
@@ -162,7 +162,7 @@ func main() {
 	// Open Resources.
 	sqldb := openDB()
 	defer sqldb.Close()
-	factory := transaction.NewFactory(sqldb, nil)
+	factory := transaction.NewFactory(sqldb)
 
 	creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 	if err != nil {

--- a/cmd/keytransparency-signer/backend.go
+++ b/cmd/keytransparency-signer/backend.go
@@ -79,7 +79,7 @@ func main() {
 
 	sqldb := openDB()
 	defer sqldb.Close()
-	factory := transaction.NewFactory(sqldb, nil)
+	factory := transaction.NewFactory(sqldb)
 
 	// Create signer helper objects.
 	mutations, err := mutations.New(sqldb, *mapID)

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -108,7 +108,7 @@ func (s *Server) getEntry(ctx context.Context, userID string, epoch int64) (*tpb
 		return nil, err
 	}
 
-	txn, err := s.factory.NewDBTxn(ctx)
+	txn, err := s.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, grpc.Errorf(codes.Internal, "Cannot create transaction")
 	}
@@ -263,7 +263,7 @@ func (s *Server) UpdateEntry(ctx context.Context, in *tpb.UpdateEntryRequest) (*
 	}
 
 	// Save mutation to the database.
-	txn, err := s.factory.NewDBTxn(ctx)
+	txn, err := s.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, grpc.Errorf(codes.Internal, "Cannot create transaction")
 	}

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -223,7 +223,7 @@ func (*fakeTxn) Rollback() error                         { return nil }
 // transaction.Factory fake
 type fakeFactory struct{}
 
-func (fakeFactory) NewDBTxn(ctx context.Context) (transaction.Txn, error) {
+func (fakeFactory) NewTxn(ctx context.Context) (transaction.Txn, error) {
 	return &fakeTxn{}, nil
 }
 

--- a/core/mapserver/mapserver.go
+++ b/core/mapserver/mapserver.go
@@ -58,7 +58,7 @@ func New(mapID int64, tree tree.Sparse, factory transaction.Factory, sths append
 }
 
 func (m *mapServer) signRoot(ctx context.Context) (smr *trillian.SignedMapRoot, retErr error) {
-	txn, err := m.factory.NewDBTxn(ctx)
+	txn, err := m.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +112,7 @@ func (m *mapServer) SetLeaves(ctx context.Context, in *trillian.SetMapLeavesRequ
 	if got, want := in.MapId, m.mapID; got != want {
 		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
 	}
-	txn, err := m.factory.NewDBTxn(ctx)
+	txn, err := m.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (m *mapServer) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesRequ
 		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
 	}
 
-	txn, err := m.factory.NewDBTxn(ctx)
+	txn, err := m.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -202,7 +202,7 @@ func (m *mapServer) GetSignedMapRoot(ctx context.Context, in *trillian.GetSigned
 		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
 	}
 
-	txn, err := m.factory.NewDBTxn(ctx)
+	txn, err := m.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -151,9 +151,9 @@ func (s *Signer) processMutations(ctx context.Context, txn transaction.Txn) (uin
 
 // CreateEpoch signs the current map head.
 func (s *Signer) CreateEpoch(ctx context.Context) error {
-	txn, err := s.factory.NewDBTxn(ctx)
+	txn, err := s.factory.NewTxn(ctx)
 	if err != nil {
-		return fmt.Errorf("NewDBTxn(): %v", err)
+		return fmt.Errorf("NewTxn(): %v", err)
 	}
 	if err := s.createEpoch(ctx, txn); err != nil {
 		if err := txn.Rollback(); err != nil {

--- a/core/transaction/txn.go
+++ b/core/transaction/txn.go
@@ -22,8 +22,8 @@ import (
 
 // Factory represents a transaction factory object.
 type Factory interface {
-	// NewDBTxn creates a new transaction object for database operations.
-	NewDBTxn(ctx context.Context) (Txn, error)
+	// NewTxn creates a new transaction object for database operations.
+	NewTxn(ctx context.Context) (Txn, error)
 }
 
 // Txn represents a transaction interface that provides atomic SQL database and

--- a/core/tree/sparse/verifier/verifier_test.go
+++ b/core/tree/sparse/verifier/verifier_test.go
@@ -59,7 +59,7 @@ func generateNbrData(t *testing.T, leaves []Leaf) ([][][]byte, error) {
 		return nil, err
 	}
 	for _, l := range leaves {
-		txn, err := factory.NewDBTxn(context.Background())
+		txn, err := factory.NewTxn(context.Background())
 		if err != nil {
 			return nil, err
 		}

--- a/impl/sql/mutations/mutations_test.go
+++ b/impl/sql/mutations/mutations_test.go
@@ -95,7 +95,7 @@ func fillDB(ctx context.Context, t *testing.T, m mutator.Mutation, factory *test
 }
 
 func write(ctx context.Context, m mutator.Mutation, factory *testutil.FakeFactory, mutation *tpb.SignedKV, outSequence uint64) error {
-	wtxn, err := factory.NewDBTxn(ctx)
+	wtxn, err := factory.NewTxn(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create write transaction: %v", err)
 	}
@@ -114,7 +114,7 @@ func write(ctx context.Context, m mutator.Mutation, factory *testutil.FakeFactor
 }
 
 func readRange(ctx context.Context, m mutator.Mutation, factory *testutil.FakeFactory, startSequence uint64, count int) (uint64, []*tpb.SignedKV, error) {
-	rtxn, err := factory.NewDBTxn(ctx)
+	rtxn, err := factory.NewTxn(ctx)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to create read transaction: %v", err)
 	}
@@ -129,7 +129,7 @@ func readRange(ctx context.Context, m mutator.Mutation, factory *testutil.FakeFa
 }
 
 func readAll(ctx context.Context, m mutator.Mutation, factory *testutil.FakeFactory, startSequence uint64) (uint64, []*tpb.SignedKV, error) {
-	rtxn, err := factory.NewDBTxn(ctx)
+	rtxn, err := factory.NewTxn(ctx)
 	if err != nil {
 		return 0, nil, fmt.Errorf("failed to create read transaction: %v", err)
 	}

--- a/impl/sql/sequenced/sequenced_test.go
+++ b/impl/sql/sequenced/sequenced_test.go
@@ -52,9 +52,9 @@ func TestGetLatest(t *testing.T) {
 		{0, 10, []byte("foo"), 10},
 		{0, 5, []byte("foo"), 10},
 	} {
-		txn, err := factory.NewDBTxn(context.Background())
+		txn, err := factory.NewTxn(context.Background())
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		if err := a.Write(txn, tc.mapID, tc.epoch, tc.data); err != nil {
@@ -65,9 +65,9 @@ func TestGetLatest(t *testing.T) {
 		}
 
 		var obj []byte
-		txn2, err := factory.NewDBTxn(context.Background())
+		txn2, err := factory.NewTxn(context.Background())
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		epoch, err := a.Latest(txn2, tc.mapID, &obj)
@@ -102,9 +102,9 @@ func TestWriteRead(t *testing.T) {
 		{0, 0, []byte("foo"), false},
 		{0, 1, []byte("foo"), true},
 	} {
-		txn, err := factory.NewDBTxn(context.Background())
+		txn, err := factory.NewTxn(context.Background())
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		err = a.Write(txn, tc.mapID, tc.epoch, tc.data)
@@ -116,9 +116,9 @@ func TestWriteRead(t *testing.T) {
 		}
 
 		if tc.want {
-			txn2, err := factory.NewDBTxn(context.Background())
+			txn2, err := factory.NewTxn(context.Background())
 			if err != nil {
-				t.Errorf("factory.NewDBTxn() failed: %v", err)
+				t.Errorf("factory.NewTxn() failed: %v", err)
 				continue
 			}
 			var readData []byte

--- a/impl/sql/sqlhist/sqlhist.go
+++ b/impl/sql/sqlhist/sqlhist.go
@@ -104,7 +104,7 @@ func New(ctx context.Context, mapID int64, factory transaction.Factory) (m *Map,
 	index, depth := tree.InvertBitString("")
 	nodeValue := hasher.HashEmpty(m.mapID, index, depth)
 
-	txn, err := factory.NewDBTxn(ctx)
+	txn, err := factory.NewTxn(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/impl/sql/sqlhist/sqlhist_test.go
+++ b/impl/sql/sqlhist/sqlhist_test.go
@@ -75,9 +75,9 @@ func TestQueueLeaf(t *testing.T) {
 		{strings.Repeat("C", 30), nil, false},            // errNilLeaf
 
 	} {
-		txn, err := factory.NewDBTxn(ctx)
+		txn, err := factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		err = tree.QueueLeaf(txn, []byte(tc.index), tc.leaf)
@@ -116,9 +116,9 @@ func TestEpochNumAdvance(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to create SQL history: %v", err)
 		}
-		txn, err := factory.NewDBTxn(ctx)
+		txn, err := factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		if tc.insert {
@@ -159,9 +159,9 @@ func TestQueueCommitRead(t *testing.T) {
 		dh("C000000000000000000000000000000000000000000000000000000000000000"),
 	} {
 		data := []byte{byte(i)}
-		txn, err := factory.NewDBTxn(ctx)
+		txn, err := factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		if err := m.QueueLeaf(txn, index, data); err != nil {
@@ -181,9 +181,9 @@ func TestQueueCommitRead(t *testing.T) {
 		}
 
 		// Create a new transaction.
-		txn, err = factory.NewDBTxn(ctx)
+		txn, err = factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		readData, err := m.ReadLeafAt(txn, index, epoch)
@@ -220,9 +220,9 @@ func TestReadNotFound(t *testing.T) {
 		{dh("2000000000000000000000000000000000000000000000000000000000000000")},
 		{dh("C000000000000000000000000000000000000000000000000000000000000000")},
 	} {
-		txn, err := factory.NewDBTxn(ctx)
+		txn, err := factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		var epoch int64 = 10
@@ -265,9 +265,9 @@ func TestReadPreviousEpochs(t *testing.T) {
 	}
 	for i, tc := range leafs {
 		data := []byte{byte(i)}
-		txn, err := factory.NewDBTxn(ctx)
+		txn, err := factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		if err := m.QueueLeaf(txn, tc.index, data); err != nil {
@@ -288,9 +288,9 @@ func TestReadPreviousEpochs(t *testing.T) {
 		}
 
 		for _, l := range leafs {
-			txn, err := factory.NewDBTxn(ctx)
+			txn, err := factory.NewTxn(ctx)
 			if err != nil {
-				t.Errorf("factory.NewDBTxn() failed: %v", err)
+				t.Errorf("factory.NewTxn() failed: %v", err)
 				continue
 			}
 			// Want success for leaves in previous epochs.
@@ -335,9 +335,9 @@ func TestAribtrayInsertOrder(t *testing.T) {
 		}
 		// Iterating over a map in Go is randomized.
 		for _, leaf := range leafs {
-			txn, err := factory.NewDBTxn(ctx)
+			txn, err := factory.NewTxn(ctx)
 			if err != nil {
-				t.Errorf("factory.NewDBTxn() failed: %v", err)
+				t.Errorf("factory.NewTxn() failed: %v", err)
 				continue
 			}
 			if err := m.QueueLeaf(txn, leaf.index, []byte(leaf.data)); err != nil {
@@ -352,9 +352,9 @@ func TestAribtrayInsertOrder(t *testing.T) {
 				continue
 			}
 		}
-		txn, err := factory.NewDBTxn(ctx)
+		txn, err := factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 			continue
 		}
 		r, err := m.ReadRootAt(txn, 10)
@@ -420,9 +420,9 @@ func TestNeighborDepth(t *testing.T) {
 		{m2, dh(defaultIndex[0]), 0},
 	} {
 
-		txn, err := factory.NewDBTxn(ctx)
+		txn, err := factory.NewTxn(ctx)
 		if err != nil {
-			t.Errorf("factory.NewDBTxn() failed: %v", err)
+			t.Errorf("factory.NewTxn() failed: %v", err)
 		}
 		nbrs, _ := tc.m.NeighborsAt(txn, tc.index, 0)
 		if got, want := len(nbrs), maxDepth; got != want {
@@ -444,9 +444,9 @@ func createTree(db *sql.DB, mapID int64, leafs []leaf) (*Map, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create map: %v", err)
 	}
-	txn, err := factory.NewDBTxn(ctx)
+	txn, err := factory.NewTxn(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("factory.NewDBTxn() failed: %v", err)
+		return nil, fmt.Errorf("factory.NewTxn() failed: %v", err)
 	}
 	for _, l := range leafs {
 		value := []byte(l.value)

--- a/impl/sql/testutil/testutil.go
+++ b/impl/sql/testutil/testutil.go
@@ -33,8 +33,8 @@ func NewFakeFactory(db *sql.DB) *FakeFactory {
 	return &FakeFactory{db}
 }
 
-// NewDBTxn creates a new database transaction.
-func (f *FakeFactory) NewDBTxn(ctx context.Context) (transaction.Txn, error) {
+// NewTxn creates a new database transaction.
+func (f *FakeFactory) NewTxn(ctx context.Context) (transaction.Txn, error) {
 	dbTxn, err := f.db.Begin()
 	if err != nil {
 		return nil, err

--- a/impl/transaction/txn.go
+++ b/impl/transaction/txn.go
@@ -16,50 +16,27 @@ package transaction
 
 import (
 	"database/sql"
-	"errors"
 	"fmt"
 
 	"github.com/google/keytransparency/core/transaction"
 
-	v3 "github.com/coreos/etcd/clientv3"
 	"golang.org/x/net/context"
-)
-
-var (
-	errInvalidIDs = errors.New("invalid identifiers (ids)")
 )
 
 // Factory represents a transaction factory for atomic database and queue ops.
 type Factory struct {
-	db     *sql.DB
-	client *v3.Client
+	db *sql.DB
 }
 
 // NewFactory creates a new instance of the transaction factory.
-func NewFactory(db *sql.DB, client *v3.Client) *Factory {
+func NewFactory(db *sql.DB) *Factory {
 	return &Factory{
-		db:     db,
-		client: client,
+		db: db,
 	}
 }
 
 // NewTxn creates a new transaction object.
-func (f *Factory) NewTxn(ctx context.Context, key string, rev int64) (transaction.Txn, error) {
-	// Create database transaction.
-	dbTxn, err := f.db.Begin()
-	if err != nil {
-		return nil, err
-	}
-
-	// Create queue transaction.
-	queueTxn := f.client.Txn(ctx)
-
-	// Create transaction object
-	return &txn{ctx, dbTxn, queueTxn, key, rev}, nil
-}
-
-// NewDBTxn creates a new transaction object to only support database operations.
-func (f *Factory) NewDBTxn(ctx context.Context) (transaction.Txn, error) {
+func (f *Factory) NewTxn(ctx context.Context) (transaction.Txn, error) {
 	// Create database transaction.
 	dbTxn, err := f.db.Begin()
 	if err != nil {
@@ -67,17 +44,16 @@ func (f *Factory) NewDBTxn(ctx context.Context) (transaction.Txn, error) {
 	}
 
 	// Create transaction object
-	return &txn{ctx, dbTxn, nil, "", -1}, nil
+	return &txn{
+		ctx:   ctx,
+		dbTxn: dbTxn,
+	}, nil
 }
 
 // txn provides a cross-domain atomic transactions between SQL database and etcd.
 type txn struct {
-	ctx      context.Context
-	dbTxn    *sql.Tx
-	queueTxn v3.Txn
-	// Key and rev are needed by the etcd queue for deletion.
-	key string
-	rev int64
+	ctx   context.Context
+	dbTxn *sql.Tx
 }
 
 // Prepare prepares an SQL statement to be executed.
@@ -85,45 +61,14 @@ func (t *txn) Prepare(query string) (*sql.Stmt, error) {
 	return t.dbTxn.Prepare(query)
 }
 
-// Commit commits the transaction. First, it deletes a queue item with matching
-// key and rev. If the delete failed due to any reason including not found key,
-// the database transaction is rolled back. Then, Commit attempts to commit the
-// DB transaction. An error is returned on failure and the mutation being
-// processed is lost. If this transaction object is created using NewDBTxn, only
-// the database transaction will be committed.
+// Commit commits the transaction. This implementation just wraps SQL database
+// transaction commit function.
 func (t *txn) Commit() error {
 	if err := t.ctx.Err(); err != nil {
 		if rbErr := t.Rollback(); rbErr != nil {
 			err = fmt.Errorf("%v, Rollback(): %v", err, rbErr)
 		}
 		return err
-	}
-
-	// Delete the queue element only if queueTxn is set.
-	if t.queueTxn != nil {
-		// cmp ensures that the key has the correct revision.
-		cmp := v3.Compare(v3.ModRevision(t.key), "=", t.rev)
-		req := v3.OpDelete(t.key)
-		resp, cErr := t.queueTxn.If(cmp).Then(req).Commit()
-		// If the key does not exist, queueTxn Commit returns a nil error
-		// but sets resp.Succeeded to false. Key does not exist can
-		// happen because another receiver might have already processed
-		// the item and deleted it from the queue.
-		var err error
-		switch {
-		case cErr != nil:
-			err = fmt.Errorf("queue commit failed: %v", cErr)
-		case !resp.Succeeded:
-			err = fmt.Errorf("queue commit failed: key not found")
-		}
-		// If commit failed or the item was not found, rollback DB
-		// transaction.
-		if err != nil {
-			if rbErr := t.Rollback(); rbErr != nil {
-				err = fmt.Errorf("%v, Rollback(): %v", err, rbErr)
-			}
-			return err
-		}
 	}
 
 	// Commit the database transaction. On failure, we lose the mutation.
@@ -133,7 +78,7 @@ func (t *txn) Commit() error {
 	return nil
 }
 
-// Rollback aborts the transaction. It only rolls back the database transaction.
+// Rollback aborts the transaction. It rolls back the database transaction.
 func (t *txn) Rollback() error {
 	return t.dbTxn.Rollback()
 }

--- a/impl/transaction/txn_test.go
+++ b/impl/transaction/txn_test.go
@@ -16,31 +16,14 @@ package transaction
 
 import (
 	"database/sql"
-	"fmt"
 	"testing"
-	"time"
 
-	"github.com/google/keytransparency/core/transaction"
-
-	v3 "github.com/coreos/etcd/clientv3"
-	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
-	"github.com/coreos/etcd/integration"
 	_ "github.com/mattn/go-sqlite3"
 	"golang.org/x/net/context"
 )
 
-var (
-	testKey     = "testkey"
-	testValue   = "testvalue"
-	testRev     = int64(1)
-	testPrefix  = "testprefix"
-	clusterSize = 3
-)
-
 type env struct {
 	db      *sql.DB
-	cluster *integration.ClusterV3
-	cli     *v3.Client
 	factory *Factory
 }
 
@@ -49,49 +32,19 @@ func newEnv(t *testing.T) *env {
 	if err != nil {
 		t.Fatalf("sql.Open(): %v", err)
 	}
-	c := integration.NewClusterV3(t, &integration.ClusterConfig{Size: clusterSize})
-	cli := c.Client(0)
-	factory := NewFactory(db, cli)
-
-	return &env{db, c, cli, factory}
-}
-
-// append prepares the test by adding a new queue item and creating a txn.
-func (e *env) append(ctx context.Context) (transaction.Txn, string, int64, error) {
-	// Add an item to the queue
-	var newKey string
-	var newRev int64
-	for {
-		newKey = fmt.Sprintf("%s/%v", testPrefix, time.Now().UnixNano())
-		req := v3.OpPut(newKey, testValue)
-		txnresp, err := e.cli.Txn(ctx).Then(req).Commit()
-		if err == nil {
-			newRev = txnresp.Header.Revision
-			break
-		} else if err != rpctypes.ErrDuplicateKey {
-			return nil, "", -1, fmt.Errorf("etcd transaction Commit() failed: %v", err)
-		}
-	}
-
-	// Create a transaction.
-	txn, err := e.factory.NewTxn(ctx, newKey, newRev)
-	if err != nil {
-		return nil, "", -1, fmt.Errorf("NewTxn failed: %v", err)
-	}
-
-	return txn, newKey, newRev, nil
+	factory := NewFactory(db)
+	return &env{db, factory}
 }
 
 func (e *env) Close(t *testing.T) {
 	e.db.Close()
-	e.cluster.Terminate(t)
 }
 
 func TestNewTxn(t *testing.T) {
 	env := newEnv(t)
 	defer env.Close(t)
 
-	if _, err := env.factory.NewTxn(context.Background(), testKey, testRev); err != nil {
+	if _, err := env.factory.NewTxn(context.Background()); err != nil {
 		t.Errorf("NewTxn failed: %v", err)
 	}
 }
@@ -101,7 +54,7 @@ func TestExpiredContext(t *testing.T) {
 	defer env.Close(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	txn, err := env.factory.NewTxn(ctx, testKey, testRev)
+	txn, err := env.factory.NewTxn(ctx)
 	if err != nil {
 		t.Fatalf("NewTxn failed: %v", err)
 	}
@@ -113,13 +66,13 @@ func TestExpiredContext(t *testing.T) {
 }
 
 func TestCommit(t *testing.T) {
+	ctx := context.Background()
 	env := newEnv(t)
 	defer env.Close(t)
 
-	// Add a new queue item and create a transaction.
-	txn, _, _, err := env.append(context.Background())
+	txn, err := env.factory.NewTxn(ctx)
 	if err != nil {
-		t.Fatalf("test preparation failed: %v", err)
+		t.Fatalf("NewTxn failed: %v", err)
 	}
 
 	// Commit the transaction. It should succeed.
@@ -128,42 +81,14 @@ func TestCommit(t *testing.T) {
 	}
 }
 
-func TestDeletedQueueItem(t *testing.T) {
-	env := newEnv(t)
-	defer env.Close(t)
-	ctx := context.Background()
-
-	// Add a new queue item and create a transaction.
-	txn, key, rev, err := env.append(ctx)
-	if err != nil {
-		t.Fatalf("test preparation failed: %v", err)
-	}
-
-	// Delete the added item.
-	cmp := v3.Compare(v3.ModRevision(key), "=", rev)
-	req := v3.OpDelete(key)
-	resp, err := env.cli.Txn(ctx).If(cmp).Then(req).Commit()
-	switch {
-	case err != nil:
-		t.Fatalf("etcd transaction Commit() failed: %v", err)
-	case !resp.Succeeded:
-		t.Fatal("cannot delete queue item, key not found")
-	}
-
-	// Commit the transaction. It should fail.
-	if err := txn.Commit(); err == nil {
-		t.Errorf("txn.Commit() unexpectedly succeeded")
-	}
-}
-
 func TestFailedDBTxnCommit(t *testing.T) {
+	ctx := context.Background()
 	env := newEnv(t)
 	defer env.Close(t)
 
-	// Add a new queue item and create a transaction.
-	txn, _, _, err := env.append(context.Background())
+	txn, err := env.factory.NewTxn(ctx)
 	if err != nil {
-		t.Fatalf("test preparation failed: %v", err)
+		t.Fatalf("NewTxn failed: %v", err)
 	}
 
 	// Rollback the database transaction
@@ -178,6 +103,7 @@ func TestFailedDBTxnCommit(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
+	ctx := context.Background()
 	env := newEnv(t)
 	defer env.Close(t)
 
@@ -188,10 +114,9 @@ func TestRollback(t *testing.T) {
 		{false, true},
 		{true, false},
 	} {
-		// Add a new queue item and create a transaction.
-		txn, _, _, err := env.append(context.Background())
+		txn, err := env.factory.NewTxn(ctx)
 		if err != nil {
-			t.Fatalf("test preparation failed: %v", err)
+			t.Fatalf("NewTxn failed: %v", err)
 		}
 
 		if tc.commit {

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -155,7 +155,7 @@ func NewEnv(t *testing.T) *Env {
 	}
 
 	// Common data structures.
-	factory := transaction.NewFactory(sqldb, nil)
+	factory := transaction.NewFactory(sqldb)
 	mutations, err := mutations.New(sqldb, mapID)
 	if err != nil {
 		log.Fatalf("Failed to create mutations object: %v", err)


### PR DESCRIPTION
This PR removes etcd dependency from the transaction object. Now, this object is simply a wrapper around SQL transaction. We still need it though to support multiple simultaneous database backend.

Closes #522.