### PR TITLE
Remove service-key requirement from kt-server

### DIFF
--- a/.keytransparency.yaml
+++ b/.keytransparency.yaml
@@ -2,7 +2,8 @@ log-key: "../trillian/testdata/log-rpc-server.pubkey.pem"
 vrf:    "genfiles/vrf-pubkey.pem"
 kt-key: "genfiles/server.crt"
 kt-sig: "genfiles/p256-pubkey.pem"
-map-id: 3506304676031956248
-kt-url: "localhost:8080"
-client-secret: "/usr/local/google/home/ismailkhoffi/go/src/github.com/google/keytransparency/client_secret_825145729157-c5frj7vasev3fectclbqpfp2mgdl44pe.apps.googleusercontent.com.json"
+domain: "example.com"
+map-id: 0
+kt-url: "104.199.112.76:5001"
+client-secret: "client_secret.json"
 service-key: ""

--- a/.keytransparency.yaml
+++ b/.keytransparency.yaml
@@ -2,8 +2,7 @@ log-key: "../trillian/testdata/log-rpc-server.pubkey.pem"
 vrf:    "genfiles/vrf-pubkey.pem"
 kt-key: "genfiles/server.crt"
 kt-sig: "genfiles/p256-pubkey.pem"
-domain: "example.com"
-map-id: 0
-kt-url: "104.199.112.76:5001"
-client-secret: "client_secret.json"
+map-id: 3506304676031956248
+kt-url: "localhost:8080"
+client-secret: "/usr/local/google/home/ismailkhoffi/go/src/github.com/google/keytransparency/client_secret_825145729157-c5frj7vasev3fectclbqpfp2mgdl44pe.apps.googleusercontent.com.json"
 service-key: ""

--- a/README.md
+++ b/README.md
@@ -96,11 +96,7 @@ Set `$GOPATH` variable to point to your Go workspace directory and add `$GOPATH/
   go get -u github.com/google/trillian/...
   ```
 
