### PR TITLE
Create a dev package to hold dev.Zero

### DIFF
--- a/core/crypto/dev/dev.go
+++ b/core/crypto/dev/dev.go
@@ -1,0 +1,33 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dev provides pseudo dev/* readers and writers.
+package dev
+
+import "io"
+
+// Zeros mimics /dev/zero by writing 0's
+var Zeros io.Reader = devZero{}
+
+// DevZero is an io.Reader that returns 0's
+type devZero struct{}
+
+// Read returns 0's
+func (devZero) Read(b []byte) (n int, err error) {
+	for i := range b {
+		b[i] = 0
+	}
+
+	return len(b), nil
+}

--- a/core/crypto/dev/dev_test.go
+++ b/core/crypto/dev/dev_test.go
@@ -1,0 +1,44 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestZeros(t *testing.T) {
+	for i, tc := range []struct {
+		in []byte
+	}{
+		{nil},
+		{[]byte{}},
+		{[]byte{1}},
+		{[]byte(strings.Repeat("A", 300))},
+	} {
+		n, err := Zeros.Read(tc.in)
+		if err != nil {
+			t.Errorf("%v: Zeros.Read(%v): _, %v, want nil", i, tc.in, err)
+		}
+		if got, want := n, len(tc.in); got != want {
+			t.Errorf("%v: Zeros.Read(%v): %v, want %v", i, tc.in, got, want)
+		}
+		for j, c := range tc.in {
+			if got, want := c, byte(0); got != want {
+				t.Errorf("%v: Zeros.Read(%v)[%v]: %v, want %v", i, tc.in, j, got, want)
+			}
+		}
+	}
+}

--- a/core/crypto/keymaster/signer_test.go
+++ b/core/crypto/keymaster/signer_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/pem"
 	"testing"
 
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 )
 
@@ -31,7 +32,7 @@ csFaQhohkiCEthY51Ga6Xa+ggn+eTZtf9Q==
 )
 
 func TestSignerFromPEM(t *testing.T) {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	for _, priv := range []string{
 		testPrivKey,
 	} {
@@ -43,7 +44,7 @@ func TestSignerFromPEM(t *testing.T) {
 }
 
 func TestSignerFromKey(t *testing.T) {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	for _, priv := range []string{
 		testPrivKey,
 	} {

--- a/core/crypto/keymaster/verifier_test.go
+++ b/core/crypto/keymaster/verifier_test.go
@@ -29,18 +29,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUxX42oxJ5voiNfbjoz8UgsGqh1bD
 -----END PUBLIC KEY-----`
 )
 
-// DevZero is an io.Reader that returns 0's.
-type DevZero struct{}
-
-// Read returns 0's.
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
-}
-
 func TestVerifierFromPEM(t *testing.T) {
 	for _, pub := range []string{
 		testPubKey,

--- a/core/crypto/signatures/p256/ecdsa_p256_test.go
+++ b/core/crypto/signatures/p256/ecdsa_p256_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 )
 
@@ -40,20 +41,8 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUxX42oxJ5voiNfbjoz8UgsGqh1bD
 -----END PUBLIC KEY-----`
 )
 
-// DevZero is an io.Reader that returns 0's
-type DevZero struct{}
-
-// Read returns 0's
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
-}
-
 func newSigner(t *testing.T, pemKey []byte) signatures.Signer {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	p, _ := pem.Decode(pemKey)
 	if p == nil {
 		t.Fatalf("no PEM block found")
@@ -229,7 +218,7 @@ func flipBit(a []byte, pos uint) []byte {
 }
 
 func TestGeneratePEMs(t *testing.T) {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	skPEM, pkPEM, err := GeneratePEMs()
 	if err != nil {
 		t.Fatalf("GeneratePEMs() failed: %v", err)

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
 	"github.com/google/keytransparency/core/mutator"
@@ -55,18 +56,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJKDbR4uyhSMXW80x02NtYRUFlMQb
 LOA+tLe/MbwZ69SRdG6Rx92f9tbC6dz7UVsyI7vIjS+961sELA6FeR91lA==
 -----END PUBLIC KEY-----`
 )
-
-// DevZero is an io.Reader that returns 0's
-type DevZero struct{}
-
-// Read returns 0's
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
-}
 
 func createEntry(commitment []byte, pkeys []string) ([]byte, error) {
 	authKeys := make([]*tpb.PublicKey, len(pkeys))
@@ -122,7 +111,7 @@ func prepareMutation(key []byte, entryData []byte, previous []byte, signers []si
 }
 
 func signersFromPEMs(t *testing.T, keys [][]byte) []signatures.Signer {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	signers := make([]signatures.Signer, 0, len(keys))
 	for _, key := range keys {
 		signer, err := factory.NewSignerFromPEM(key)

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/keytransparency/cmd/keytransparency-client/grpcc"
 	"github.com/google/keytransparency/core/authentication"
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
 
@@ -64,7 +65,7 @@ var (
 )
 
 func createSigner(t *testing.T, privKey string) signatures.Signer {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	signer, err := factory.NewSignerFromPEM([]byte(privKey))
 	if err != nil {
 		t.Fatalf("factory.NewSigner failed: %v", err)

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/keytransparency/core/admin"
 	"github.com/google/keytransparency/core/appender"
 	"github.com/google/keytransparency/core/authentication"
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/crypto/vrf/p256"
@@ -104,7 +105,7 @@ K8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5AV2WCmStBt4N2Dx+7BrycJFbxhW
 f5JqSoyp0uiL8LeNYyj5vgklK8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 -----END PUBLIC KEY-----`
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	sig, err := keys.NewFromPrivatePEM(sigPriv, "")
 	if err != nil {
 		return nil, nil, err
@@ -136,18 +137,6 @@ f5JqSoyp0uiL8LeNYyj5vgklK8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 		return nil, nil, err
 	}
 	return vrf, verfier, nil
-}
-
-// DevZero is an io.Reader that returns 0's
-type DevZero struct{}
-
-// Read returns 0's
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
 }
 
 // NewEnv sets up common resources for tests.


### PR DESCRIPTION
Some cryptographic tests need a repeatable source of randomness to
make tests repeatable and test vectors meaningful. Multiple tests
had a DevZero object. Rather than repeating this object over and over,
it makes sense to have one, tested version of it.