### PR TITLE
Install/update kubectl requires sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_deploy:
   - openssl aes-256-cbc -K $encrypted_a1eb99cfc21e_key -iv $encrypted_a1eb99cfc21e_iv -in travis_secrets.tar.gz.enc -out travis_secrets.tar.gz -d
   - tar -xzf travis_secrets.tar.gz
   - gcloud --quiet version
-  - gcloud --quiet components update kubectl
+  - sudo gcloud --quiet components update kubectl
 
 deploy:
   provider: script


### PR DESCRIPTION
To install kubectl sudo is required.
See: https://travis-ci.org/google/keytransparency/builds/244975635#L5030-L5035