### PR TITLE
Fix off by one error between Map and Log

### DIFF
--- a/core/appender/trillian.go
+++ b/core/appender/trillian.go
@@ -47,6 +47,7 @@ func (t *Trillian) Write(ctx context.Context, logID, epoch int64, obj interface{
 		return err
 	}
 	// TODO(gbelvin): Add leaf at a specific index. trillian#423
+	// Insert index = epoch -1. MapRevisions start at 1. Log leaves start at 0.
 	if err := log.AddLeaf(ctx, b); err != nil {
 		return err
 	}

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -157,7 +157,10 @@ func (s *Server) getEntry(ctx context.Context, userID, appID string, firstTreeSi
 		&trillian.GetInclusionProofRequest{
 			LogId: s.logID,
 			// SignedMapRoot must be placed in the log at MapRevision.
-			LeafIndex: getResp.GetMapRoot().GetMapRevision(),
+			// MapRevisions start at 1. Log leaves start at 0.
+			// MapRevision should be at least 1 since the Signer is
+			// supposed to create at least one revision on startup.
+			LeafIndex: getResp.GetMapRoot().GetMapRevision() - 1,
 			TreeSize:  secondTreeSize,
 		})
 	if err != nil {


### PR DESCRIPTION
Our first SignedMapRoot starts at revision 1
(Revision 0 is completely empty).
Log leaves, however, start at 0.

Fixes #654