### PR TITLE
Fix/756 Fix ListHistory command

### DIFF
--- a/cmd/keytransparency-client/cmd/history.go
+++ b/cmd/keytransparency-client/cmd/history.go
@@ -98,6 +98,6 @@ func (m mapHeads) Less(i, j int) bool { return m[i].MapRevision < m[j].MapRevisi
 func init() {
 	RootCmd.AddCommand(histCmd)
 
-	histCmd.PersistentFlags().Int64Var(&start, "start", 0, "Start epoch")
+	histCmd.PersistentFlags().Int64Var(&start, "start", 1, "Start epoch")
 	histCmd.PersistentFlags().Int64Var(&end, "end", 0, "End epoch")
 }

--- a/cmd/keytransparency-client/grpcc/grpc_client.go
+++ b/cmd/keytransparency-client/grpcc/grpc_client.go
@@ -177,7 +177,7 @@ func (c *Client) ListHistory(ctx context.Context, userID, appID string, start, e
 	var currentProfile []byte
 	profiles := make(map[*trillian.SignedMapRoot][]byte)
 	epochsReceived := int64(0)
-	epochsWant := end - start
+	epochsWant := end - start + 1
 	for epochsReceived < epochsWant {
 		resp, err := c.cli.ListEntryHistory(ctx, &tpb.ListEntryHistoryRequest{
 			UserId:   userID,

--- a/core/fake/trillian_log_client.go
+++ b/core/fake/trillian_log_client.go
@@ -20,7 +20,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-type logServer struct{}
+type logServer struct {
+	treeSize int64
+}
 
 // NewFakeTrillianLogClient returns a fake trillian log client.
 func NewFakeTrillianLogClient() trillian.TrillianLogClient {
@@ -28,6 +30,7 @@ func NewFakeTrillianLogClient() trillian.TrillianLogClient {
 }
 
 func (l *logServer) QueueLeaf(ctx context.Context, in *trillian.QueueLeafRequest, opts ...grpc.CallOption) (*trillian.QueueLeafResponse, error) {
+	l.treeSize++
 	return nil, nil
 }
 
@@ -48,7 +51,11 @@ func (l *logServer) GetConsistencyProof(ctx context.Context, in *trillian.GetCon
 }
 
 func (l *logServer) GetLatestSignedLogRoot(ctx context.Context, in *trillian.GetLatestSignedLogRootRequest, opts ...grpc.CallOption) (*trillian.GetLatestSignedLogRootResponse, error) {
-	return &trillian.GetLatestSignedLogRootResponse{}, nil
+	return &trillian.GetLatestSignedLogRootResponse{
+		SignedLogRoot: &trillian.SignedLogRoot{
+			TreeSize: l.treeSize,
+		},
+	}, nil
 }
 
 func (l *logServer) GetSequencedLeafCount(ctx context.Context, in *trillian.GetSequencedLeafCountRequest, opts ...grpc.CallOption) (*trillian.GetSequencedLeafCountResponse, error) {

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -99,6 +99,10 @@ func (s *Server) GetEntry(ctx context.Context, in *tpb.GetEntryRequest) (*tpb.Ge
 
 func (s *Server) getEntry(ctx context.Context, userID, appID string, firstTreeSize, epoch int64) (*tpb.GetEntryResponse, error) {
 	index, proof := s.vrf.Evaluate(vrf.UniqueID(userID, appID))
+	if epoch == 0 {
+		return nil, grpc.Errorf(codes.InvalidArgument,
+			"Epoch 0 is inavlid. The first map revision is epoch 1.")
+	}
 
 	getResp, err := s.tmap.GetLeaves(ctx, &trillian.GetMapLeavesRequest{
 		MapId:    s.mapID,

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -43,8 +43,6 @@ const (
 	defaultPageSize = 16
 	// Maximum allowed requested page size to prevent DOS.
 	maxPageSize = 16
-	// If no epoch is provided default to epoch 1.
-	defaultStartEpoch = 1
 )
 
 // Server holds internal state for the key server.

--- a/core/keyserver/validate.go
+++ b/core/keyserver/validate.go
@@ -109,12 +109,6 @@ func validateListEntryHistoryRequest(in *tpb.ListEntryHistoryRequest, currentEpo
 	if in.Start < 0 || in.Start > currentEpoch {
 		return ErrInvalidStart
 	}
-	// TODO(ismail): make epochs consistently start from 0 and provide a function
-	// such that callers don't need convert between starting 0 and 1.
-	// Ensure a valid start epoch is provided if the Start parameter is not set.
-	if in.Start == 0 {
-		in.Start = defaultStartEpoch
-	}
 
 	switch {
 	case in.PageSize < 0:

--- a/core/signer/signer.go
+++ b/core/signer/signer.go
@@ -113,6 +113,7 @@ func (s *Signer) Initialize(ctx context.Context) error {
 	// add the empty map root to the log.
 	if logRoot.GetSignedLogRoot().GetTreeSize() == 0 &&
 		mapRoot.GetMapRoot().GetMapRevision() == 0 {
+		glog.Infof("Initializing Trillian Log with empty map root")
 		if err := queueLogLeaf(ctx, s.tlog, s.logID, mapRoot.GetMapRoot()); err != nil {
 			return err
 		}


### PR DESCRIPTION
Cleans up a few off by on errors and poor stopping condition logic in the list history command.

Fixes #756 
Rebased on #760 and #762. Merge them first.

