### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# exclude top-level credential files:
+/service_key.json
+/client_secret*.json
+/travis_secrets.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,8 @@ before_deploy:
     curl https://sdk.cloud.google.com | bash; fi
   - openssl aes-256-cbc -K $encrypted_a1eb99cfc21e_key -iv $encrypted_a1eb99cfc21e_iv -in travis_secrets.tar.gz.enc -out travis_secrets.tar.gz -d
   - tar -xzf travis_secrets.tar.gz
+  - gcloud auth activate-service-account --key-file service_key.json
+  - rm -f service_key.json
   - gcloud --quiet version
   - sudo gcloud --quiet components update kubectl
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,7 +37,6 @@ function main()
 
 function initGcloud()
 {
-  gcloud auth activate-service-account --key-file service_key.json
   gcloud config set project ${PROJECT_NAME}
   gcloud config set compute/zone us-central1-a
   gcloud container clusters get-credentials ci-cluster


### PR DESCRIPTION
and move `gcloud auth` command from the deploy script to travis, delete secret_key after usage (so it doesn't end up in docker images)

resolves #623 