-4. Get a [service account key](https://console.developers.google.com/apis/credentials) and download the generated JSON file.
-
-  The service account key is used to verify client OAuth tokens.
-
-5. Run server setup 
+3. Run server setup 
 
   ```sh
 ./scripts/prepare_server.sh
@@ -113,13 +109,13 @@ Set `$GOPATH` variable to point to your Go workspace directory and add `$GOPATH/
   - `genfiles/server.crt`
   - `genfile/p256-pubkey.pem`
 
-6. Run the trillian-map server 
+4. Run the trillian-map server 
 
   ```sh
 docker-compose up -d trillian-map
   ```
 
-7. Provision a log and a map 
+5. Provision a log and a map 
 ```sh
 MAP_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' keytransparency_trillian-map_1`
 export LOG_ID=`go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=$GOPATH/src/github.com/google/trillian/testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG`
@@ -127,7 +123,7 @@ export MAP_ID=`go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main
 ```
 
 
-8. Launch the rest of the cluster and observe.
+6. Launch the rest of the cluster and observe.
 - `docker-compose up -d`
 - `docker-compose logs --tail=0 --follow`
 - [https://localhost:8080/v1/users/foo@bar.com](https://localhost:8080/v1/users/foo@bar.com)

--- a/README.md
+++ b/README.md
@@ -122,12 +122,10 @@ docker-compose up -d trillian-map
 7. Provision a log and a map 
 ```sh
 MAP_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' keytransparency_trillian-map_1`
-go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG
-go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --hash_strategy=TEST_MAP_HASHER --tree_type=MAP
+export LOG_ID=`go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=$GOPATH/src/github.com/google/trillian/testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG`
+export MAP_ID=`go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=$GOPATH/src/github.com/google/trillian/testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA  --hash_strategy=TEST_MAP_HASHER --tree_type=MAP`
 ```
 
-Set the `LOG_ID` and `MAP_ID` environment variables in `docker-compose.yml` with the output
-of the respective commands.
 
 8. Launch the rest of the cluster and observe.
 - `docker-compose up -d`

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -248,7 +248,7 @@ func dial(ktURL, caFile, clientSecretFile string, serviceKeyFile string) (*grpc.
 	return cc, nil
 }
 
-// GetClient connects to the server and returns a key transpency verification
+// GetClient connects to the server and returns a key transparency verification
 // client.
 func GetClient(clientSecretFile string) (*grpcc.Client, error) {
 	vrfFile := viper.GetString("vrf")

--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -16,8 +16,7 @@ ENV VRF_PRIV=genfiles/vrf-key.pem \
 ENV MAP_ID=0 \
     MAP_URL=""
 ENV LOG_ID=0 \
-    LOG_URL=localhost:8090 
-ENV GOOGLE_APPLICATION_CREDENTIALS=genfiles/service_key.json
+    LOG_URL=localhost:8090
 ENV VERBOSE=0
 
 ADD genfiles/* /kt/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,9 @@ services:
       - "8080:8080" # json & grpc
       - "8081:8081" # metrics
     environment:
-      LOG_ID: 4450861294505218766 # Update with trillian admin CLI.
+      LOG_ID: ${LOG_ID} # Update with trillian admin CLI.
       LOG_URL: trillian-log:8090
-      MAP_ID: 5698043027494814677 # Update with trillian admin CLI.
+      MAP_ID: ${MAP_ID} # Update with trillian admin CLI.
       MAP_URL: trillian-map:8090
       DB_HOST: db:3306
       DB_DATABASE: test
@@ -114,9 +114,9 @@ services:
     image: us.gcr.io/key-transparency/keytransparency-signer
     restart: always
     environment:
-      LOG_ID: 4450861294505218766 # Update with trillian admin CLI.
+      LOG_ID: ${LOG_ID} # Update with trillian admin CLI.
       LOG_URL: trillian-log:8090
-      MAP_ID: 5698043027494814677 # Update with trillian admin CLI.
+      MAP_ID: ${MAP_ID} # Update with trillian admin CLI.
       MAP_URL: trillian-map:8090
       DB_HOST: db:3306
       DB_DATABASE: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,6 @@ services:
       DB_DATABASE: test
       DB_USER: test
       DB_PASSWORD: zaphod
-      GOOGLE_APPLICATION_CREDENTIALS: /kt/service_key.json
       CERT: /kt/server.crt
       VRF_PRIV: /kt/vrf-key.pem
       VRF_PUB: /kt/vrf-pubkey.pem

--- a/impl/google/authentication/google.go
+++ b/impl/google/authentication/google.go
@@ -23,7 +23,6 @@ import (
 
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	gAPI "google.golang.org/api/oauth2/v2"
 	"google.golang.org/grpc/metadata"
 )
@@ -47,23 +46,11 @@ var (
 )
 
 // GAuth authenticates Google users through the Google TokenInfo API endpoint.
-type GAuth struct {
-	service *gAPI.Service
-}
+type GAuth struct {}
 
 // NewGoogleAuth creates a new authenticator for Google users.
 func NewGoogleAuth() (*GAuth, error) {
-	//httpClient := a.config.Client(ctx, token)
-	ctx := context.TODO()
-	httpClient, err := google.DefaultClient(ctx, gAPI.UserinfoEmailScope)
-	if err != nil {
-		return nil, err
-	}
-	googleService, err := gAPI.New(httpClient)
-	if err != nil {
-		return nil, err
-	}
-	return &GAuth{googleService}, nil
+	return &GAuth{}, nil
 }
 
 // ValidateCreds verifies that email is equal to the validated email address
@@ -122,7 +109,7 @@ func (a *GAuth) validateToken(ctx context.Context) (*gAPI.Tokeninfo, error) {
 		return nil, ErrInvalidToken
 	}
 
-	infoCall := a.service.Tokeninfo()
+	infoCall := gAPI.TokeninfoCall{}
 	infoCall.AccessToken(token.AccessToken)
 	info, err := infoCall.Do()
 	if err != nil {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,8 +9,11 @@
 #   project via:                                                               #
 #   # see gcloud help auth and authenticate, then:                             #
 #   gcloud config set project key-transparency                                 #
-#   gcloud container clusters get-credentials <cluster-name>                   #
-#   gcloud config set compute/zone us-central1-a                               #
+#   gcloud container clusters get-credentials <your-cluster-name>              #
+#   gcloud config set compute/zone <your-compute-zone>                         #
+#                                                                              #
+#   See the project's .travis.yml file for a working example.                  #
+#                                                                              #
 ################################################################################
 
 PROJECT_NAME=key-transparency

--- a/scripts/prepare_client.sh
+++ b/scripts/prepare_client.sh
@@ -75,7 +75,7 @@ vrf:    \"${VRF}\"
 kt-key: \"${KTKEY}\"
 kt-sig: \"${SIGKEY}\"
 domain: \"${DOMAIN}\"
-mapid: 0 
+mapid: ${MAP_ID}
 kt-url: \"${KTURL}\"
 client-secret: \"${CLIENTSECRET}\"
 service-key: \"${SERVICEKEY}\""

--- a/scripts/prepare_server.sh
+++ b/scripts/prepare_server.sh
@@ -159,7 +159,6 @@ fi
 
 # Generating .env file
 ENV="SIGN_PERIOD=5
-GOOGLE_APPLICATION_CREDENTIALS=\"${SERVICEKEY}\""
 
 if [[ -n "${CERTDOMAIN}" ]]; then
     ENV="${ENV}


### PR DESCRIPTION
Use a default http client to query https://www.googleapis.com/oauth2/v2

Also, use environment vars for `LOG_ID` and `MAP_ID` in the `docker-compose.yml` file (makes local testing/debugging a easier/more convenient).

Resolves #640 
Resolves #617 