### PR TITLE
Monitor: kubernets config and deploy script

### DIFF
--- a/deploy/kubernetes/keytransparency-deployment.yml.tmpl
+++ b/deploy/kubernetes/keytransparency-deployment.yml.tmpl
@@ -156,3 +156,58 @@ spec:
         ports:
           - containerPort: 9090
             name: prometheus
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: kt-monitor
+spec:
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        run: kt-monitor
+    spec:
+      volumes:
+      - name: secrets-volume
+        secret:
+          secretName: kt-monitor-secrets
+      containers:
+      - name: kt-monitor
+        image: us.gcr.io/key-transparency/keytransparency-monitor
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: secrets-volume
+          readOnly: true
+          mountPath: "/secrets"
+        ports:
+          - containerPort: 8080
+            name: json-grpc
+        args: ["--addr=0.0.0.0:8099",
+               "--kt-url=kt-server:8080",
+               # TODO(ismail): generate TLS key-pairs for the monitor:
+               "--tls-key=/secrets/server.key",
+               "--tls-cert=/secrets/server.crt",
+               "--poll-period=5s",
+               "--sign-key=/secrets/monitor_sign-key.pem",
+               "--password=towel",
+               "--alsologtostderr",
+               "--v=3"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kt-monitor
+  labels:
+    run: kt-monitor
+spec:
+  type: NodePort
+  ports:
+    - port: 8081
+      targetPort: 8081
+      name: metrics
+  selector:
+    run: kt-monitor
+---

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -145,12 +145,16 @@ function checkCmdsAvailable()
 
 function prepareSecrets()
 {
-  local EXISTS=0
   # if kt-secrets does not exist, create it:
   kubectl get secret kt-secrets
   # kubectl exits with 1 if kt-secret does not exist
   if [ $? -ne 0 ]; then
     kubectl create secret generic kt-secrets --from-file=genfiles/server.crt --from-file=genfiles/server.key --from-file=genfiles/vrf-key.pem
+  fi
+  # if monitor-secrets does not exist, create it, too:
+  kubectl get secret kt-monitor-secrets
+  if [ $? -ne 0 ]; then
+    kubectl create secret generic kt-monitor-secrets --from-file=genfiles/monitor_sign-key.pem
   fi
 }
 


### PR DESCRIPTION
Work in progress: some modifications to the deploy script to store the monitor's keys in a kube secrets config. Also, a kubernetes config for the monitor.
This should be reviewed after it is ready and  #776 and #768 been reviewed and merged.