### PR TITLE
LOG still uses RFC_6962

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ docker-compose up -d trillian-map
 7. Provision a log and a map 
 ```sh
 MAP_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' keytransparency_trillian-map_1`
-go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --hash_strategy=TEST_MAP_HASHER --tree_type=LOG
+go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG
 go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --hash_strategy=TEST_MAP_HASHER --tree_type=MAP
 ```
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -101,7 +101,7 @@ function createTreeAndSetIDs()
     let COUNTER+=1
     # get the currentl trillian-map pod:
     MAPSRV=$(kubectl get pods --selector=run=trillian-map -o jsonpath={.items[*].metadata.name});
-    LOG_ID=$(echo 'go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=localhost:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --hash_strategy=TEST_MAP_HASHER --tree_type=LOG' | kubectl exec -i $MAPSRV -- /bin/sh )
+    LOG_ID=$(echo 'go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=localhost:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG' | kubectl exec -i $MAPSRV -- /bin/sh )
     MAP_ID=$(echo 'go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=localhost:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --hash_strategy=TEST_MAP_HASHER --tree_type=MAP' | kubectl exec -i $MAPSRV -- /bin/sh )
   done
 


### PR DESCRIPTION
only MAP-type trees can use new hash-strategy: `TEST_MAP_HASHER` (see google/trillian#685)

resolves #638