### PR TITLE
Fix broken build after Trillian update

### DIFF
--- a/core/mapserver/mapserver.go
+++ b/core/mapserver/mapserver.go
@@ -151,3 +151,8 @@ func (m *mapServer) GetLeaves(ctx context.Context, in *trillian.GetMapLeavesRequ
 func (m *mapServer) GetSignedMapRoot(ctx context.Context, in *trillian.GetSignedMapRootRequest, opts ...grpc.CallOption) (resp *trillian.GetSignedMapRootResponse, retErr error) {
 	return m.readonly.GetSignedMapRoot(ctx, in)
 }
+
+// GetSignedMapRootByRevision returns the requested MapRoot for a given revision.
+func (m *mapServer) GetSignedMapRootByRevision(ctx context.Context, in *trillian.GetSignedMapRootByRevisionRequest, opts ...grpc.CallOption) (resp *trillian.GetSignedMapRootResponse, retErr error) {
+	return m.readonly.GetSignedMapRootByRevision(ctx, in)
+}


### PR DESCRIPTION
After adding `GetSignedMapRootByRevision` to Trillian and running `go get -u ./...` in Key Transparency, some breakages needed to be fixed.