### PR TITLE
Make kubernetes/gcloud also use the generated keys (as in docker-comp…

### DIFF
--- a/cmd/keytransparency-signer/Dockerfile
+++ b/cmd/keytransparency-signer/Dockerfile
@@ -20,6 +20,7 @@ ADD genfiles/* /kt/
 ADD . /go/src/github.com/google/keytransparency
 WORKDIR /go/src/github.com/google/keytransparency 
 
+RUN apt-get update && apt-get install -y libtool libltdl-dev
 RUN go get -tags="mysql" ./cmd/keytransparency-signer
 
 ENTRYPOINT /go/bin/keytransparency-signer \

--- a/deploy/kubernetes/keytransparency-deployment.yml.tmpl
+++ b/deploy/kubernetes/keytransparency-deployment.yml.tmpl
@@ -91,9 +91,9 @@ spec:
             - name: DB_HOST
               value: mysql:3306
             - name: LOG_KEY
-              value: /trillian/log-rpc-server.pubkey.pem
+              value: /kt/trillian-log.pem
             - name: SIGN_KEY # TODO(ismail): https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/
-              value: /trillian/log-rpc-server.privkey.pem
+              value: /kt/p256-key.pem
             - name: SIGN_KEY_PW
               value: towel
 ---

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -41,6 +41,10 @@ function main()
   waitForTrillian
   createTreeAndSetIDs
 
+  # Need to (re)build kt-signer after writing the public-keys
+  docker-compose build kt-signer
+  gcloud docker -- push us.gcr.io/keytransparency-signer
+
   # Deploy all keytransparency related services (server and signer):
   kubectl apply -f deploy/kubernetes/keytransparency-deployment.yml
 }
@@ -68,7 +72,7 @@ function pushTrillianImgs()
 
 function pushKTImgs()
 {
-  images=("keytransparency-server" "keytransparency-signer" "prometheus")
+  images=("keytransparency-server" "prometheus")
   for DOCKER_IMAGE_NAME in "${images[@]}"
   do
     # Push the images as we refer to them in the kubernetes config files:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -43,7 +43,7 @@ function main()
 
   # Need to (re)build kt-signer after writing the public-keys
   docker-compose build kt-signer
-  gcloud docker -- push us.gcr.io/keytransparency-signer
+  gcloud docker -- push us.gcr.io/key-transparency/keytransparency-signer
 
   # Deploy all keytransparency related services (server and signer):
   kubectl apply -f deploy/kubernetes/keytransparency-deployment.yml


### PR DESCRIPTION
Catch up with the latest changes (#656): Update referenced keys in kubernetes config
(see https://github.com/google/keytransparency/pull/656/files#diff-4e5e90c6228fd48698d074241c2ba760L125)

Fix building of kt-signer after PKCS#11 signer support was introduced.


Resolves: #664 
Resolves: #665