### PR TITLE
Add test vectors to crypto/commitment

### DIFF
--- a/core/crypto/commitments/commitments.go
+++ b/core/crypto/commitments/commitments.go
@@ -46,6 +46,8 @@ var (
 	fixedKey = []byte{0x19, 0x6e, 0x7e, 0x52, 0x84, 0xa7, 0xef, 0x93, 0x0e, 0xcb, 0x9a, 0x19, 0x78, 0x74, 0x97, 0x55}
 	// ErrInvalidCommitment occurs when the commitment doesn't match the profile.
 	ErrInvalidCommitment = errors.New("invalid commitment")
+	// Rand is the PRNG reader. It can be overwritten in tests.
+	Rand = rand.Reader
 )
 
 // Committer saves cryptographic commitments.
@@ -60,7 +62,7 @@ type Committer interface {
 func Commit(userID, appID string, data []byte) ([]byte, *tpb.Committed, error) {
 	// Generate commitment nonce.
 	nonce := make([]byte, commitmentKeyLen)
-	if _, err := rand.Read(nonce); err != nil {
+	if _, err := Rand.Read(nonce); err != nil {
 		return nil, nil, err
 	}
 

--- a/core/crypto/commitments/commitments_test.go
+++ b/core/crypto/commitments/commitments_test.go
@@ -59,7 +59,11 @@ func TestVectors(t *testing.T) {
 		userID, appID, data string
 		want                []byte
 	}{
+		{"", "", "", dh("0698789c7beed09e93848e4df08be5c911de534d286abcbf69359debe4c62bc2")},
 		{"foo", "app", "bar", dh("064c8933f50f897e8b179065c6b3ec13e9d093337c6d403c77e3ed1701378ed6")},
+		{"foo1", "app", "bar", dh("77015921f7fe584e1b5866a32ab9f305715c4e0241581d41f66ee34b24cdb566")},
+		{"foo", "app1", "bar", dh("e7337229d7747cc2c9a83ee08adbec712f4acafd1b72258bbebf74637de987b7")},
+		{"foo", "app", "bar1", dh("0fa2d7d53552e0871564c0e82ad394e72476b75f7fc77f40e2080af7f33d66eb")},
 	} {
 		k, c, err := Commit(tc.userID, tc.appID, []byte(tc.data))
 		if err != nil {

--- a/core/crypto/commitments/commitments_test.go
+++ b/core/crypto/commitments/commitments_test.go
@@ -17,7 +17,11 @@
 package commitments
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
+
+	"github.com/google/keytransparency/core/crypto/dev"
 )
 
 func TestCommit(t *testing.T) {
@@ -44,4 +48,40 @@ func TestCommit(t *testing.T) {
 			t.Errorf("Verify(%v, %v, %x, %x): %v, want %v", tc.userID, tc.appID, k, c, err, tc.want)
 		}
 	}
+}
+
+func TestVectors(t *testing.T) {
+	// Use a constant key of zero to obtain consistent test vectors.
+	// Real commitment library MUST use random keys.
+	Rand = dev.Zeros
+	zeroKey := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	for _, tc := range []struct {
+		userID, appID, data string
+		want                []byte
+	}{
+		{"foo", "app", "bar", dh("064c8933f50f897e8b179065c6b3ec13e9d093337c6d403c77e3ed1701378ed6")},
+	} {
+		k, c, err := Commit(tc.userID, tc.appID, []byte(tc.data))
+		if err != nil {
+			t.Errorf("Commit(%v, %x): %v", tc.userID, tc.data, err)
+		}
+		if got, want := k, tc.want; !bytes.Equal(got, want) {
+			t.Errorf("Commit(%v, %x): %x ,want %x", tc.userID, tc.data, got, want)
+		}
+		if got, want := c.Key, zeroKey; !bytes.Equal(got, want) {
+			t.Errorf("Commit(%v, %x).Key: %x ,want %x", tc.userID, tc.data, got, want)
+		}
+		if got, want := c.Data, []byte(tc.data); !bytes.Equal(got, want) {
+			t.Errorf("Commit(%v, %x).Data: %x ,want %x", tc.userID, tc.data, got, want)
+		}
+	}
+}
+
+// Hex to Bytes
+func dh(h string) []byte {
+	result, err := hex.DecodeString(h)
+	if err != nil {
+		panic("DecodeString failed")
+	}
+	return result
 }

--- a/core/crypto/dev/dev.go
+++ b/core/crypto/dev/dev.go
@@ -1,0 +1,33 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package dev provides pseudo dev/* readers and writers.
+package dev
+
+import "io"
+
+// Zeros mimics /dev/zero by writing 0's
+var Zeros io.Reader = devZero{}
+
+// DevZero is an io.Reader that returns 0's
+type devZero struct{}
+
+// Read returns 0's
+func (devZero) Read(b []byte) (n int, err error) {
+	for i := range b {
+		b[i] = 0
+	}
+
+	return len(b), nil
+}

--- a/core/crypto/dev/dev_test.go
+++ b/core/crypto/dev/dev_test.go
@@ -1,0 +1,44 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestZeros(t *testing.T) {
+	for i, tc := range []struct {
+		in []byte
+	}{
+		{nil},
+		{[]byte{}},
+		{[]byte{1}},
+		{[]byte(strings.Repeat("A", 300))},
+	} {
+		n, err := Zeros.Read(tc.in)
+		if err != nil {
+			t.Errorf("%v: Zeros.Read(%v): _, %v, want nil", i, tc.in, err)
+		}
+		if got, want := n, len(tc.in); got != want {
+			t.Errorf("%v: Zeros.Read(%v): %v, want %v", i, tc.in, got, want)
+		}
+		for j, c := range tc.in {
+			if got, want := c, byte(0); got != want {
+				t.Errorf("%v: Zeros.Read(%v)[%v]: %v, want %v", i, tc.in, j, got, want)
+			}
+		}
+	}
+}

--- a/core/crypto/keymaster/signer_test.go
+++ b/core/crypto/keymaster/signer_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/pem"
 	"testing"
 
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 )
 
@@ -31,7 +32,7 @@ csFaQhohkiCEthY51Ga6Xa+ggn+eTZtf9Q==
 )
 
 func TestSignerFromPEM(t *testing.T) {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	for _, priv := range []string{
 		testPrivKey,
 	} {
@@ -43,7 +44,7 @@ func TestSignerFromPEM(t *testing.T) {
 }
 
 func TestSignerFromKey(t *testing.T) {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	for _, priv := range []string{
 		testPrivKey,
 	} {

--- a/core/crypto/keymaster/verifier_test.go
+++ b/core/crypto/keymaster/verifier_test.go
@@ -29,18 +29,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUxX42oxJ5voiNfbjoz8UgsGqh1bD
 -----END PUBLIC KEY-----`
 )
 
-// DevZero is an io.Reader that returns 0's.
-type DevZero struct{}
-
-// Read returns 0's.
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
-}
-
 func TestVerifierFromPEM(t *testing.T) {
 	for _, pub := range []string{
 		testPubKey,

--- a/core/crypto/signatures/p256/ecdsa_p256_test.go
+++ b/core/crypto/signatures/p256/ecdsa_p256_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 )
 
@@ -40,20 +41,8 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUxX42oxJ5voiNfbjoz8UgsGqh1bD
 -----END PUBLIC KEY-----`
 )
 
-// DevZero is an io.Reader that returns 0's
-type DevZero struct{}
-
-// Read returns 0's
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
-}
-
 func newSigner(t *testing.T, pemKey []byte) signatures.Signer {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	p, _ := pem.Decode(pemKey)
 	if p == nil {
 		t.Fatalf("no PEM block found")
@@ -229,7 +218,7 @@ func flipBit(a []byte, pos uint) []byte {
 }
 
 func TestGeneratePEMs(t *testing.T) {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	skPEM, pkPEM, err := GeneratePEMs()
 	if err != nil {
 		t.Fatalf("GeneratePEMs() failed: %v", err)

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
 	"github.com/google/keytransparency/core/mutator"
@@ -55,18 +56,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJKDbR4uyhSMXW80x02NtYRUFlMQb
 LOA+tLe/MbwZ69SRdG6Rx92f9tbC6dz7UVsyI7vIjS+961sELA6FeR91lA==
 -----END PUBLIC KEY-----`
 )
-
-// DevZero is an io.Reader that returns 0's
-type DevZero struct{}
-
-// Read returns 0's
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
-}
 
 func createEntry(commitment []byte, pkeys []string) ([]byte, error) {
 	authKeys := make([]*tpb.PublicKey, len(pkeys))
@@ -122,7 +111,7 @@ func prepareMutation(key []byte, entryData []byte, previous []byte, signers []si
 }
 
 func signersFromPEMs(t *testing.T, keys [][]byte) []signatures.Signer {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	signers := make([]signatures.Signer, 0, len(keys))
 	for _, key := range keys {
 		signer, err := factory.NewSignerFromPEM(key)

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/keytransparency/cmd/keytransparency-client/grpcc"
 	"github.com/google/keytransparency/core/authentication"
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
 
@@ -64,7 +65,7 @@ var (
 )
 
 func createSigner(t *testing.T, privKey string) signatures.Signer {
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	signer, err := factory.NewSignerFromPEM([]byte(privKey))
 	if err != nil {
 		t.Fatalf("factory.NewSigner failed: %v", err)

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/keytransparency/core/admin"
 	"github.com/google/keytransparency/core/appender"
 	"github.com/google/keytransparency/core/authentication"
+	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/crypto/vrf/p256"
@@ -104,7 +105,7 @@ K8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5AV2WCmStBt4N2Dx+7BrycJFbxhW
 f5JqSoyp0uiL8LeNYyj5vgklK8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 -----END PUBLIC KEY-----`
-	signatures.Rand = DevZero{}
+	signatures.Rand = dev.Zeros
 	sig, err := keys.NewFromPrivatePEM(sigPriv, "")
 	if err != nil {
 		return nil, nil, err
@@ -136,18 +137,6 @@ f5JqSoyp0uiL8LeNYyj5vgklK8pLcyDbRqch9Az8jXVAmcBAkvaSrLW8wQ==
 		return nil, nil, err
 	}
 	return vrf, verfier, nil
-}
-
-// DevZero is an io.Reader that returns 0's
-type DevZero struct{}
-
-// Read returns 0's
-func (DevZero) Read(b []byte) (n int, err error) {
-	for i := range b {
-		b[i] = 0
-	}
-
-	return len(b), nil
 }
 
 // NewEnv sets up common resources for tests.


### PR DESCRIPTION
Merge #595 first

Add a modifiable source of randomness to facilitate reliable tests.
Uses the new dev.Zero reader to generate test vectors.