### PR TITLE
Add missing license

### DIFF
--- a/core/mutation/mutation_test.go
+++ b/core/mutation/mutation_test.go
@@ -1,3 +1,19 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mutation implements the monitor service. This package contains the
+// core functionality.
 package mutation
 
 import (

--- a/core/signer/signer_test.go
+++ b/core/signer/signer_test.go
@@ -1,3 +1,19 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mutation implements the monitor service. This package contains the
+// core functionality.
 package signer
 
 import (


### PR DESCRIPTION
Add missing license headers in `core/mutation/mutation_test.go` and `core/signer/signer_test.go`.

Partial #682.