### PR TITLE
Fix one-off error in mutations API

### DIFF
--- a/deploy/kubernetes/keytransparency-deployment.yml.tmpl
+++ b/deploy/kubernetes/keytransparency-deployment.yml.tmpl
@@ -40,6 +40,8 @@ spec:
               value: /kt/server.key
             - name: TLS_CRT_PATH
               value: /kt/server.crt
+            - name: VRF_PRIV
+              value: /kt/vrf-key.pem
       initContainers:
       - name: init-trillian-map
         image: radial/busyboxplus


### PR DESCRIPTION
Catch up with one off fix in mutations API
also fixes current kubernetes deployment (correct `VRF_PRIV`environment variable)

related to https://github.com/google/keytransparency/pull/661 and https://github.com/google/keytransparency/issues/654