### PR TITLE
Simplify mutator interface: reduce code redundancy 

### DIFF
--- a/cmd/keytransparency-client/grpcc/grpc_client.go
+++ b/cmd/keytransparency-client/grpcc/grpc_client.go
@@ -209,12 +209,12 @@ func (c *Client) Update(ctx context.Context, userID, appID string, profileData [
 	if err != nil {
 		return nil, fmt.Errorf("proto.Marshal(): %v", err)
 	}
-	if err := c.mutator.CheckMutation(getResp.LeafProof.Leaf.LeafValue, m); err != nil {
+	if _, err := c.mutator.Mutate(getResp.GetLeafProof().GetLeaf().GetLeafValue(), m); err != nil {
 		return nil, fmt.Errorf("CheckMutation: %v", err)
 	}
 
 	err = c.Retry(ctx, req)
-	// Retry submitting until an incluion proof is returned.
+	// Retry submitting until an inclusion proof is returned.
 	for i := 0; err == ErrRetry && i < c.RetryCount; i++ {
 		time.Sleep(c.RetryDelay)
 		err = c.Retry(ctx, req)

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -278,7 +278,7 @@ func (s *Server) UpdateEntry(ctx context.Context, in *tpb.UpdateEntryRequest) (*
 	}
 
 	// The very first mutation will have resp.LeafProof.LeafData=nil.
-	if err := s.mutator.CheckMutation(resp.LeafProof.Leaf.LeafValue, m); err == mutator.ErrReplay {
+	if _, err := s.mutator.Mutate(resp.LeafProof.Leaf.LeafValue, m); err == mutator.ErrReplay {
 		glog.Warningf("Discarding request due to replay")
 		// Return the response. The client should handle the replay case
 		// by comparing the returned response with the request. Check

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -188,7 +188,7 @@ func TestCheckMutation(t *testing.T) {
 			t.Fatalf("prepareMutation(%v, %v, %v)=%v", tc.key, tc.entryData, tc.previous, err)
 		}
 
-		if got := New().CheckMutation(tc.oldValue, mutation); got != tc.err {
+		if _, got := New().Mutate(tc.oldValue, mutation); got != tc.err {
 			t.Errorf("CheckMutation(%v, %v)=%v, want %v", tc.oldValue, mutation, got, tc.err)
 		}
 	}

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -47,9 +47,8 @@ var (
 
 // Mutator verifies mutations and transforms values in the map.
 type Mutator interface {
-	// CheckMutation verifies that this is a valid mutation for this item.
-	CheckMutation(value, mutation []byte) error
-	// Mutate applies mutation to value
+	// CheckMutation verifies that this is a valid mutation for this item and
+	// applies mutation to value.
 	Mutate(value, mutation []byte) ([]byte, error)
 }
 

--- a/core/proto/keytransparency_v1_types/keytransparency_v1_types.proto
+++ b/core/proto/keytransparency_v1_types/keytransparency_v1_types.proto
@@ -78,6 +78,7 @@ message KeyValue {
   bytes key = 1;
   // value contains the map entry value.
   bytes value = 2;
+  // TODO(ismail): make proto.Any
 }
 
 // SignedKV is a signed change to a map entry.


### PR DESCRIPTION
and prevent calling `Mutate(...)` without checking that the mutation is actually valid:

- remove `mutation.CheckMutation` from interface 
- `mutation.Mutate` does both now: checks the mutation and returns the update (which it created anyway)
