### PR TITLE
Create tree scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,7 @@ docker-compose up -d trillian-map
 
 5. Provision a log and a map 
 ```sh
-MAP_IP=`docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' keytransparency_trillian-map_1`
-export LOG_ID=`go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=$GOPATH/src/github.com/google/trillian/testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA --tree_type=LOG`
-export MAP_ID=`go run $GOPATH/src/github.com/google/trillian/cmd/createtree/main.go --admin_server=$MAP_IP:8090 --pem_key_path=$GOPATH/src/github.com/google/trillian/testdata/log-rpc-server.privkey.pem --pem_key_password="towel" --signature_algorithm=ECDSA  --hash_strategy=TEST_MAP_HASHER --tree_type=MAP`
+source scripts/configure_trillian.sh && createLog && createMap
 ```
 
 

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -34,8 +34,8 @@ import (
 
 	"github.com/google/trillian/client"
 	"github.com/google/trillian/crypto/keys"
-	// Make sure the objhasher is registered:
-	_ "github.com/google/trillian/merkle/objhasher"
+	_ "github.com/google/trillian/merkle/objhasher" // Register objhasher
+	"github.com/google/trillian/merkle/hashers"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
@@ -44,7 +44,6 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
 	"github.com/google/trillian"
-	"github.com/google/trillian/merkle/hashers"
 )
 
 var (

--- a/cmd/keytransparency-signer/main.go
+++ b/cmd/keytransparency-signer/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keys"
 	"github.com/google/trillian/util"
+	_ "github.com/google/trillian/merkle/objhasher" // Register objhasher
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       DB_DATABASE: test
       DB_USER: test
       DB_PASSWORD: zaphod
+      SEQUENCER_INTERVAL: 1s
 
 
   trillian-map:
@@ -101,6 +102,7 @@ services:
       VRF_PUB: /kt/vrf-pubkey.pem
       TLS_KEY_PATH: /kt/server.key
       TLS_CRT_PATH: /kt/server.crt
+      VERBOSITY: 5
 
   kt-signer:
     depends_on:
@@ -125,3 +127,4 @@ services:
       SIGN_KEY: /trillian/log-rpc-server.privkey.pem
       SIGN_KEY_PW: towel
       MIN_SIGN_PERIOD: 5s
+      VERBOSITY: 5

--- a/impl/config/config.go
+++ b/impl/config/config.go
@@ -21,8 +21,7 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
 	"github.com/google/trillian/crypto/keys"
-	// Make sure the objecthasher is registered:
-	_ "github.com/google/trillian/merkle/objhasher"
+	_ "github.com/google/trillian/merkle/objhasher" // Register objecthasher
 	"github.com/google/trillian/merkle/hashers"
 
 	"github.com/golang/glog"

--- a/scripts/configure_trillian.sh
+++ b/scripts/configure_trillian.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Defaults from docker-compose.yml.
+LOG_URL=localhost:8091
+MAP_URL=localhost:8094
+
+function createLog()
+{
+  LOG_JSON=`curl -X POST -d  '{"tree":{"tree_state":"ACTIVE","tree_type":"LOG","hash_strategy":"RFC6962_SHA256","signature_algorithm":"ECDSA","max_root_duration":"0","hash_algorithm":"SHA256"},"key_spec":{"ecdsa_params":{"curve":"P256"}}}'  http://${LOG_URL}/v1beta1/trees`
+  export LOG_ID=`echo ${LOG_JSON} | jq -r '.tree_id'`
+  echo "-----BEGIN PUBLIC KEY-----" > genfiles/trillian-log.pem
+  echo $LOG_JSON | jq '.public_key.der'  | sed 's/\"//g' | cat >> genfiles/trillian-log.pem
+  echo "-----END PUBLIC KEY-----" >> genfiles/trillian-log.pem
+}
+
+function createMap()
+{
+  MAP_JSON=`curl -X POST -d  '{"tree":{"tree_state":"ACTIVE","tree_type":"MAP","hash_strategy":"TEST_MAP_HASHER","signature_algorithm":"ECDSA","max_root_duration":"0","hash_algorithm":"SHA256"},"key_spec":{"ecdsa_params":{"curve":"P256"}}}'  http://${MAP_URL}/v1beta1/trees`
+  export MAP_ID=`echo ${MAP_JSON} | jq -r '.tree_id'`
+  echo "-----BEGIN PUBLIC KEY-----" > genfiles/trillian-map.pem
+  echo $MAP_JSON | jq -r '.public_key.der'  | cat >> genfiles/trillian-map.pem
+  echo "-----END PUBLIC KEY-----" >> genfiles/trillian-map.pem
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -108,8 +108,8 @@ function createTreeAndSetIDs()
     sleep 10;
     let COUNTER+=1
     # Overwrite default LOG_URL and MAP_URL:
-    export LOG_URL=trillian-log;
-    export MAP_URL=trillian-map;
+    export LOG_URL=trillian-log:8091;
+    export MAP_URL=trillian-map:8091;
     createLog
     createMap
   done

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -107,9 +107,9 @@ function createTreeAndSetIDs()
     # RPC was not available yet, wait and retry:
     sleep 10;
     let COUNTER+=1
-    # get the current trillian-map and trillian-log pods:
-    export LOG_URL=$(kubectl get pods --selector=run=trillian-log -o jsonpath={.items[*].metadata.name});
-    export MAP_URL=$(kubectl get pods --selector=run=trillian-map -o jsonpath={.items[*].metadata.name});
+    # Overwrite default LOG_URL and MAP_URL:
+    export LOG_URL=trillian-log;
+    export MAP_URL=trillian-map;
     createLog
     createMap
   done


### PR DESCRIPTION
Use HTTP POST to create trees, store the public keys and export `LOG_ID` and `MAP_ID` vars.