### PR TITLE
Use local trillian repo when building Docker images 

### DIFF
--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -9,9 +9,9 @@ ENV HOST=0.0.0.0 \
     RPC_PORT=8080
 
 # TLS Certificate needs 0.0.0.0 to be in the SAN IP field.
-ENV VRF_PRIV=genfiles/vrf-key.pem \
-    TLS_KEY_PATH=genfiles/server.key \
-    TLS_CRT_PATH=genfiles/server.crt
+ENV VRF_PRIV=keytransparency/genfiles/vrf-key.pem \
+    TLS_KEY_PATH=keytransparency/genfiles/server.key \
+    TLS_CRT_PATH=keytransparency/genfiles/server.crt
 
 ENV MAP_ID=0 \
     MAP_URL=""
@@ -20,8 +20,9 @@ ENV LOG_ID=0 \
 
 ENV VERBOSITY=1
 
-ADD genfiles/* /kt/
-ADD . /go/src/github.com/google/keytransparency
+ADD keytransparency/genfiles/* /kt/
+ADD ./keytransparency /go/src/github.com/google/keytransparency
+ADD ./trillian /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/keytransparency 
 
 RUN apt-get update && apt-get install -y libtool libltdl-dev

--- a/cmd/keytransparency-signer/Dockerfile
+++ b/cmd/keytransparency-signer/Dockerfile
@@ -9,15 +9,16 @@ ENV MAP_ID=0 \
     MAP_URL=""
 ENV LOG_ID=0 \
     LOG_URL=localhost:8090 \
-    LOG_KEY=../trillian/testdata/log-rpc-server.pubkey.pem
+    LOG_KEY=trillian/testdata/log-rpc-server.pubkey.pem
 
 ENV MIN_SIGN_PERIOD=5s \
     MAX_SIGN_PERIOD=24h
 
 ENV VERBOSITY=0
 
-ADD genfiles/* /kt/
-ADD . /go/src/github.com/google/keytransparency
+ADD keytransparency/genfiles/* /kt/
+ADD ./keytransparency /go/src/github.com/google/keytransparency
+ADD ./trillian /go/src/github.com/google/trillian
 WORKDIR /go/src/github.com/google/keytransparency 
 
 RUN apt-get update && apt-get install -y libtool libltdl-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,8 +82,8 @@ services:
       - trillian-log
       - trillian-map
     build:
-      context: .
-      dockerfile: ./cmd/keytransparency-server/Dockerfile
+      context: ..
+      dockerfile: ./keytransparency/cmd/keytransparency-server/Dockerfile
     image: us.gcr.io/key-transparency/keytransparency-server
     restart: always
     ports:
@@ -111,8 +111,8 @@ services:
       - trillian-log
       - trillian-map
     build:
-      context: .
-      dockerfile: ./cmd/keytransparency-signer/Dockerfile
+      context: ..
+      dockerfile: ./keytransparency/cmd/keytransparency-signer/Dockerfile
     image: us.gcr.io/key-transparency/keytransparency-signer
     restart: always
     environment:
@@ -128,4 +128,5 @@ services:
       SIGN_KEY: /kt/p256-key.pem
       SIGN_KEY_PW: towel
       MIN_SIGN_PERIOD: 5s
+      MAX_SIGN_PERIOD: 5m
       VERBOSITY: 5


### PR DESCRIPTION
Changes the build context for the kt-server and the kt-signer to:
`$GOPATH/src/github.com/google/`
and uses the local trillian repo instead of fetching it (via go get)

resolves #689