### PR TITLE
Use mapserver in signer

### DIFF
--- a/cmd/keytransparency-client/grpcc/grpc_client.go
+++ b/cmd/keytransparency-client/grpcc/grpc_client.go
@@ -19,6 +19,7 @@ package grpcc
 
 import (
 	"bytes"
+	"crypto"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -89,7 +90,7 @@ type Client struct {
 }
 
 // New creates a new client.
-func New(mapID int64, client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier signatures.Verifier, log client.VerifyingLogClient) *Client {
+func New(mapID int64, client spb.KeyTransparencyServiceClient, vrf vrf.PublicKey, verifier crypto.PublicKey, log client.VerifyingLogClient) *Client {
 	return &Client{
 		cli:        client,
 		vrf:        vrf,

--- a/cmd/keytransparency-signer/backend.go
+++ b/cmd/keytransparency-signer/backend.go
@@ -38,7 +38,6 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/util"
-
 	"golang.org/x/net/context"
 )
 

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -109,6 +109,9 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, userID string, in
 	}
 	Vlog.Printf("✓ Sparse tree proof verified.")
 
+	// SignedMapRoot contains its own signature. To verify, we need to create a local
+	// copy of the object and return the object to the state it was in when signed
+	// by removing the signature from the object.
 	smr := *in.GetSmr()
 	smr.Signature = nil // Remove the signature from the object to be verified.
 	if err := tcrypto.VerifyObject(v.sig, smr, in.GetSmr().Signature); err != nil {

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -15,6 +15,7 @@
 package kt
 
 import (
+	"crypto"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,13 +23,13 @@ import (
 	"log"
 
 	"github.com/google/keytransparency/core/commitments"
-	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/tree/sparse"
 	tv "github.com/google/keytransparency/core/tree/sparse/verifier"
-	"github.com/google/trillian/client"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian/client"
+	tcrypto "github.com/google/trillian/crypto"
 	"golang.org/x/net/context"
 
 	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
@@ -46,14 +47,14 @@ var (
 type Verifier struct {
 	vrf  vrf.PublicKey
 	tree *tv.Verifier
-	sig  signatures.Verifier
+	sig  crypto.PublicKey
 	log  client.VerifyingLogClient
 }
 
 // New creates a new instance of the client verifier.
 func New(vrf vrf.PublicKey,
 	tree *tv.Verifier,
-	sig signatures.Verifier,
+	sig crypto.PublicKey,
 	log client.VerifyingLogClient) *Verifier {
 	return &Verifier{
 		vrf:  vrf,
@@ -108,9 +109,9 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, userID string, in
 	}
 	Vlog.Printf("✓ Sparse tree proof verified.")
 
-	sig := in.GetSmr().Signature
-	in.GetSmr().Signature = nil // Remove the signature from the object to be verified.
-	if err := v.sig.Verify(in.GetSmr(), sig); err != nil {
+	smr := *in.GetSmr()
+	smr.Signature = nil // Remove the signature from the object to be verified.
+	if err := tcrypto.VerifyObject(v.sig, smr, in.GetSmr().Signature); err != nil {
 		Vlog.Printf("✗ Signed Map Head signature verification failed.")
 		return fmt.Errorf("sig.Verify(SMR): %v", err)
 	}

--- a/core/mapserver/mapserver.go
+++ b/core/mapserver/mapserver.go
@@ -149,33 +149,5 @@ func (m *mapServer) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesRequ
 
 // GetSignedMapRoot returns the requested MapRoot.
 func (m *mapServer) GetSignedMapRoot(ctx context.Context, in *trillian.GetSignedMapRootRequest, opts ...grpc.CallOption) (resp *trillian.GetSignedMapRootResponse, retErr error) {
-	if got, want := in.MapId, m.mapID; got != want {
-		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
-	}
-
-	txn, err := m.factory.NewTxn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if retErr != nil {
-			if rbErr := txn.Rollback(); rbErr != nil {
-				retErr = fmt.Errorf("%v, Rollback(): %v", retErr, rbErr)
-			}
-		}
-	}()
-
-	// Get current epoch.
-	var root trillian.SignedMapRoot
-	if _, err := m.sths.Latest(txn, in.MapId, &root); err != nil {
-		return nil, err
-	}
-
-	if err := txn.Commit(); err != nil {
-		return nil, err
-	}
-
-	return &trillian.GetSignedMapRootResponse{
-		MapRoot: &root,
-	}, nil
+	return m.readonly.GetSignedMapRoot(ctx, in)
 }

--- a/core/mapserver/mapserver.go
+++ b/core/mapserver/mapserver.go
@@ -82,13 +82,16 @@ func (m *mapServer) signRoot(ctx context.Context) (smr *trillian.SignedMapRoot, 
 		return nil, fmt.Errorf("ReadRootAt(%v): %v", epoch, err)
 	}
 
-	smr = &trillian.SignedMapRoot{
+	smr := &trillian.SignedMapRoot{
 		MapId:          m.mapID,
-		MapRevision:    epoch,
+		TimestampNanos: s.clock.Now().UnixNano(),
 		RootHash:       root,
-		TimestampNanos: m.clock.Now().Unix(),
-		// TODO: Add mutation high watermark?
+		MapRevision:    epoch,
+		Metadata: &trillian.MapperMetadata{
+			HighestFullyCompletedSeq: maxSequence,
+		},
 	}
+
 	sig, err := m.signer.SignObject(smr)
 	if err != nil {
 		return nil, err

--- a/core/mapserver/mapserver.go
+++ b/core/mapserver/mapserver.go
@@ -36,28 +36,27 @@ import (
 
 // mapServer implements TrilianMap functionality.
 type mapServer struct {
-	mapID   int64
-	tree    tree.Sparse
-	factory transaction.Factory
-	sths    appender.Local
-	signer  *tcrypto.Signer
-	clock   util.TimeSource
+	readonly
+	signer *tcrypto.Signer
+	clock  util.TimeSource
 }
 
 // New returns a TrillianMapClient.
 func New(mapID int64, tree tree.Sparse, factory transaction.Factory, sths appender.Local,
 	signer crypto.Signer, clock util.TimeSource) trillian.TrillianMapClient {
 	return &mapServer{
-		mapID:   mapID,
-		tree:    tree,
-		factory: factory,
-		sths:    sths,
-		signer:  tcrypto.NewSHA256Signer(signer),
-		clock:   clock,
+		readonly: readonly{
+			mapID:   mapID,
+			tree:    tree,
+			factory: factory,
+			sths:    sths,
+		},
+		signer: tcrypto.NewSHA256Signer(signer),
+		clock:  clock,
 	}
 }
 
-func (m *mapServer) signRoot(ctx context.Context) (smr *trillian.SignedMapRoot, retErr error) {
+func (m *mapServer) signRoot(ctx context.Context, metadata *trillian.MapperMetadata) (smr *trillian.SignedMapRoot, retErr error) {
 	txn, err := m.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, err
@@ -82,14 +81,12 @@ func (m *mapServer) signRoot(ctx context.Context) (smr *trillian.SignedMapRoot, 
 		return nil, fmt.Errorf("ReadRootAt(%v): %v", epoch, err)
 	}
 
-	smr := &trillian.SignedMapRoot{
+	smr = &trillian.SignedMapRoot{
 		MapId:          m.mapID,
-		TimestampNanos: s.clock.Now().UnixNano(),
+		TimestampNanos: m.clock.Now().UnixNano(),
 		RootHash:       root,
 		MapRevision:    epoch,
-		Metadata: &trillian.MapperMetadata{
-			HighestFullyCompletedSeq: maxSequence,
-		},
+		Metadata:       metadata,
 	}
 
 	sig, err := m.signer.SignObject(smr)
@@ -135,7 +132,7 @@ func (m *mapServer) SetLeaves(ctx context.Context, in *trillian.SetMapLeavesRequ
 		return nil, err
 	}
 
-	smh, err := m.signRoot(ctx)
+	smh, err := m.signRoot(ctx, in.MapperData)
 	if err != nil {
 		return nil, fmt.Errorf("signRoot(): %v", err)
 	}
@@ -147,56 +144,7 @@ func (m *mapServer) SetLeaves(ctx context.Context, in *trillian.SetMapLeavesRequ
 
 // GetLeaves returns the requested leaves.
 func (m *mapServer) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesRequest, opts ...grpc.CallOption) (resp *trillian.GetMapLeavesResponse, retErr error) {
-	if got, want := in.MapId, m.mapID; got != want {
-		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
-	}
-
-	txn, err := m.factory.NewTxn(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if retErr != nil {
-			if rbErr := txn.Rollback(); rbErr != nil {
-				retErr = fmt.Errorf("%v, Rollback(): %v", retErr, rbErr)
-			}
-		}
-	}()
-
-	// Get current epoch.
-	var root trillian.SignedMapRoot
-	if _, err := m.sths.Latest(txn, in.MapId, &root); err != nil {
-		return nil, err
-	}
-
-	// ReadLeavesAtEpoch.
-	inclusions := make([]*trillian.MapLeafInclusion, 0, len(in.Index))
-	for _, index := range in.Index {
-		leafData, err := m.tree.ReadLeafAt(txn, index, root.MapRevision)
-		if err != nil {
-			return nil, err
-		}
-		nbrs, err := m.tree.NeighborsAt(txn, index, root.MapRevision)
-		if err != nil {
-			return nil, err
-		}
-		inclusions = append(inclusions, &trillian.MapLeafInclusion{
-			Leaf: &trillian.MapLeaf{
-				Index:     index,
-				LeafValue: leafData,
-			},
-			Inclusion: nbrs,
-		})
-	}
-
-	if err := txn.Commit(); err != nil {
-		return nil, err
-	}
-
-	return &trillian.GetMapLeavesResponse{
-		MapLeafInclusion: inclusions,
-		MapRoot:          &root,
-	}, nil
+	return m.readonly.GetLeaves(ctx, in)
 }
 
 // GetSignedMapRoot returns the requested MapRoot.

--- a/core/mapserver/readonly.go
+++ b/core/mapserver/readonly.go
@@ -45,6 +45,7 @@ func NewReadonly(mapID int64, tree tree.Sparse, factory transaction.Factory, sth
 }
 
 func (r *readonly) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesRequest, opts ...grpc.CallOption) (resp *trillian.GetMapLeavesResponse, retErr error) {
+	// TODO: remove when multi-tennant maps are supported.
 	if got, want := in.MapId, r.mapID; got != want {
 		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
 	}
@@ -104,7 +105,7 @@ func (r *readonly) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesReque
 }
 
 func (r *readonly) SetLeaves(ctx context.Context, in *trillian.SetMapLeavesRequest, opts ...grpc.CallOption) (*trillian.SetMapLeavesResponse, error) {
-	panic("not implemented")
+	panic("SetLeaves not implmeneted in read only object")
 }
 
 func (r *readonly) GetSignedMapRoot(ctx context.Context, in *trillian.GetSignedMapRootRequest, opts ...grpc.CallOption) (resp *trillian.GetSignedMapRootResponse, retErr error) {

--- a/core/mapserver/readonly.go
+++ b/core/mapserver/readonly.go
@@ -1,0 +1,112 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapserver
+
+import (
+	"fmt"
+
+	"github.com/google/keytransparency/core/appender"
+	"github.com/google/keytransparency/core/transaction"
+	"github.com/google/keytransparency/core/tree"
+
+	"github.com/google/trillian"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+// readonly implements a readonly mapserver frontend.
+type readonly struct {
+	mapID   int64
+	tree    tree.Sparse
+	factory transaction.Factory
+	sths    appender.Local
+}
+
+// NewReadonly returns a readonly view of the sparse merkle tree.
+func NewReadonly(mapID int64, tree tree.Sparse, factory transaction.Factory, sths appender.Local) trillian.TrillianMapClient {
+	return &readonly{
+		mapID:   mapID,
+		tree:    tree,
+		factory: factory,
+		sths:    sths,
+	}
+}
+
+func (r *readonly) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesRequest, opts ...grpc.CallOption) (resp *trillian.GetMapLeavesResponse, retErr error) {
+	if got, want := in.MapId, r.mapID; got != want {
+		return nil, fmt.Errorf("Wrong Map ID: %v, want %v", got, want)
+	}
+
+	txn, err := r.factory.NewTxn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			if rbErr := txn.Rollback(); rbErr != nil {
+				retErr = fmt.Errorf("%v, Rollback(): %v", retErr, rbErr)
+			}
+		}
+	}()
+
+	var root trillian.SignedMapRoot
+	if in.Revision == -1 {
+		// Get current epoch.
+		if _, err := r.sths.Latest(txn, in.MapId, &root); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := r.sths.Read(txn, in.MapId, in.Revision, &root); err != nil {
+			return nil, err
+		}
+	}
+
+	// ReadLeavesAtEpoch.
+	inclusions := make([]*trillian.MapLeafInclusion, 0, len(in.Index))
+	for _, index := range in.Index {
+		leafData, err := r.tree.ReadLeafAt(txn, index, root.MapRevision)
+		if err != nil {
+			return nil, err
+		}
+		nbrs, err := r.tree.NeighborsAt(txn, index, root.MapRevision)
+		if err != nil {
+			return nil, err
+		}
+		inclusions = append(inclusions, &trillian.MapLeafInclusion{
+			Leaf: &trillian.MapLeaf{
+				Index:     index,
+				LeafValue: leafData,
+			},
+			Inclusion: nbrs,
+		})
+	}
+
+	if err := txn.Commit(); err != nil {
+		return nil, err
+	}
+
+	return &trillian.GetMapLeavesResponse{
+		MapLeafInclusion: inclusions,
+		MapRoot:          &root,
+	}, nil
+}
+
+func (r *readonly) SetLeaves(ctx context.Context, in *trillian.SetMapLeavesRequest, opts ...grpc.CallOption) (*trillian.SetMapLeavesResponse, error) {
+	panic("not implemented")
+}
+
+func (r *readonly) GetSignedMapRoot(ctx context.Context, in *trillian.GetSignedMapRootRequest, opts ...grpc.CallOption) (*trillian.GetSignedMapRootResponse, error) {
+	panic("not implemented")
+}

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -174,7 +174,9 @@ func (s *Signer) CreateEpoch(ctx context.Context) error {
 		return err
 	}
 
-	// TODO: verify inclusion proofs?
+	// Trust the leaf values provided by the map server.
+	// If the map server is run by an untrusted entity, perform inclusion
+	// and signature verification here.
 	leaves := make([]*trillian.MapLeaf, 0, len(getResp.MapLeafInclusion))
 	for _, m := range getResp.MapLeafInclusion {
 		leaves = append(leaves, m.Leaf)

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/google/trillian"
 	"golang.org/x/net/context"
+
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 )
 
 // Signer processes mutations and sends them to the trillian map.
@@ -71,7 +73,7 @@ func (s *Signer) StartSigning(ctx context.Context, interval time.Duration) {
 
 // newMutations returns a list of mutations to process and highest sequence number returned.
 func (s *Signer) newMutations(ctx context.Context, startSequence int64) ([]*tpb.SignedKV, int64, error) {
-	txn, err := s.factory.NewDBTxn(ctx)
+	txn, err := s.factory.NewTxn(ctx)
 	if err != nil {
 		return nil, 0, fmt.Errorf("NewDBTxn(): %v", err)
 	}

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -260,7 +260,8 @@ func (e *Env) setupHistory(ctx context.Context, userID string, signers []signatu
 	// did not submit a new profile in that epoch, or contains the profile
 	// that the user is submitting. The user profile history contains the
 	// following profiles:
-	// [nil, nil, 1, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 5, 5, 6, 6, 5, 7, 7].  // Note that profile 5 is submitted twice by the user to test that
+	// [nil, nil, 1, 2, 2, 2, 3, 3, 4, 5, 5, 5, 5, 5, 5, 6, 6, 5, 7, 7].
+	// Note that profile 5 is submitted twice by the user to test that
 	// filtering case.
 	for i, p := range []*tpb.Profile{
 		nil, nil, cp(1), cp(2), nil, nil, cp(3), nil,


### PR DESCRIPTION
Use an internal implementation of the trillian map server. 
In the keyserver:
- Use GetLeaves to retrieve leaf values and inclusion proofs.
- Use GetSignedMapRoot to retrieve the current epoch.  (Replaces sths object)

In the signer:
- Collect all mutations that have occurred since the last epoch.
- GetLeaves for the respective indexes
- Verify and Apply the mutations.
- Call SetLeaves to create a new epoch with the new values. 

TODO:
- Pass an expected epoch field to make sure that the read/write cycle to the mapserver is atomic. google/trillian#559
- Use mastership election to make sure that only one signer is active at any point. #565

Contributes to #486
