### PR TITLE
Use same hasher for LogClient and trillian-log

### DIFF
--- a/cmd/keytransparency-signer/main.go
+++ b/cmd/keytransparency-signer/main.go
@@ -63,8 +63,6 @@ var (
 	logID     = flag.Int64("log-id", 0, "Trillian Log ID")
 	logURL    = flag.String("log-url", "", "URL of Trillian Log Server for Signed Map Heads")
 	logPubKey = flag.String("log-key", "", "File path to public key of the Trillian Log")
-	// TODO(ismail): add hasher flag; defaults to hasher used to create tree in
-	// log_payload.json (hash_algorithm)
 )
 
 func openDB() *sql.DB {

--- a/cmd/keytransparency-signer/main.go
+++ b/cmd/keytransparency-signer/main.go
@@ -63,6 +63,8 @@ var (
 	logID     = flag.Int64("log-id", 0, "Trillian Log ID")
 	logURL    = flag.String("log-url", "", "URL of Trillian Log Server for Signed Map Heads")
 	logPubKey = flag.String("log-key", "", "File path to public key of the Trillian Log")
+	// TODO(ismail): add hasher flag; defaults to hasher used to create tree in
+	// log_payload.json (hash_algorithm)
 )
 
 func openDB() *sql.DB {

--- a/impl/config/config.go
+++ b/impl/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package config has utilitites for loading configuration files from disk.
+// Package config has utilities for loading configuration files from disk.
 package config
 
 import (
@@ -21,13 +21,13 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
 	"github.com/google/trillian/crypto/keys"
-	"github.com/google/trillian/merkle/hashers"
-	_ "github.com/google/trillian/merkle/objhasher" // Register objecthasher
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
+	"github.com/google/trillian/merkle/rfc6962"
 )
 
+// TODO(ismail): add hasher param
 // LogClient creates a log client.
 func LogClient(logID int64, logURL, pubKeyFile string) (client.VerifyingLogClient, error) {
 	sthPubKey, err := keys.NewFromPublicPEMFile(pubKeyFile)
@@ -39,11 +39,7 @@ func LogClient(logID int64, logURL, pubKeyFile string) (client.VerifyingLogClien
 	if err != nil {
 		return nil, fmt.Errorf("Failed to connect to %v: %v", logURL, err)
 	}
-	hasher, err := hashers.NewLogHasher(trillian.HashStrategy_OBJECT_RFC6962_SHA256)
-	if err != nil {
-		return nil, fmt.Errorf("Failed retrieving LogHasher from registry: %v", err)
-	}
-	log := client.New(logID, trillian.NewTrillianLogClient(cc), hasher, sthPubKey)
+	log := client.New(logID, trillian.NewTrillianLogClient(cc), rfc6962.DefaultHasher, sthPubKey)
 
 	return log, nil
 }

--- a/scripts/log_payload.json
+++ b/scripts/log_payload.json
@@ -5,7 +5,7 @@
     "hash_strategy":"RFC6962_SHA256",
     "signature_algorithm":"ECDSA",
     "max_root_duration":"0",
-    "hash_algorithm":"SHA256"
+    "hash_algorithm":"OBJECT_RFC6962_SHA256"
   },
   "key_spec":{
     "ecdsa_params":{


### PR DESCRIPTION
We currently create the tree using [log_payload.json](https://github.com/google/keytransparency/blob/a7b3f6246ec0be578713fca451afe260dce45317/scripts/log_payload.json#L8) which uses SHA256 as a hasher. The log-client created by the kt-signer used `OBJECT_RFC6962_SHA256`. A following PR should make this a param to `config.LogClient` and autom. read it (either from the json or from a cmd-flag/config flag).

Fixes `WaitForInclusion` timing out.

Together with google/trillian#729 this resolves #688