### PR TITLE
Turn on more presubmit checks

### DIFF
--- a/cmd/keytransparency-client/grpcc/grpc_client.go
+++ b/cmd/keytransparency-client/grpcc/grpc_client.go
@@ -48,9 +48,6 @@ const (
 	// keys. Assuming 2 keys per profile (each of size 2048-bit), a page of
 	// size 16 will contain about 8KB of data.
 	pageSize = 16
-	// The default capacity used when creating a profiles list in
-	// ListHistory.
-	defaultListCap = 10
 	// TODO: Public keys of trusted monitors.
 )
 

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -28,26 +28,27 @@ import (
 	"github.com/google/keytransparency/core/keyserver"
 	"github.com/google/keytransparency/core/mutator/entry"
 
-	cmutation "github.com/google/keytransparency/core/mutation"
 	"github.com/google/keytransparency/impl/authorization"
-	gauth "github.com/google/keytransparency/impl/google/authentication"
 	"github.com/google/keytransparency/impl/mutation"
-	ktpb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
-	mpb "github.com/google/keytransparency/impl/proto/mutation_v1_service"
 	"github.com/google/keytransparency/impl/sql/commitments"
 	"github.com/google/keytransparency/impl/sql/engine"
 	"github.com/google/keytransparency/impl/sql/mutations"
 	"github.com/google/keytransparency/impl/transaction"
-	"github.com/google/trillian"
 
 	"github.com/golang/glog"
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"github.com/google/trillian"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
+
+	cmutation "github.com/google/keytransparency/core/mutation"
+	gauth "github.com/google/keytransparency/impl/google/authentication"
+	ktpb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
+	mpb "github.com/google/keytransparency/impl/proto/mutation_v1_service"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 
 var (
@@ -207,7 +208,7 @@ func main() {
 	mux.Handle("/", gwmux)
 
 	metricMux := http.NewServeMux()
-	metricMux.Handle("/metrics", prometheus.Handler())
+	metricMux.Handle("/metrics", promhttp.Handler())
 	go func() {
 		log.Printf("Hosting metrics on %v", *metricsAddr)
 		if err := http.ListenAndServe(*metricsAddr, metricMux); err != nil {

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -113,7 +113,7 @@ func grpcGatewayMux(addr string) (*runtime.ServeMux, error) {
 
 // grpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
 // connections or otherHandler otherwise. Copied from cockroachdb.
-func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Handler {
+func grpcHandlerFunc(grpcServer http.Handler, otherHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This is a partial recreation of gRPC's internal checks.
 		// https://github.com/grpc/grpc-go/blob/master/transport/handler_server.go#L62

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -54,7 +54,6 @@ var (
 	addr         = flag.String("addr", ":8080", "The ip:port combination to listen on")
 	metricsAddr  = flag.String("metrics-addr", ":8081", "The ip:port to publish metrics on")
 	serverDBPath = flag.String("db", "db", "Database connection string")
-	realm        = flag.String("auth-realm", "registered-users@gmail.com", "Authentication realm for WWW-Authenticate response header")
 	vrfPath      = flag.String("vrf", "private_vrf_key.dat", "Path to VRF private key")
 	keyFile      = flag.String("key", "testdata/server.key", "TLS private key file")
 	certFile     = flag.String("cert", "testdata/server.pem", "TLS cert file")

--- a/cmd/keytransparency-signer/main.go
+++ b/cmd/keytransparency-signer/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/keytransparency/core/appender"
 	"github.com/google/keytransparency/core/mutator/entry"
 	"github.com/google/keytransparency/core/signer"
+
 	"github.com/google/keytransparency/impl/config"
 	"github.com/google/keytransparency/impl/sql/engine"
 	"github.com/google/keytransparency/impl/sql/mutations"
@@ -32,7 +33,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	_ "github.com/google/trillian/merkle/objhasher" // Register objhasher
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
@@ -104,7 +105,7 @@ func main() {
 	mutator := entry.New()
 
 	metricMux := http.NewServeMux()
-	metricMux.Handle("/metrics", prometheus.Handler())
+	metricMux.Handle("/metrics", promhttp.Handler())
 	go func() {
 		if err := http.ListenAndServe(*metricsAddr, metricMux); err != nil {
 			glog.Fatalf("ListenAndServeTLS(%v): %v", *metricsAddr, err)

--- a/core/client/kt/verify_test.go
+++ b/core/client/kt/verify_test.go
@@ -28,7 +28,6 @@ import (
 var (
 	primaryUserID = "bob"
 	primaryAppID  = "myapp"
-	fakeUserID    = "eve"
 	profileData   = []byte("key")
 )
 

--- a/core/crypto/vrf/p256/p256.go
+++ b/core/crypto/vrf/p256/p256.go
@@ -77,7 +77,7 @@ func H1(m []byte) (x, y *big.Int) {
 	for x == nil && i < 100 {
 		// TODO: Use a NIST specified DRBG.
 		h.Reset()
-		binary.Write(h, binary.BigEndian, uint32(i))
+		binary.Write(h, binary.BigEndian, i)
 		h.Write(m)
 		r := []byte{2} // Set point encoding to "compressed", y=0.
 		r = h.Sum(r)
@@ -97,7 +97,7 @@ func H2(m []byte) *big.Int {
 	for i := uint32(0); ; i++ {
 		// TODO: Use a NIST specified DRBG.
 		h.Reset()
-		binary.Write(h, binary.BigEndian, uint32(i))
+		binary.Write(h, binary.BigEndian, i)
 		h.Write(m)
 		b := h.Sum(nil)
 		k := new(big.Int).SetBytes(b[:byteLen])

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -122,7 +122,7 @@ func (s *Signer) StartSigning(ctx context.Context, minInterval, maxInterval time
 	last := time.Unix(0, mapRoot.GetTimestampNanos())
 	// Start issuing epochs:
 	clock := util.SystemTimeSource{}
-	tc := time.Tick(minInterval)
+	tc := time.NewTicker(minInterval).C
 	for f := range genEpochTicks(clock, last, tc, minInterval, maxInterval) {
 		ctxTime, cancel := context.WithTimeout(ctx, minInterval)
 		if err := s.CreateEpoch(ctxTime, f); err != nil {
@@ -318,7 +318,7 @@ func (s *Signer) CreateEpoch(ctx context.Context, forceNewEpoch bool) error {
 	mutationsCtr.Add(float64(len(mutations)))
 	indexCtr.Add(float64(len(indexes)))
 	mapUpdateHist.Observe(mapSetEnd.Sub(mapSetStart).Seconds())
-	createEpochHist.Observe(time.Now().Sub(start).Seconds())
+	createEpochHist.Observe(time.Since(start).Seconds())
 	glog.Infof("CreatedEpoch: rev: %v, root: %x", revision, setResp.GetMapRoot().GetRootHash())
 	return nil
 }

--- a/impl/sql/mutations/mysql.go
+++ b/impl/sql/mutations/mysql.go
@@ -21,8 +21,6 @@ import (
 )
 
 var (
-	driverName = "mysql"
-
 	createStmt = []string{
 		`
 	CREATE TABLE IF NOT EXISTS Maps (

--- a/impl/sql/mutations/sqlite.go
+++ b/impl/sql/mutations/sqlite.go
@@ -21,8 +21,6 @@ import (
 )
 
 var (
-	driverName = "sqlite3"
-
 	createStmt = []string{
 		`
 	CREATE TABLE IF NOT EXISTS Maps (

--- a/metalinter.json
+++ b/metalinter.json
@@ -4,7 +4,7 @@
 	      "license": "grep -rL 'Apache License' {path}:^(?P<path>.*?\\.go.*)"
              },
   "Severity": {"license": "error"},
-  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo"],
+  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode"],
   "Vendor": true,
   "VendoredLinters": true,
   "Skip": ["core/proto", "impl/proto"],

--- a/metalinter.json
+++ b/metalinter.json
@@ -4,7 +4,7 @@
 	      "license": "grep -rL 'Apache License' {path}:^(?P<path>.*?\\.go.*)"
              },
   "Severity": {"license": "error"},
-  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck"],
+  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert"],
   "Vendor": true,
   "VendoredLinters": true,
   "Skip": ["core/proto", "impl/proto"],

--- a/metalinter.json
+++ b/metalinter.json
@@ -4,7 +4,7 @@
 	      "license": "grep -rL 'Apache License' {path}:^(?P<path>.*?\\.go.*)"
              },
   "Severity": {"license": "error"},
-  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert"],
+  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert", "megacheck"],
   "Vendor": true,
   "VendoredLinters": true,
   "Skip": ["core/proto", "impl/proto"],

--- a/metalinter.json
+++ b/metalinter.json
@@ -4,7 +4,7 @@
 	      "license": "grep -rL 'Apache License' {path}:^(?P<path>.*?\\.go.*)"
              },
   "Severity": {"license": "error"},
-  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode"],
+  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck"],
   "Vendor": true,
   "VendoredLinters": true,
   "Skip": ["core/proto", "impl/proto"],

--- a/metalinter.json
+++ b/metalinter.json
@@ -4,7 +4,7 @@
 	      "license": "grep -rL 'Apache License' {path}:^(?P<path>.*?\\.go.*)"
              },
   "Severity": {"license": "error"},
-  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert", "megacheck"],
+  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert", "megacheck", "gas"],
   "Vendor": true,
   "VendoredLinters": true,
   "Skip": ["core/proto", "impl/proto"],


### PR DESCRIPTION
Based on #732 

This PR turns on the following linter checks along with simple code fixups. 

- deadcode
- varcheck detects unused global variables
- interfacer - not turned on due to larger code changes needed, but did implement a fixup
- megacheck - detects use of deprecated interfaces. 
- gas - security checks