### PR TITLE
Bug fix: replace impossible "&&" with "||" in VRF test.

### DIFF
--- a/core/crypto/vrf/p256/p256_test.go
+++ b/core/crypto/vrf/p256/p256_test.go
@@ -45,7 +45,7 @@ func TestH2(t *testing.T) {
 			t.Fatalf("Failed generating random message: %v", err)
 		}
 		x := H2(m)
-		if got := len(x.Bytes()); got < 1 && got > l {
+		if got := len(x.Bytes()); got < 1 || got > l {
 			t.Errorf("len(h2(%v)) = %v, want %v", m, got, l)
 		}
 	}


### PR DESCRIPTION
I found this bug while working on the JavaScript client.