### PR TITLE
Monitor verification logic

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@ Antonio Marcedone <a.marcedone@gmail.com>
 Cesar Ghali <cghali@uci.edu>
 Daniel Ziegler <dmz@yahoo-inc.com>
 Gary Belvin <gdbelvin@gmail.com>
+Ismail Khoffi <Ismail.Khoffi@gmail.com>

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -120,6 +120,10 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, userID, appID str
 	// by removing the signature from the object.
 	smr := *in.GetSmr()
 	smr.Signature = nil // Remove the signature from the object to be verified.
+	fmt.Println("CLIENT tcrypto.VerifyObject:")
+	fmt.Println(v.mapPubKey)
+	fmt.Println(smr)
+	fmt.Println(in.GetSmr().GetSignature())
 	if err := tcrypto.VerifyObject(v.mapPubKey, smr, in.GetSmr().GetSignature()); err != nil {
 		Vlog.Printf("✗ Signed Map Head signature verification failed.")
 		return fmt.Errorf("sig.Verify(SMR): %v", err)

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -120,10 +120,6 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, userID, appID str
 	// by removing the signature from the object.
 	smr := *in.GetSmr()
 	smr.Signature = nil // Remove the signature from the object to be verified.
-	fmt.Println("CLIENT tcrypto.VerifyObject:")
-	fmt.Println(v.mapPubKey)
-	fmt.Println(smr)
-	fmt.Println(in.GetSmr().GetSignature())
 	if err := tcrypto.VerifyObject(v.mapPubKey, smr, in.GetSmr().GetSignature()); err != nil {
 		Vlog.Printf("✗ Signed Map Head signature verification failed.")
 		return fmt.Errorf("sig.Verify(SMR): %v", err)

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -33,14 +33,14 @@ import (
 // Monitor holds the internal state for a monitor accessing the mutations API
 // and for verifying its responses.
 type Monitor struct {
-	hasher      hashers.MapHasher
+	logHasher   hashers.LogHasher
+	mapHasher   hashers.MapHasher
 	logPubKey   crypto.PublicKey
 	mapPubKey   crypto.PublicKey
 	logVerifier merkle.LogVerifier
 	signer      *tcrypto.Signer
-	// TODO(ismail): update last trusted signed log root
-	trusted *trillian.SignedLogRoot
-	store   *storage.Storage
+	trusted     *trillian.SignedLogRoot
+	store       *storage.Storage
 }
 
 // New creates a new instance of the monitor.
@@ -54,7 +54,8 @@ func New(logTree, mapTree *trillian.Tree, signer *tcrypto.Signer, store *storage
 		return nil, fmt.Errorf("Failed creating MapHasher: %v", err)
 	}
 	return &Monitor{
-		hasher:      mapHasher,
+		mapHasher:   mapHasher,
+		logHasher:   logHasher,
 		logVerifier: merkle.NewLogVerifier(logHasher),
 		logPubKey:   logTree.GetPublicKey(),
 		mapPubKey:   mapTree.GetPublicKey(),

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -39,8 +39,8 @@ type Monitor struct {
 	logVerifier merkle.LogVerifier
 	signer      *tcrypto.Signer
 	// TODO(ismail): update last trusted signed log root
-	//trusted     trillian.SignedLogRoot
-	store *storage.Storage
+	trusted *trillian.SignedLogRoot
+	store   *storage.Storage
 }
 
 // New creates a new instance of the monitor.

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -35,24 +35,19 @@ import (
 // Monitor holds the internal state for a monitor accessing the mutations API
 // and for verifying its responses.
 type Monitor struct {
-	mapID          int64
-	logHasher      hashers.LogHasher
-	mapHasher      hashers.MapHasher
-	logPubKey      crypto.PublicKey
-	mapPubKey      crypto.PublicKey
-	logVerifier    merkle.LogVerifier
-	logVerifierCli client.LogVerifier
-	signer         *tcrypto.Signer
-	trusted        *trillian.SignedLogRoot
-	store          *storage.Storage
+	mapID       int64
+	logHasher   hashers.LogHasher
+	mapHasher   hashers.MapHasher
+	logPubKey   crypto.PublicKey
+	mapPubKey   crypto.PublicKey
+	logVerifier client.LogVerifier
+	signer      *tcrypto.Signer
+	trusted     *trillian.SignedLogRoot
+	store       *storage.Storage
 }
 
 // New creates a new instance of the monitor.
-func New(logverifierCli client.LogVerifier, logTree, mapTree *trillian.Tree, signer *tcrypto.Signer, store *storage.Storage) (*Monitor, error) {
-	logHasher, err := hashers.NewLogHasher(logTree.GetHashStrategy())
-	if err != nil {
-		return nil, fmt.Errorf("Failed creating LogHasher: %v", err)
-	}
+func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcrypto.Signer, store *storage.Storage) (*Monitor, error) {
 	mapHasher, err := hashers.NewMapHasher(mapTree.GetHashStrategy())
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating MapHasher: %v", err)
@@ -62,15 +57,12 @@ func New(logverifierCli client.LogVerifier, logTree, mapTree *trillian.Tree, sig
 		return nil, fmt.Errorf("Could not unmarshal map public key: %v", err)
 	}
 	return &Monitor{
-		logVerifierCli: logverifierCli,
-		mapID:          mapTree.TreeId,
-		mapHasher:      mapHasher,
-		logHasher:      logHasher,
-		logVerifier:    merkle.NewLogVerifier(logHasher),
-		logPubKey:      logTree.GetPublicKey(),
-		mapPubKey:      mapPubKey,
-		signer:         signer,
-		store:          store,
+		logVerifier: logverifierCli,
+		mapID:       mapTree.TreeId,
+		mapHasher:   mapHasher,
+		mapPubKey:   mapPubKey,
+		signer:      signer,
+		store:       store,
 	}, nil
 }
 

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -27,18 +27,15 @@ import (
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
 	tcrypto "github.com/google/trillian/crypto"
-	"github.com/google/trillian/merkle"
-	"github.com/google/trillian/merkle/hashers"
 	"github.com/google/trillian/crypto/keys/der"
+	"github.com/google/trillian/merkle/hashers"
 )
 
 // Monitor holds the internal state for a monitor accessing the mutations API
 // and for verifying its responses.
 type Monitor struct {
 	mapID       int64
-	logHasher   hashers.LogHasher
 	mapHasher   hashers.MapHasher
-	logPubKey   crypto.PublicKey
 	mapPubKey   crypto.PublicKey
 	logVerifier client.LogVerifier
 	signer      *tcrypto.Signer
@@ -52,7 +49,7 @@ func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcry
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating MapHasher: %v", err)
 	}
-	mapPubKey, err  := der.UnmarshalPublicKey(mapTree.GetPublicKey().GetDer())
+	mapPubKey, err := der.UnmarshalPublicKey(mapTree.GetPublicKey().GetDer())
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal map public key: %v", err)
 	}

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -18,14 +18,181 @@
 package monitor
 
 import (
+	"bytes"
+	"errors"
+	"math/big"
+
+	"github.com/golang/glog"
+
+	"github.com/google/trillian/merkle"
+	"github.com/google/trillian/storage"
+
+	tcrypto "github.com/google/trillian/crypto"
+
+	"github.com/google/keytransparency/core/mutator/entry"
 	ktpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 )
 
-// verifyMutationsResponse verifies a response received by the GetMutations API.
+var (
+	// ErrInvalidMutation occurs when verification failed because of an invalid
+	// mutation.
+	ErrInvalidMutation = errors.New("invalid mutation")
+	// ErrNotMatchingMapRoot occurs when the reconstructed root differs from the one
+	// we received from the server.
+	ErrNotMatchingMapRoot = errors.New("recreated root does not match")
+	// ErrInvalidMapSignature occurs if the map roots signature does not verify.
+	ErrInvalidMapSignature = errors.New("invalid signature on map root")
+	// ErrInvalidLogSignature occurs if the log roots signature does not verify.
+	ErrInvalidLogSignature = errors.New("invalid signature on log root")
+	// ErrInconsistentProofs occurs when the server returned different hashes
+	// for the same inclusion proof node in the tree.
+	ErrInconsistentProofs = errors.New("inconsistent inclusion proofs")
+	// ErrInvalidConsistencyProof occurs when the log consistency proof does not
+	// verify.
+	ErrInvalidConsistencyProof = errors.New("invalid log consistency proof")
+)
+
+// verifyResponse verifies a response received by the GetMutations API.
 // Additionally to the response it takes a complete list of mutations. The list
 // of received mutations may differ from those included in the initial response
-// because of the max. page size. If any verification check failed it returns
-// an error.
+// because of the max. page size.
 func (m *Monitor) verifyMutationsResponse(in *ktpb.GetMutationsResponse) []error {
+	errList := make([]error, 0)
+	// copy of singed map root
+	smr := *in.GetSmr()
+	// reset to the state before it was signed:
+	smr.Signature = nil
+	// verify signature on map root:
+	if err := tcrypto.VerifyObject(m.mapPubKey, smr, in.GetSmr().GetSignature()); err != nil {
+		glog.Infof("couldn't verify signature on map root: %v", err)
+		errList = append(errList, ErrInvalidMapSignature)
+	}
+
+	logRoot := in.GetLogRoot()
+	// Verify SignedLogRoot signature.
+	hash := tcrypto.HashLogRoot(*logRoot)
+	if err := tcrypto.Verify(m.logPubKey, hash, logRoot.GetSignature()); err != nil {
+		glog.Infof("couldn't verify signature on log root: %v", err)
+		errList = append(errList, ErrInvalidLogSignature)
+	}
+
+	if m.trusted != nil {
+		// Verify consistency proof:
+		err := m.logVerifier.VerifyConsistencyProof(
+			m.trusted.TreeSize, logRoot.TreeSize,
+			m.trusted.RootHash, logRoot.RootHash,
+			in.GetLogConsistency())
+		if err != nil {
+			errList = append(errList, ErrInvalidConsistencyProof)
+		}
+	} else {
+		// trust the first log root we see, don't verify anything yet
+		m.trusted = in.GetLogRoot()
+	}
+
+	// m.logVerifier.VerifyInclusionProof()
+	//
+	// retrieve the old root hash from storage!
+	monRes, err := m.store.Get(in.Epoch - 1)
+	if err != nil {
+		glog.Infof("Could not retrieve previous monitoring result: %v", err)
+	}
+	// we need the old root for verifying the inclusion of the old leafs in the
+	// previous epoch. Storage always stores the mutations response independent
+	// from if the checks succeeded or not.
+	oldRoot := monRes.Response.GetSmr().GetRootHash()
+
+	if err := m.verifyMutations(in.GetMutations(), oldRoot,
+		in.GetSmr().GetRootHash(), in.GetSmr().GetMapId()); len(err) > 0 {
+		errList = append(errList, err...)
+	}
+
+	return errList
+}
+
+func (m *Monitor) verifyMutations(muts []*ktpb.Mutation, oldRoot, expectedNewRoot []byte, mapID int64) []error {
+	errList := make([]error, 0)
+	mutator := entry.New()
+	oldProofNodes := make(map[string][]byte)
+	newLeaves := make([]merkle.HStar2LeafHash, 0, len(muts))
+
+	for _, mut := range muts {
+		oldLeaf, err := entry.FromLeafValue(mut.GetProof().GetLeaf().GetLeafValue())
+		if err != nil {
+			errList = append(errList, ErrInvalidMutation)
+		}
+
+		// verify that the provided leaf’s inclusion proof goes to epoch e-1:
+		index := mut.GetProof().GetLeaf().GetIndex()
+		leafHash := mut.GetProof().GetLeaf().GetLeafHash()
+		if err := merkle.VerifyMapInclusionProof(mapID, index,
+			leafHash, oldRoot, mut.GetProof().GetInclusion(), m.hasher); err != nil {
+			glog.Infof("VerifyMapInclusionProof(%x): %v", index, err)
+			errList = append(errList, err)
+		}
+
+		// compute the new leaf
+		newLeaf, err := mutator.Mutate(oldLeaf, mut.GetUpdate())
+		if err != nil {
+			errList = append(errList, ErrInvalidMutation)
+		}
+		newLeafnID := storage.NewNodeIDFromPrefixSuffix(index, storage.Suffix{}, m.hasher.BitLen())
+		newLeafHash := m.hasher.HashLeaf(mapID, index, newLeaf)
+		newLeaves = append(newLeaves, merkle.HStar2LeafHash{
+			Index:    newLeafnID.BigInt(),
+			LeafHash: newLeafHash,
+		})
+
+		// store the proof hashes locally to recompute the tree below:
+		sibIDs := newLeafnID.Siblings()
+		// TODO(ismail) iterate over the sibIDs instead!
+		for level, proof := range mut.GetProof().GetInclusion() {
+			pID := sibIDs[level]
+			if p, ok := oldProofNodes[pID.String()]; ok {
+				// sanity check: for each mut overlapping proof nodes should be
+				// equal:
+				if !bytes.Equal(p, proof) {
+					// TODO(ismail): remove this check and this error type as
+					// soon as the server does not return interior proof nodes
+					// multiple times
+					//
+					// this is really odd and should never happen
+					errList = append(errList, ErrInconsistentProofs)
+				}
+			} else {
+				oldProofNodes[pID.String()] = proof
+			}
+		}
+	}
+	if err := m.validateMapRoot(expectedNewRoot, mapID, newLeaves, oldProofNodes); err != nil {
+		errList = append(errList, err)
+	}
+
+	return errList
+}
+
+func (m *Monitor) validateMapRoot(expectedRoot []byte, mapID int64, mutatedLeaves []merkle.HStar2LeafHash, oldProofNodes map[string][]byte) error {
+	// compute the new root using local intermediate hashes from epoch e
+	// (above proof hashes):
+	hs2 := merkle.NewHStar2(mapID, m.hasher)
+	newRoot, err := hs2.HStar2Nodes([]byte{}, m.hasher.Size(), mutatedLeaves,
+		func(depth int, index *big.Int) ([]byte, error) {
+			nID := storage.NewNodeIDFromBigInt(depth, index, m.hasher.BitLen())
+			if p, ok := oldProofNodes[nID.String()]; ok {
+				return p, nil
+			}
+			return nil, nil
+		}, nil)
+
+	if err != nil {
+		glog.Errorf("hs2.HStar2Nodes(_): %v", err)
+		// TODO(ismail): figure out what to return here
+	}
+
+	// verify rootHash
+	if !bytes.Equal(newRoot, expectedRoot) {
+		return ErrNotMatchingMapRoot
+	}
+
 	return nil
 }

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/google/keytransparency/core/mutator/entry"
 	ktpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
-	"fmt"
 )
 
 var (
@@ -110,7 +109,6 @@ func (m *Monitor) VerifyMutationsResponse(in *ktpb.GetMutationsResponse) []error
 	// from if the checks succeeded or not.
 	var oldRoot []byte
 	if m.store.LatestEpoch() > 0 {
-		fmt.Println("Called")
 		// retrieve the old root hash from storage!
 		monRes, err := m.store.Get(in.Epoch - 1)
 		if err != nil {
@@ -149,9 +147,6 @@ func (m *Monitor) verifyMutations(muts []*ktpb.Mutation, oldRoot, expectedNewRoo
 		}
 
 		// compute the new leaf
-		fmt.Println("old leaf: ")
-		fmt.Println(mut.GetProof().GetLeaf().GetLeafValue())
-		fmt.Println(oldLeaf)
 		newLeaf, err := mutator.Mutate(oldLeaf, mut.GetUpdate())
 		if err != nil {
 			glog.Infof("Mutation did not verify: %v", err)
@@ -183,9 +178,6 @@ func (m *Monitor) verifyMutations(muts []*ktpb.Mutation, oldRoot, expectedNewRoo
 			}
 		}
 	}
-	fmt.Println(newLeaves)
-	fmt.Println(expectedNewRoot)
-	fmt.Println(oldProofNodes)
 	if err := m.validateMapRoot(expectedNewRoot, mapID, newLeaves, oldProofNodes); err != nil {
 		errList = append(errList, err)
 	}

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -23,14 +23,13 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/golang/glog"
+	"github.com/google/keytransparency/core/mutator/entry"
 
+	"github.com/golang/glog"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 
-	tcrypto "github.com/google/trillian/crypto"
-
-	"github.com/google/keytransparency/core/mutator/entry"
 	ktpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 )
 

--- a/core/mutation/mutation.go
+++ b/core/mutation/mutation.go
@@ -108,7 +108,7 @@ func (s *Server) GetMutations(ctx context.Context, in *tpb.GetMutationsRequest) 
 	// TODO: allow leaf proofs to be optional.
 	var epoch int64
 	if in.Epoch > 1 {
-		epoch = in.Epoch-1
+		epoch = in.Epoch - 1
 	} else {
 		epoch = 1
 	}

--- a/core/mutation/mutation.go
+++ b/core/mutation/mutation.go
@@ -106,7 +106,13 @@ func (s *Server) GetMutations(ctx context.Context, in *tpb.GetMutationsRequest) 
 	}
 	// Get leaf proofs.
 	// TODO: allow leaf proofs to be optional.
-	proofs, err := s.inclusionProofs(ctx, indexes, in.Epoch)
+	var epoch int64
+	if in.Epoch > 1 {
+		epoch = in.Epoch-1
+	} else {
+		epoch = 1
+	}
+	proofs, err := s.inclusionProofs(ctx, indexes, epoch)
 	if err != nil {
 		return nil, err
 	}
@@ -114,10 +120,10 @@ func (s *Server) GetMutations(ctx context.Context, in *tpb.GetMutationsRequest) 
 		mutations[i].Proof = p
 	}
 
-	// MapRevisions start at 1. Log leave's index starts at 0.
+	// MapRevisions start at 1. Log leave's index starts at 1.
 	// MapRevision should be at least 1 since the Signer is
 	// supposed to create at least one revision on startup.
-	respEpoch := resp.GetMapRoot().GetMapRevision() - 1
+	respEpoch := resp.GetMapRoot().GetMapRevision()
 	// Fetch log proofs.
 	logRoot, logConsistency, logInclusion, err := s.logProofs(ctx, in.GetFirstTreeSize(), respEpoch)
 	if err != nil {

--- a/impl/monitor/client/client.go
+++ b/impl/monitor/client/client.go
@@ -64,9 +64,9 @@ func (c *Client) StartPolling(startEpoch int64) (<-chan *ktpb.GetMutationsRespon
 			glog.Infof("Polling: %v", now)
 			// time out if we exceed the poll period:
 			ctx, _ := context.WithTimeout(context.Background(), c.pollPeriod)
-			monitorResp, err := c.pollMutations(ctx, epoch)
+			monitorResp, err := c.PollMutations(ctx, epoch)
 			if err != nil {
-				glog.Infof("pollMutations(_): %v", err)
+				glog.Infof("PollMutations(_): %v", err)
 				errChan <- err
 			} else {
 				// only write to results channel and increment epoch
@@ -80,7 +80,9 @@ func (c *Client) StartPolling(startEpoch int64) (<-chan *ktpb.GetMutationsRespon
 	return response, errChan
 }
 
-func (c *Client) pollMutations(ctx context.Context,
+// PollMutations polls GetMutationsResponses from the configured
+// key-transparency server's mutations API.
+func (c *Client) PollMutations(ctx context.Context,
 	queryEpoch int64,
 	opts ...grpc.CallOption) (*ktpb.GetMutationsResponse, error) {
 	response, err := c.client.GetMutations(ctx, &ktpb.GetMutationsRequest{

--- a/integration/monitor_test.go
+++ b/integration/monitor_test.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/google/keytransparency/core/monitor"
 	"github.com/google/keytransparency/core/monitor/storage"
-	"github.com/google/keytransparency/impl/monitor/client"
 	kpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+	"github.com/google/keytransparency/impl/monitor/client"
 	spb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
 	mupb "github.com/google/keytransparency/impl/proto/mutation_v1_service"
 	"github.com/google/trillian/crypto"
@@ -54,14 +54,14 @@ func TestMonitorEmptyStart(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't retrieve domain info: %v", err)
 	}
-	signer, err  := pem.UnmarshalPrivateKey(monitorPrivKey, "")
+	signer, err := pem.UnmarshalPrivateKey(monitorPrivKey, "")
 	if err != nil {
 		t.Fatalf("Couldn't create signer: %v", err)
 	}
-	logTree := resp.Log
+	//logTree := resp.Log
 	mapTree := resp.Map
 	store := storage.New()
-	mon, err := monitor.New(fake.NewFakeTrillianLogVerifier(), logTree, mapTree, crypto.NewSHA256Signer(signer), store)
+	mon, err := monitor.New(fake.NewFakeTrillianLogVerifier(), mapTree, crypto.NewSHA256Signer(signer), store)
 	if err != nil {
 		t.Fatalf("Couldn't create monitor: %v", err)
 	}

--- a/integration/monitor_test.go
+++ b/integration/monitor_test.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/keytransparency/core/monitor"
+	"github.com/google/keytransparency/core/monitor/storage"
+	"github.com/google/keytransparency/impl/monitor/client"
+	kpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+	spb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
+	mupb "github.com/google/keytransparency/impl/proto/mutation_v1_service"
+	"github.com/google/trillian/crypto"
+	"github.com/google/trillian/crypto/keys/pem"
+
+	"github.com/google/keytransparency/core/fake"
+)
+
+const (
+	monitorPrivKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIAV7H3qRi/cj/w04vEQBFjLdhcXRbZR4ouT5zaAy1XUHoAoGCCqGSM49
+AwEHoUQDQgAEqUDbATN2maGIm6YQLpjx67bYN1hxPPdF0VrPTZe36yQhH+GCwZQV
+amFdON6OhjYnBmJWe4fVnbxny0PfpkvXtg==
+-----END EC PRIVATE KEY-----`
+)
+
+func TestMonitorEmptyStart(t *testing.T) {
+	bctx := context.Background()
+	env := NewEnv(t)
+	defer env.Close(t)
+	env.Client.RetryCount = 0
+
+	// setup monitor:
+
+	// TODO(ismail) setup a proper log environment in the integration
+	// environment, then use GetDomainInfo here:
+	c := spb.NewKeyTransparencyServiceClient(env.Conn)
+	resp, err := c.GetDomainInfo(bctx, &kpb.GetDomainInfoRequest{})
+	if err != nil {
+		t.Fatalf("Couldn't retrieve domain info: %v", err)
+	}
+	signer, err  := pem.UnmarshalPrivateKey(monitorPrivKey, "")
+	if err != nil {
+		t.Fatalf("Couldn't create signer: %v", err)
+	}
+	logTree := resp.Log
+	mapTree := resp.Map
+	store := storage.New()
+	mon, err := monitor.New(fake.NewFakeTrillianLogVerifier(), logTree, mapTree, crypto.NewSHA256Signer(signer), store)
+	if err != nil {
+		t.Fatalf("Couldn't create monitor: %v", err)
+	}
+	// Initialization and CreateEpoch is called by NewEnv
+	mcc := mupb.NewMutationServiceClient(env.Conn)
+	mutCli := client.New(mcc, time.Second)
+	//  verify first SMR
+	mutResp, err := mutCli.PollMutations(bctx, 1)
+	if err != nil {
+		t.Fatalf("Could not query mutations: %v", err)
+	}
+	_ = mon
+	if err := mon.Process(mutResp); err != nil {
+		t.Fatalf("Monitor could process mutations: %v", err)
+	}
+	mresp, err := store.Get(1)
+	if err != nil {
+		t.Fatalf("Could not read monitoring response: %v", err)
+	}
+	for _, err := range mresp.Errors {
+		t.Errorf("Got error: %v", err)
+	}
+
+	// TODO client sends one mutation, sequencer "signs", monitor verifies
+}

--- a/integration/monitor_test.go
+++ b/integration/monitor_test.go
@@ -41,16 +41,13 @@ amFdON6OhjYnBmJWe4fVnbxny0PfpkvXtg==
 -----END EC PRIVATE KEY-----`
 )
 
-func TestMonitorEmptyStart(t *testing.T) {
+func TestMonitor(t *testing.T) {
 	bctx := context.Background()
 	env := NewEnv(t)
 	defer env.Close(t)
 	env.Client.RetryCount = 0
 
 	// setup monitor:
-
-	// TODO(ismail) setup a proper log environment in the integration
-	// environment, then use GetDomainInfo here:
 	c := spb.NewKeyTransparencyServiceClient(env.Conn)
 	resp, err := c.GetDomainInfo(bctx, &kpb.GetDomainInfoRequest{})
 	if err != nil {
@@ -63,6 +60,7 @@ func TestMonitorEmptyStart(t *testing.T) {
 	//logTree := resp.Log
 	mapTree := resp.Map
 	store := storage.New()
+	// TODO(ismail): setup and use a real logVerifier instead:
 	mon, err := monitor.New(fake.NewFakeTrillianLogVerifier(), mapTree, crypto.NewSHA256Signer(signer), store)
 	if err != nil {
 		t.Fatalf("Couldn't create monitor: %v", err)

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -138,11 +138,6 @@ func NewEnv(t *testing.T) *Env {
 	logTree, err := mapEnv.AdminClient.CreateTree(ctx, &trillian.CreateTreeRequest{
 		Tree: stestonly.LogTree,
 	})
-	//logPubKey, err := der.UnmarshalPublicKey(tree.GetPublicKey().GetDer())
-	//if err != nil {
-	//	t.Fatalf("Failed to load signing keypair: %v", err)
-	//}
-
 	if err != nil {
 		t.Fatalf("CreateTree(): %v", err)
 	}

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -43,11 +43,11 @@ import (
 
 	_ "github.com/mattn/go-sqlite3" // Use sqlite database for testing.
 
+	cmutation "github.com/google/keytransparency/core/mutation"
+	"github.com/google/keytransparency/impl/mutation"
 	pb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
 	mpb "github.com/google/keytransparency/impl/proto/mutation_v1_service"
-	cmutation "github.com/google/keytransparency/core/mutation"
 	stestonly "github.com/google/trillian/storage/testonly"
-	"github.com/google/keytransparency/impl/mutation"
 )
 
 // NewDB creates a new in-memory database for testing.


### PR DESCRIPTION
This PR contains the monitor verification logic which should be plugged into the monitor after #776  is merged.

Includes a fix for https://github.com/google/keytransparency/issues/800 and related to this a temporary workaround for #811. 

resolves #800 