### PR TITLE
Use MapID as reported in SignedMapRoot

### DIFF
--- a/cmd/keytransparency-client/grpcc/grpc_client.go
+++ b/cmd/keytransparency-client/grpcc/grpc_client.go
@@ -91,7 +91,7 @@ type Client struct {
 }
 
 // New creates a new client.
-func New(mapID int64,
+func New(
 	client spb.KeyTransparencyServiceClient,
 	vrf vrf.PublicKey,
 	verifier crypto.PublicKey,
@@ -99,7 +99,7 @@ func New(mapID int64,
 	return &Client{
 		cli:        client,
 		vrf:        vrf,
-		kt:         kt.New(vrf, tv.New(mapID, sparse.CONIKSHasher), verifier, log),
+		kt:         kt.New(vrf, tv.New(sparse.CONIKSHasher), verifier, log),
 		log:        log,
 		mutator:    entry.New(),
 		RetryCount: 1,

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -25,15 +25,16 @@ import (
 	"github.com/google/keytransparency/core/crypto/commitments"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/tree/sparse"
-	tv "github.com/google/keytransparency/core/tree/sparse/verifier"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian"
 	"github.com/google/trillian/client"
-	tcrypto "github.com/google/trillian/crypto"
 	"golang.org/x/net/context"
 
+	tv "github.com/google/keytransparency/core/tree/sparse/verifier"
+	tcrypto "github.com/google/trillian/crypto"
+
 	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
-	"github.com/google/trillian"
 )
 
 var (
@@ -106,7 +107,8 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, userID, appID str
 		return ErrNilProof
 	}
 
-	if err := v.tree.VerifyProof(leafProof.Inclusion, index[:], leafProof.Leaf.LeafValue, sparse.FromBytes(in.GetSmr().RootHash)); err != nil {
+	mapID := in.GetSmr().GetMapId()
+	if err := v.tree.VerifyProof(mapID, leafProof.Inclusion, index[:], leafProof.Leaf.LeafValue, sparse.FromBytes(in.GetSmr().RootHash)); err != nil {
 		Vlog.Printf("✗ Sparse tree proof verification failed.")
 		return fmt.Errorf("tree.VerifyProof(): %v", err)
 	}

--- a/core/tree/sparse/verifier/verifier_test.go
+++ b/core/tree/sparse/verifier/verifier_test.go
@@ -82,7 +82,7 @@ func generateNbrData(t *testing.T, leaves []Leaf) ([][][]byte, error) {
 */
 
 func TestVerifyProof(t *testing.T) {
-	verifier := New(mapID, sparse.CONIKSHasher)
+	verifier := New(sparse.CONIKSHasher)
 	for _, tc := range []struct {
 		root   []byte
 		leaves []Leaf
@@ -165,7 +165,7 @@ func TestVerifyProof(t *testing.T) {
 				nbrs[256-len(leaf.nbrs)+k] = nbr
 			}
 
-			if err := verifier.VerifyProof(nbrs, leaf.index, leaf.value, sparse.FromBytes(tc.root)); err != nil {
+			if err := verifier.VerifyProof(mapID, nbrs, leaf.index, leaf.value, sparse.FromBytes(tc.root)); err != nil {
 				t.Errorf("VerifyProof(_, %v, _, _)=%v", leaf.index, err)
 			}
 		}

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -214,7 +214,7 @@ func NewEnv(t *testing.T) *Env {
 		t.Fatalf("Dial(%v) = %v", addr, err)
 	}
 	cli := pb.NewKeyTransparencyServiceClient(cc)
-	client := grpcc.New(mapID, cli, vrfPub, verifier, fake.NewFakeTrillianLogVerifier())
+	client := grpcc.New(cli, vrfPub, verifier, fake.NewFakeTrillianLogVerifier())
 	client.RetryCount = 0
 
 	return &Env{s, server, cc, client, signer, sqldb, factory, vrfPriv, cli, hs}

--- a/scripts/prepare_client.sh
+++ b/scripts/prepare_client.sh
@@ -76,7 +76,6 @@ vrf:    \"${VRF}\"
 kt-key: \"${KTKEY}\"
 kt-sig: \"${SIGKEY}\"
 domain: \"${DOMAIN}\"
-mapid: ${MAP_ID}
 kt-url: \"${KTURL}\"
 client-secret: \"${CLIENTSECRET}\"
 service-key: \"${SERVICEKEY}\""


### PR DESCRIPTION
MapID is part of SignedMapRoot and part of leaf and empty hash
computation. We can remove a bit of state from the client without a
reduction in security by relying on the value as reported by the server.