### PR TITLE
Add license check

### DIFF
--- a/metalinter.json
+++ b/metalinter.json
@@ -4,7 +4,7 @@
 	      "license": "grep -rL 'Apache License' {path}:^(?P<path>.*?\\.go.*)"
              },
   "Severity": {"license": "error"},
-  "Enable": ["gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert", "megacheck", "gas"],
+  "Enable": ["license", "gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert", "megacheck", "gas"],
   "Vendor": true,
   "VendoredLinters": true,
   "Skip": ["core/proto", "impl/proto"],


### PR DESCRIPTION
Now that gometalinter doesn't panic on custom linters, we can enable the license check.
https://github.com/alecthomas/gometalinter/pull/333