### PR TITLE
Update keytransparency-client documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,9 @@ Set `$GOPATH` variable to point to your Go workspace directory and add `$GOPATH/
 
   ```sh
   ./keytransparency-client authorized-keys add --generate --type=ecdsa --activate
-  ./keytransparency-client post <email> -d '{"app1": "dGVzdA=="}' --config=./.keytransparency.yaml
-  {Keys:map[app1:[116 101 115 116]}
+  ./keytransparency-client post user@domain.com app1 -d 'dGVzdA==' --config=./.keytransparency.yaml
   ```
-  Key material is base64 encoded.
+  Key material is base64 encoded, e.g., 'dGVzdA==' is 'test' encoded.
 
   Note: Use `./keytransparency-client authorized-keys --help` for more information about authorized key managements.
 

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -51,7 +51,7 @@ User email MUST match the OAuth account used to authorize the update.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Validate input.
 		if len(args) < 2 {
-			return fmt.Errorf("user email needs to be provided")
+			return fmt.Errorf("user email and app-id need to be provided")
 		}
 		if data == "" {
 			return fmt.Errorf("no key data provided")


### PR DESCRIPTION
New commandline format:
./keytransparency-client post user@domain.com app1 -d dGVzdA==
--config=./.keytransparency.yaml

Fixes #606