### PR TITLE
Another place where the name of the credentials file should be adapted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_deploy:
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk;
     curl https://sdk.cloud.google.com | bash; fi
   - openssl aes-256-cbc -K $encrypted_a1eb99cfc21e_key -iv $encrypted_a1eb99cfc21e_iv -in travis_secrets.tar.gz.enc -out travis_secrets.tar.gz -d
-  - tar -xzf service_key.tar.gz
+  - tar -xzf travis_secrets.tar.gz
   - gcloud --quiet version
   - gcloud --quiet components update kubectl
 


### PR DESCRIPTION
Replace `tar -xzf service_key.tar.gz` with `tar -xzf travis_secrets.tar.gz`
to make travis pass (hopefully): https://travis-ci.org/google/keytransparency/builds/244962734#L5015-L5022