### PR TITLE
Enforce golint in travis-presubmit.sh

### DIFF
--- a/scripts/travis-presubmit.sh
+++ b/scripts/travis-presubmit.sh
@@ -48,9 +48,10 @@ main() {
   fi
 
   printf "running golint...\n"
-  status=$(find . -iregex '.[^.]*.go' ! -path "./vendor/*" -exec golint {} \;)
+  status=$(find . -iregex '.[^.]*.go' ! -path "./vendor/*" ! -name "gen.go" -exec golint {} \;)
   if [[ -n ${status} ]]; then
     printf "golint found the following issues:\n${status}\n"
+    fail=1
   fi
 
   printf "running go vet...\n"


### PR DESCRIPTION
Currently `golint` is not enforced in `scripts/travis-presubmit.sh`. This PR enforces it in order to detect style violations during Travis run.