### PR TITLE
Ensure VRF uniqueness

### DIFF
--- a/core/crypto/vrf/p256/p256.go
+++ b/core/crypto/vrf/p256/p256.go
@@ -90,14 +90,6 @@ func H1(m []byte) (x, y *big.Int) {
 var one = big.NewInt(1)
 
 // H2 hashes to an integer [1,N-1]
-// TODO: replace with first 128 bits of SHA256.
-// To cheat, find new m that produces same output.
-// To cheet, find a new m that produces a partiuclar output.
-//   close to fix x find x' s.t H(x') == H(x)
-// For 128 bit security only need 128 bits.
-// NSEC5 - This only needs to be SHA256[:]
-// Only need uniqueness. Non-uniformity is not a requirement.
-// Truncated SHA.
 func H2(m []byte) *big.Int {
 	// NIST SP 800-90A § A.5.1: Simple discard method.
 	byteLen := (params.BitSize + 7) >> 3

--- a/core/crypto/vrf/p256/p256_test.go
+++ b/core/crypto/vrf/p256/p256_test.go
@@ -53,7 +53,6 @@ func TestH1(t *testing.T) {
 }
 
 func TestH2(t *testing.T) {
-	t.Skip("Too long")
 	l := 32
 	for i := 0; i < 10000; i++ {
 		m := make([]byte, 100)

--- a/core/crypto/vrf/p256/p256_test.go
+++ b/core/crypto/vrf/p256/p256_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 )
 
+// TODO: Add test vectors
+
 func TestH1(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		m := make([]byte, 100)


### PR DESCRIPTION
VRF uniqueness could be violated because the VRF output itself was not
included in the the computation of `s`, the commitment to the VRF and
zero knowledge proof. Fixes #567. 

Other changes also included in this PR: 
- H2(.., m, ..) -> H2(.., H1(m),..) for better alignment with the NSEC5 VRF (sec 3.5).  This change was suggested by Leonid Reyzin and approved by @jcb82 (the CONIKS paper has been updated).
- Variable name notation has been updated for better code clarity. 
- Add test vectors #613 

References:
- [NSEC5 Paper](https://eprint.iacr.org/2017/099.pdf)
- [CONIKS Papser](https://eprint.iacr.org/2014/1004.pdf)  