### PR TITLE
Add End Sequence to ReadRange API

### DIFF
--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -217,7 +217,7 @@ func (fakeFactory) NewTxn(ctx context.Context) (transaction.Txn, error) {
 // mutator.Mutation fake
 type fakeMutation struct{}
 
-func (fakeMutation) ReadRange(txn transaction.Txn, startSequence uint64, count int) (uint64, []*tpb.SignedKV, error) {
+func (fakeMutation) ReadRange(txn transaction.Txn, startSequence uint64, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error) {
 	return 0, nil, nil
 }
 

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -217,7 +217,7 @@ func (fakeFactory) NewTxn(ctx context.Context) (transaction.Txn, error) {
 // mutator.Mutation fake
 type fakeMutation struct{}
 
-func (fakeMutation) ReadRange(txn transaction.Txn, startSequence uint64, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error) {
+func (fakeMutation) ReadRange(txn transaction.Txn, startSequence, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error) {
 	return 0, nil, nil
 }
 

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -61,7 +61,7 @@ type Mutation interface {
 	// count. Note that startSequence is not included in the result.
 	// ReadRange stops when endSequence or count is reached, whichever comes
 	// first. ReadRange also returns the maximum sequence number read.
-	ReadRange(txn transaction.Txn, startSequence uint64, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error)
+	ReadRange(txn transaction.Txn, startSequence, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error)
 	// ReadAll reads all mutations starting from the given sequence number.
 	// Note that startSequence is not included in the result. ReadAll also
 	// returns the maximum sequence number read.

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -59,8 +59,9 @@ type Mutation interface {
 	// ReadRange reads all mutations for a specific given mapID and sequence
 	// range. The range is identified by a starting sequence number and a
 	// count. Note that startSequence is not included in the result.
-	// ReadRange also returns the maximum sequence number read.
-	ReadRange(txn transaction.Txn, startSequence uint64, count int) (uint64, []*tpb.SignedKV, error)
+	// ReadRange stops when endSequence or count is reached, whichever comes
+	// first. ReadRange also returns the maximum sequence number read.
+	ReadRange(txn transaction.Txn, startSequence uint64, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error)
 	// ReadAll reads all mutations starting from the given sequence number.
 	// Note that startSequence is not included in the result. ReadAll also
 	// returns the maximum sequence number read.

--- a/impl/sql/mutations/mutations.go
+++ b/impl/sql/mutations/mutations.go
@@ -70,7 +70,7 @@ func New(db *sql.DB, mapID int64) (mutator.Mutation, error) {
 // startSequence is not included in the result. ReadRange stops when endSequence
 // or count is reached, whichever comes first. ReadRange also returns the maximum
 // sequence number read.
-func (m *mutations) ReadRange(txn transaction.Txn, startSequence uint64, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error) {
+func (m *mutations) ReadRange(txn transaction.Txn, startSequence, endSequence uint64, count int32) (uint64, []*tpb.SignedKV, error) {
 	readStmt, err := txn.Prepare(readRangeExpr)
 	if err != nil {
 		return 0, nil, err


### PR DESCRIPTION
This allows callers to specify both count and end sequence in mutations `ReadRange` API. The returned range stops when either count or end sequence is reached, whichever comes first.

Partial #59.