### PR TITLE
Add support for fake authentication

### DIFF
--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/keytransparency/core/authentication"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
@@ -86,12 +85,6 @@ User email MUST match the OAuth account used to authorize the update.
 		if err != nil {
 			return fmt.Errorf("updateKeys() failed: %v", err)
 		}
-
-		// Put fake authentication information in the context
-		if fakeUserId := viper.GetString("fake-auth-userid"); fakeUserId != "" {
-			ctx = authentication.InsertFakeAuthIntoContext(ctx,fakeUserId)
-		}
-
 		// TODO: fill signers and authorizedKeys.
 		if _, err := c.Update(ctx, userID, appID, profileData, signers, authorizedKeys); err != nil {
 			return fmt.Errorf("update failed: %v", err)

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/google/keytransparency/core/authentication"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
@@ -85,6 +86,12 @@ User email MUST match the OAuth account used to authorize the update.
 		if err != nil {
 			return fmt.Errorf("updateKeys() failed: %v", err)
 		}
+
+		// Put fake authentication information in the context
+		if fakeUserId := viper.GetString("fake-auth-userid"); fakeUserId != "" {
+			ctx = authentication.InsertFakeAuthIntoContext(ctx,fakeUserId)
+		}
+
 		// TODO: fill signers and authorizedKeys.
 		if _, err := c.Update(ctx, userID, appID, profileData, signers, authorizedKeys); err != nil {
 			return fmt.Errorf("update failed: %v", err)

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -42,7 +42,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
-
 )
 
 var (
@@ -88,7 +87,7 @@ func init() {
 	RootCmd.PersistentFlags().String("kt-key", "testdata/server.crt", "Path to public key for Key Transparency")
 	RootCmd.PersistentFlags().String("kt-sig", "testdata/p256-pubkey.pem", "Path to public key for signed map heads")
 
-	RootCmd.PersistentFlags().String("fake-auth-userid","","userid to present to the server as identity for authentication. Only succeeds if fake auth is enabled on the server side.")
+	RootCmd.PersistentFlags().String("fake-auth-userid", "", "userid to present to the server as identity for authentication. Only succeeds if fake auth is enabled on the server side.")
 
 	// Global flags for use by subcommands.
 	RootCmd.PersistentFlags().DurationP("timeout", "t", 3*time.Minute, "Time to wait before operations timeout")
@@ -234,7 +233,7 @@ func dial(ktURL, caFile, clientSecretFile string, serviceKeyFile string) (*grpc.
 			return nil, err
 		}
 		opts = append(opts, grpc.WithPerRPCCredentials(creds))
-	case serviceKeyFile != "" :
+	case serviceKeyFile != "":
 		creds, err := getServiceCreds(serviceKeyFile)
 		if err != nil {
 			return nil, err

--- a/cmd/keytransparency-server/frontend.go
+++ b/cmd/keytransparency-server/frontend.go
@@ -129,7 +129,6 @@ var requestCounter uint64
 // jsonLogger logs the request and response protobufs as json objects.
 func jsonLogger(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
 	atomic.AddUint64(&requestCounter, 1)
-
 	// Print request.
 	pb, ok := req.(proto.Message)
 	if !ok {

--- a/core/authentication/fake.go
+++ b/core/authentication/fake.go
@@ -15,12 +15,13 @@
 package authentication
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/credentials"
-	"strings"
-	"fmt"
 )
 
 

--- a/core/authentication/fake.go
+++ b/core/authentication/fake.go
@@ -20,12 +20,11 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 )
 
 const fakeCredentialType string = "FakeCredential"
-
 
 // NewFake returns a new authenticator.
 func NewFake() *FakeAuth {
@@ -51,7 +50,7 @@ func (a *FakeAuth) ValidateCreds(ctx context.Context, requiredUserID string) err
 		return fmt.Errorf("Bad Authentication Format")
 	}
 
-	if got,want := p[0], fakeCredentialType; got!= want {
+	if got, want := p[0], fakeCredentialType; got != want {
 		return fmt.Errorf("FakeAuth: wrong credential type. got: %v, want %v", got, want)
 	}
 
@@ -63,11 +62,11 @@ func (a *FakeAuth) ValidateCreds(ctx context.Context, requiredUserID string) err
 	return nil
 }
 
-func GetFakeCredential(userID string) credentials.PerRPCCredentials{
+func GetFakeCredential(userID string) credentials.PerRPCCredentials {
 	return FakeCredential{userID}
 }
 
-type FakeCredential struct{
+type FakeCredential struct {
 	userID string
 }
 

--- a/core/authentication/fake.go
+++ b/core/authentication/fake.go
@@ -18,7 +18,11 @@ import (
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/credentials"
+	"strings"
+	"fmt"
 )
+
 
 // FakeAuth provides a fake authenticator for testing.
 type FakeAuth struct{}
@@ -28,32 +32,50 @@ func NewFake() *FakeAuth {
 	return &FakeAuth{}
 }
 
-// NewContext adds authentication details to a new background context.
-func (a *FakeAuth) NewContext(userID string) context.Context {
-	return InsertFakeAuthIntoContext(context.TODO(), userID)
+func GetFakeCredential(userID string) credentials.PerRPCCredentials{
+	return FakeCredential{userID}
 }
 
-// Includes (fake) authentication information in the context to authenticate to the server as userID.
-func InsertFakeAuthIntoContext(ctx context.Context, userID string) context.Context {
-	return metadata.NewOutgoingContext(ctx, metadata.Pairs("userid", userID))
-}
-
-// ValidateCreds verifies that the requiredUserID is present in ctx.
+// ValidateCreds verifies that the requiredUserID is present in the authorization metadata of the ctx.
 func (a *FakeAuth) ValidateCreds(ctx context.Context, requiredUserID string) error {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
 		glog.V(2).Infof("FakeAuth: missing authentication data")
 		return ErrMissingAuth
 	}
-	userIDs, ok := md["userid"]
-	if !ok || len(userIDs) != 1 {
-		glog.V(2).Infof("FakeAuth: missing authentication data")
+	authHeader, ok := md["authorization"]
+	if !ok || len(authHeader) != 1 {
 		return ErrMissingAuth
 	}
-	if got, want := md["userid"][0], requiredUserID; got != want {
+	p := strings.Split(authHeader[0], " ")
+	if len(p) != 2 {
+		return fmt.Errorf("Bad Authentication Format")
+	}
+
+	if got,want := p[0], fakeCredentialType; got!= want {
+		return fmt.Errorf("FakeAuth: wrong credential type. got: %v, want %v", got, want)
+	}
+
+	if got, want := p[1], requiredUserID; got != want {
 		glog.V(2).Infof("FakeAuth: wrong user. got: %v, want %v", got, want)
 		return ErrWrongUser
 	}
 	glog.V(2).Infof("FakeAuth: fake authentication suceeded for user %+v", requiredUserID)
 	return nil
+}
+
+const fakeCredentialType string = "FakeCredential"
+
+type FakeCredential struct{
+	userID string
+}
+
+func (c FakeCredential) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return map[string]string{
+		"authorization": fakeCredentialType + " " + c.userID,
+	}, nil
+}
+
+func (c FakeCredential) RequireTransportSecurity() bool {
+	return true
 }

--- a/core/authentication/fake.go
+++ b/core/authentication/fake.go
@@ -24,18 +24,16 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+const fakeCredentialType string = "FakeCredential"
 
-// FakeAuth provides a fake authenticator for testing.
-type FakeAuth struct{}
 
 // NewFake returns a new authenticator.
 func NewFake() *FakeAuth {
 	return &FakeAuth{}
 }
 
-func GetFakeCredential(userID string) credentials.PerRPCCredentials{
-	return FakeCredential{userID}
-}
+// FakeAuth provides a fake authenticator for testing.
+type FakeAuth struct{}
 
 // ValidateCreds verifies that the requiredUserID is present in the authorization metadata of the ctx.
 func (a *FakeAuth) ValidateCreds(ctx context.Context, requiredUserID string) error {
@@ -65,7 +63,9 @@ func (a *FakeAuth) ValidateCreds(ctx context.Context, requiredUserID string) err
 	return nil
 }
 
-const fakeCredentialType string = "FakeCredential"
+func GetFakeCredential(userID string) credentials.PerRPCCredentials{
+	return FakeCredential{userID}
+}
 
 type FakeCredential struct{
 	userID string

--- a/core/authentication/fake_test.go
+++ b/core/authentication/fake_test.go
@@ -25,9 +25,9 @@ import (
 func TestBasicValidateCreds(t *testing.T) {
 	auth := NewFake()
 	for _, tc := range []struct {
-		cred	 	credentials.PerRPCCredentials
-		requiredUserID 	string
-		want           	error
+		cred           credentials.PerRPCCredentials
+		requiredUserID string
+		want           error
 	}{
 		{nil, "foo", ErrMissingAuth},
 		{GetFakeCredential("foo"), "bar", ErrWrongUser},
@@ -36,7 +36,7 @@ func TestBasicValidateCreds(t *testing.T) {
 		// Build context by adding the credential information.
 		var inCtx context.Context
 		if tc.cred == nil {
-			inCtx = metadata.NewIncomingContext(context.Background(),nil)
+			inCtx = metadata.NewIncomingContext(context.Background(), nil)
 		} else {
 			md, _ := tc.cred.GetRequestMetadata(context.Background())
 			inCtx = metadata.NewIncomingContext(context.Background(), metadata.New(md))

--- a/core/authentication/fake_test.go
+++ b/core/authentication/fake_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 
 	"golang.org/x/net/context"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestBasicValidateCreds(t *testing.T) {

--- a/core/keyserver/validate_test.go
+++ b/core/keyserver/validate_test.go
@@ -90,9 +90,9 @@ func TestValidateUpdateEntryRequest(t *testing.T) {
 		commitment []byte
 		committed  *tpb.Committed
 	}{
-		{false, userID, [32]byte{}, nil, nil},              // Incorrect index
-		{false, userID, index, nil, nil},                   // Incorrect commitment
-		{false, userID, index, commitment, nil},            // Incorrect key
+		{false, userID, [32]byte{}, nil, nil},   // Incorrect index
+		{false, userID, index, nil, nil},        // Incorrect commitment
+		{false, userID, index, commitment, nil}, // Incorrect key
 		{true, userID, index, commitment, committed},
 	} {
 		entry := &tpb.Entry{

--- a/core/keyserver/validate_test.go
+++ b/core/keyserver/validate_test.go
@@ -19,13 +19,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/keytransparency/core/authentication"
 	"github.com/google/keytransparency/core/crypto/commitments"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/crypto/vrf/p256"
 
 	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 )
@@ -84,21 +82,18 @@ func TestValidateUpdateEntryRequest(t *testing.T) {
 	vrfPriv, _ := p256.GenerateKey()
 	index, _ := vrfPriv.Evaluate(vrf.UniqueID(userID, appID))
 	commitment, committed, _ := commitments.Commit(userID, appID, profileData)
-	authCtx := authentication.NewFake().NewContext(userID)
 
 	for _, tc := range []struct {
 		want       bool
-		ctx        context.Context
 		userID     string
 		index      [32]byte
 		commitment []byte
 		committed  *tpb.Committed
 	}{
-		{false, context.Background(), userID, [32]byte{}, nil, nil}, // Incorrect auth
-		{false, authCtx, userID, [32]byte{}, nil, nil},              // Incorrect index
-		{false, authCtx, userID, index, nil, nil},                   // Incorrect commitment
-		{false, authCtx, userID, index, commitment, nil},            // Incorrect key
-		{true, authCtx, userID, index, commitment, committed},
+		{false, userID, [32]byte{}, nil, nil},              // Incorrect index
+		{false, userID, index, nil, nil},                   // Incorrect commitment
+		{false, userID, index, commitment, nil},            // Incorrect key
+		{true, userID, index, commitment, committed},
 	} {
 		entry := &tpb.Entry{
 			Commitment: tc.commitment,

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/google/keytransparency/cmd/keytransparency-client/grpcc"
-	"github.com/google/keytransparency/core/authentication"
 	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
@@ -84,7 +83,6 @@ func getAuthorizedKey(pubKey string) *tpb.PublicKey {
 
 func TestEmptyGetAndUpdate(t *testing.T) {
 	bctx := context.Background()
-	auth := authentication.NewFake()
 	env := NewEnv(t)
 	defer env.Close(t)
 	env.Client.RetryCount = 0
@@ -112,12 +110,12 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 		authorizedKeys []*tpb.PublicKey
 	}{
 		{false, false, context.Background(), "noalice", signers1, authorizedKeys1}, // Empty
-		{false, true, auth.NewContext("bob"), "bob", signers1, authorizedKeys1},    // Insert
+		{false, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers1, authorizedKeys1},    // Insert
 		{false, false, context.Background(), "nocarol", signers1, authorizedKeys1}, // Empty
 		{true, false, context.Background(), "bob", signers1, authorizedKeys1},      // Not Empty
-		{true, true, auth.NewContext("bob"), "bob", signers1, authorizedKeys1},     // Update
-		{true, true, auth.NewContext("bob"), "bob", signers2, authorizedKeys2},     // Update, changing keys
-		{true, true, auth.NewContext("bob"), "bob", signers3, authorizedKeys3},     // Update, using new keys
+		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers1, authorizedKeys1},     // Update
+		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers2, authorizedKeys2},     // Update, changing keys
+		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers3, authorizedKeys3},     // Update, using new keys
 	} {
 		// Check profile.
 		if err := env.checkProfile(tc.userID, appID, tc.want); err != nil {
@@ -163,7 +161,6 @@ func TestUpdateValidation(t *testing.T) {
 	defer env.Close(t)
 	env.Client.RetryCount = 0
 
-	auth := authentication.NewFake()
 	profile := []byte("bar")
 
 	// Create lists of signers and authorized keys
@@ -179,9 +176,9 @@ func TestUpdateValidation(t *testing.T) {
 		authorizedKeys []*tpb.PublicKey
 	}{
 		{false, context.Background(), "alice", profile, signers, authorizedKeys},
-		{false, auth.NewContext("carol"), "bob", profile, signers, authorizedKeys},
-		{true, auth.NewContext("dave"), "dave", profile, signers, authorizedKeys},
-		{true, auth.NewContext("eve"), "eve", profile, signers, authorizedKeys},
+		{false, GetNewOutgoingContextWithFakeAuth("carol"), "bob", profile, signers, authorizedKeys},
+		{true, GetNewOutgoingContextWithFakeAuth("dave"), "dave", profile, signers, authorizedKeys},
+		{true, GetNewOutgoingContextWithFakeAuth("eve"), "eve", profile, signers, authorizedKeys},
 	} {
 		req, err := env.Client.Update(tc.ctx, tc.userID, appID, tc.profile, tc.signers, tc.authorizedKeys)
 
@@ -206,7 +203,7 @@ func TestUpdateValidation(t *testing.T) {
 
 func TestListHistory(t *testing.T) {
 	userID := "bob"
-	ctx := authentication.NewFake().NewContext(userID)
+	ctx := GetNewOutgoingContextWithFakeAuth(userID)
 
 	env := NewEnv(t)
 	defer env.Close(t)

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -109,13 +109,13 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 		signers        []signatures.Signer
 		authorizedKeys []*tpb.PublicKey
 	}{
-		{false, false, context.Background(), "noalice", signers1, authorizedKeys1}, // Empty
-		{false, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers1, authorizedKeys1},    // Insert
-		{false, false, context.Background(), "nocarol", signers1, authorizedKeys1}, // Empty
-		{true, false, context.Background(), "bob", signers1, authorizedKeys1},      // Not Empty
-		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers1, authorizedKeys1},     // Update
-		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers2, authorizedKeys2},     // Update, changing keys
-		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers3, authorizedKeys3},     // Update, using new keys
+		{false, false, context.Background(), "noalice", signers1, authorizedKeys1},                // Empty
+		{false, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers1, authorizedKeys1}, // Insert
+		{false, false, context.Background(), "nocarol", signers1, authorizedKeys1},                // Empty
+		{true, false, context.Background(), "bob", signers1, authorizedKeys1},                     // Not Empty
+		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers1, authorizedKeys1},  // Update
+		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers2, authorizedKeys2},  // Update, changing keys
+		{true, true, GetNewOutgoingContextWithFakeAuth("bob"), "bob", signers3, authorizedKeys3},  // Update, using new keys
 	} {
 		// Check profile.
 		if err := env.checkProfile(tc.userID, appID, tc.want); err != nil {

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -226,7 +226,7 @@ func (env *Env) Close(t *testing.T) {
 }
 
 // GetNewOutgoingContextWithFakeAuth returns a new context containing FakeAuth information to authenticate userID
-func GetNewOutgoingContextWithFakeAuth(userID string) context.Context{
+func GetNewOutgoingContextWithFakeAuth(userID string) context.Context {
 	md, _ := authentication.GetFakeCredential(userID).GetRequestMetadata(context.Background())
 	return metadata.NewOutgoingContext(context.Background(), metadata.New(md))
 }

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -48,6 +48,7 @@ import (
 	_ "github.com/mattn/go-sqlite3" // Use sqlite database for testing.
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	pb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
 	"github.com/google/trillian"
@@ -222,4 +223,10 @@ func (env *Env) Close(t *testing.T) {
 	env.GRPCServer.Stop()
 	env.db.Close()
 	env.mapLog.Close()
+}
+
+// GetNewOutgoingContextWithFakeAuth returns a new context containing FakeAuth information to authenticate userID
+func GetNewOutgoingContextWithFakeAuth(userID string) context.Context{
+	md, _ := authentication.GetFakeCredential(userID).GetRequestMetadata(context.Background())
+	return metadata.NewOutgoingContext(context.Background(), metadata.New(md))
 }


### PR DESCRIPTION
Adds support for fake authentication both to the client and the server (to be used for debug only). 

This allows the client to authenticate as user@domain.com by passing the additional parameter
`--fake-auth-userid=user@domain.com `
to the keytransparency-client binary (rather than having to get an actual oauth token). 
The feature should be enabled on the server side by starting the keytransparency-server binary with the ` --insecure-fake-auth ` flag.