### PR TITLE
Remote Signer implementation

### DIFF
--- a/cmd/keytransparency-sequencer/adminapi.go
+++ b/cmd/keytransparency-sequencer/adminapi.go
@@ -37,7 +37,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 
-	ktpb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
+	ktpb "github.com/google/keytransparency/core/proto/keytransparency_v1_grpc"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 

--- a/cmd/keytransparency-sequencer/adminapi.go
+++ b/cmd/keytransparency-sequencer/adminapi.go
@@ -1,0 +1,141 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/google/keytransparency/core/adminservice"
+	"github.com/google/keytransparency/core/crypto/keymaster"
+	"github.com/google/keytransparency/core/crypto/vrf"
+	"github.com/google/keytransparency/core/crypto/vrf/p256"
+	"github.com/google/keytransparency/core/mutator/entry"
+	"github.com/google/keytransparency/impl/sql/commitments"
+	"github.com/google/keytransparency/impl/sql/mutations"
+	"github.com/google/keytransparency/impl/transaction"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
+
+	ktpb "github.com/google/keytransparency/impl/proto/keytransparency_v1_service"
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+)
+
+var (
+	keyStoreFile = flag.String("keystore", "genfiles/.keystore", "Path to keystore file")
+	vrfPath      = flag.String("vrf", "genfiles/vrf-key.pem", "Path to VRF private key")
+)
+
+func openVRFKey() vrf.PrivateKey {
+	vrfBytes, err := ioutil.ReadFile(*vrfPath)
+	if err != nil {
+		glog.Exitf("Failed opening VRF private key: %v", err)
+	}
+	vrfPriv, err := p256.NewVRFSignerFromPEM(vrfBytes)
+	if err != nil {
+		glog.Exitf("Failed parsing VRF private key: %v", err)
+	}
+	return vrfPriv
+}
+
+func readKeyStoreFile() (*keymaster.KeyMaster, error) {
+	store := keymaster.New()
+	// Authorized keys file might not exist.
+	data, err := ioutil.ReadFile(*keyStoreFile)
+	if err != nil {
+		return nil, fmt.Errorf("reading keystore file %v failed: %v", *keyStoreFile, err)
+	}
+	if err = keymaster.Unmarshal(data, store); err != nil {
+		return nil, fmt.Errorf("keystore.Unmarshak() failed: %v", err)
+	}
+	return store, nil
+}
+
+func grpcGatewayMux(addr string) (*runtime.ServeMux, error) {
+	ctx := context.Background()
+
+	creds, err := credentials.NewClientTLSFromFile(*certFile, "")
+	if err != nil {
+		return nil, err
+	}
+	dopts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+
+	gwmux := runtime.NewServeMux()
+	if err := ktpb.RegisterKeyTransparencyAdminServiceHandlerFromEndpoint(ctx, gwmux, addr, dopts); err != nil {
+		return nil, err
+	}
+
+	return gwmux, nil
+}
+
+func adminAPI(sqldb *sql.DB,
+	tmap trillian.TrillianMapClient,
+	tlog trillian.TrillianLogClient) (*grpc.Server, *runtime.ServeMux) {
+
+	creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
+	if err != nil {
+		glog.Exitf("Failed to load server credentials %v", err)
+	}
+
+	commitments, err := commitments.New(sqldb, *mapID)
+	if err != nil {
+		glog.Exitf("Failed to create committer: %v", err)
+	}
+	mutations, err := mutations.New(sqldb, *mapID)
+	if err != nil {
+		glog.Exitf("Failed to create mutations object: %v", err)
+	}
+	vrfPriv := openVRFKey()
+	mutator := entry.New()
+	factory := transaction.NewFactory(sqldb)
+
+	store, err := readKeyStoreFile()
+	if err != nil {
+		glog.Exitf("Failed to read keystore file: %v", err)
+	}
+
+	svr := adminservice.New(
+		*mapID, tmap,
+		*logID, tlog,
+		vrfPriv,
+		mutator, mutations,
+		factory, commitments,
+		store.Signers())
+
+	grpcServer := grpc.NewServer(
+		grpc.Creds(creds),
+		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
+		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
+	)
+	ktpb.RegisterKeyTransparencyAdminServiceServer(grpcServer, svr)
+	reflection.Register(grpcServer)
+	grpc_prometheus.Register(grpcServer)
+	grpc_prometheus.EnableHandlingTimeHistogram()
+
+	gwmux, err := grpcGatewayMux(*addr)
+	if err != nil {
+		glog.Exitf("Failed setting up REST proxy: %v", err)
+	}
+
+	return grpcServer, gwmux
+}

--- a/core/fake/trillian_map_client.go
+++ b/core/fake/trillian_map_client.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	tpb "github.com/google/trillian"
+)
+
+type mapServer struct {
+	// roots by revision number
+	roots    map[int64]*tpb.SignedMapRoot
+	revision int64
+}
+
+// NewTrillianMapClient returns a fake tpb.TrillianMapClient
+// This client only stores tpb.MapperMetadata in roots. It does not store
+// leaves compute inclusion proofs, or sign roots.  This client is not
+// threadsafe.
+func NewTrillianMapClient() tpb.TrillianMapClient {
+	m := &mapServer{
+		roots: make(map[int64]*tpb.SignedMapRoot),
+	}
+	m.roots[0] = &tpb.SignedMapRoot{} // Set the initial root
+	return m
+}
+
+// GetLeaves just returns the indexes requested. No leaf data, no inclusion proofs.
+func (m *mapServer) GetLeaves(ctx context.Context, in *tpb.GetMapLeavesRequest, opts ...grpc.CallOption) (*tpb.GetMapLeavesResponse, error) {
+	return m.GetLeavesByRevision(ctx, &tpb.GetMapLeavesByRevisionRequest{
+		MapId:    in.MapId,
+		Index:    in.Index,
+		Revision: m.revision,
+	})
+}
+
+// GetLeavesByRevision just returns the indexes requested. No leaf data, no inclusion proofs.
+func (m *mapServer) GetLeavesByRevision(ctx context.Context, in *tpb.GetMapLeavesByRevisionRequest, opts ...grpc.CallOption) (*tpb.GetMapLeavesResponse, error) {
+	leaves := make([]*tpb.MapLeafInclusion, 0, len(in.Index))
+	for _, index := range in.Index {
+		leaves = append(leaves, &tpb.MapLeafInclusion{
+			Leaf: &tpb.MapLeaf{
+				Index: index,
+			},
+		})
+	}
+	return &tpb.GetMapLeavesResponse{
+		MapLeafInclusion: leaves,
+	}, nil
+}
+
+// SetLeaves is not thread safe. It will store the root metadata.
+func (m *mapServer) SetLeaves(ctx context.Context, in *tpb.SetMapLeavesRequest, opts ...grpc.CallOption) (*tpb.SetMapLeavesResponse, error) {
+	m.revision++
+	m.roots[m.revision] = &tpb.SignedMapRoot{
+		Metadata:    in.Metadata,
+		MapRevision: m.revision,
+	}
+	return nil, nil
+}
+
+// GetSignedMapRootByRevision returns the current map root.
+func (m *mapServer) GetSignedMapRoot(ctx context.Context, in *tpb.GetSignedMapRootRequest, opts ...grpc.CallOption) (*tpb.GetSignedMapRootResponse, error) {
+	return m.GetSignedMapRootByRevision(ctx, &tpb.GetSignedMapRootByRevisionRequest{
+		Revision: m.revision,
+	})
+}
+
+// GetSignedMapRootByRevision returns the saved map root.
+func (m *mapServer) GetSignedMapRootByRevision(ctx context.Context, in *tpb.GetSignedMapRootByRevisionRequest, opts ...grpc.CallOption) (*tpb.GetSignedMapRootResponse, error) {
+	return &tpb.GetSignedMapRootResponse{
+		MapRoot: m.roots[in.Revision],
+	}, nil
+}

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -97,6 +97,14 @@ func (m *Mutation) SetCommitment(data []byte) error {
 	return nil
 }
 
+// GetCommitment returns the commitment information in this mutation.
+func (m *Mutation) GetCommitment() (commitment, data, nonce []byte) {
+	data = m.data
+	nonce = m.nonce
+	commitment = m.entry.Commitment
+	return
+}
+
 // ReplaceAuthorizedKeys sets authorized keys to pubkeys.
 // pubkeys must contain at least one key.
 func (m *Mutation) ReplaceAuthorizedKeys(pubkeys []*keyspb.PublicKey) error {

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -72,4 +72,7 @@ type MutationStorage interface {
 	// Write saves the mutation in the database. Write returns the sequence
 	// number that is written.
 	Write(txn transaction.Txn, mapID int64, mutation *pb.EntryUpdate) (uint64, error)
+	// BulkWrite saves many mutations to the database.
+	// BulkWrite returns the highest sequence number that was written.
+	BulkWrite(txn transaction.Txn, mapID int64, mutations []*tpb.EntryUpdate) (uint64, error)
 }

--- a/core/resetserver/batch.go
+++ b/core/resetserver/batch.go
@@ -1,0 +1,245 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resetserver
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/glog"
+	"github.com/google/keytransparency/core/adminstorage"
+	"github.com/google/keytransparency/core/crypto/signatures"
+	"github.com/google/keytransparency/core/crypto/vrf"
+	"github.com/google/keytransparency/core/crypto/vrf/p256"
+	"github.com/google/keytransparency/core/mutator"
+	"github.com/google/keytransparency/core/mutator/entry"
+	"github.com/google/keytransparency/core/transaction"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keyspb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
+	pb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
+)
+
+var (
+	// ErrRetry occurs when an update request has been submitted, but the
+	// results of the update are not visible on the server yet. The client
+	// must retry until the request is visible.
+	ErrRetry = errors.New("update not present on server yet")
+)
+
+// batch holds a single batch operation
+type batch struct {
+	tmap    trillian.TrillianMapClient
+	storage mutator.MutationStorage
+	factory transaction.Factory
+
+	domain  *adminstorage.Domain
+	vrfKey  crypto.PrivateKey
+	indexes map[string]Account
+}
+
+// Account puts a UserID and Profile together.
+type Account struct {
+	data     []byte
+	authKeys []*keyspb.PublicKey
+
+	mutation      *entry.Mutation
+	update        *pb.EntryUpdate
+	updateApplied bool
+	err           error
+}
+
+// NewBatch creates a new batch operation. Only one domain is allowed.
+func (s *server) NewBatch(ctx context.Context, accounts []*pb.Account) (*batch, error) {
+	if got, want := len(accounts), 1; got < want {
+		return nil, fmt.Errorf("NewBatch with %d accounts, want > %d", got, want)
+	}
+
+	// The whole batch must have the same domain_id.
+	domainID := accounts[0].GetDomainId()
+	for _, a := range accounts {
+		if got, want := a.DomainId, domainID; got != want {
+			return nil, fmt.Errorf("whole batch must have same domain_id. Got %v, want %v", got, want)
+		}
+	}
+
+	// Read domain info.
+	domain, err := s.admin.Read(ctx, domainID, false)
+	if err != nil {
+		glog.Errorf("adminstorage.Read(%v): %v", domainID, err)
+		return nil, grpc.Errorf(codes.NotFound, "Cannot fetch domain info")
+	}
+	vrfPriv, err := p256.NewFromWrappedKey(ctx, domain.VRFPriv)
+	if err != nil {
+		return nil, err
+	}
+
+	return &batch{
+		tmap:    s.tmap,
+		storage: s.storage,
+		factory: s.factory,
+
+		domain:  domain,
+		vrfKey:  vrfPriv,
+		indexes: makeAccountMap(accounts, vrfPriv),
+	}, nil
+}
+
+func makeAccountMap(accounts []*pb.Account, vrfPriv vrf.PrivateKey) map[string]Account {
+	indexes := make(map[string]Account)
+	for _, a := range accounts {
+		index, _ := vrfPriv.Evaluate(vrf.UniqueID(a.UserId, a.AppId))
+		idx := index[:]
+		indexes[string(idx)] = Account{
+			data:     a.Data,
+			authKeys: a.AuthorizedKeys,
+			mutation: entry.NewMutation(idx, a.UserId, a.AppId),
+		}
+	}
+	return indexes
+}
+
+// GetLeaves fills in the oldLeaf field
+func (b *batch) GetLeaves(ctx context.Context) error {
+	indexes := make([][]byte, 0, len(b.indexes))
+	for i := range b.indexes {
+		indexes = append(indexes, []byte(i))
+	}
+	// Batch read existing values from map.
+	getResp, err := b.tmap.GetLeaves(ctx, &trillian.GetMapLeavesRequest{
+		MapId:    b.domain.MapID,
+		Index:    indexes,
+		Revision: -1, // Get latest revision.
+	})
+	if err != nil {
+		return err
+	}
+	if got, want := len(getResp.GetMapLeafInclusion()), len(indexes); got != want {
+		return fmt.Errorf("map returned %d leaves, want %d", got, want)
+	}
+
+	for _, incl := range getResp.GetMapLeafInclusion() {
+		leafIndex := incl.GetLeaf().GetIndex()
+		a, ok := b.indexes[string(leafIndex)]
+		if !ok {
+			return fmt.Errorf("User for index %x not found", leafIndex)
+		}
+		if err := a.mutation.SetPrevious(incl.GetLeaf().GetLeafValue()); err != nil {
+			return fmt.Errorf("mutation.SetPrevious(): %v", err)
+		}
+	}
+	return nil
+}
+
+// Verify requeries the map and verifies that the changes requested were applied.
+// TODO: pull out a function for operating on data returned from the server.
+func (b *batch) Verify(ctx context.Context) error {
+	indexes := make([][]byte, 0, len(b.indexes))
+	for i := range b.indexes {
+		indexes = append(indexes, []byte(i))
+	}
+	// Batch read existing values from map.
+	getResp, err := b.tmap.GetLeaves(ctx, &trillian.GetMapLeavesRequest{
+		MapId:    b.domain.MapID,
+		Index:    indexes,
+		Revision: -1, // Get latest revision.
+	})
+	if err != nil {
+		return err
+	}
+	if got, want := len(getResp.GetMapLeafInclusion()), len(indexes); got != want {
+		return fmt.Errorf("map returned %d leaves, want %d", got, want)
+	}
+
+	for _, incl := range getResp.GetMapLeafInclusion() {
+		leafIndex := incl.GetLeaf().GetIndex()
+		a, ok := b.indexes[string(leafIndex)]
+		if !ok {
+			return fmt.Errorf("User for index %x not found", leafIndex)
+		}
+
+		leafValue, err := entry.FromLeafValue(incl.GetLeaf().GetLeafValue())
+		if err != nil {
+			a.err = fmt.Errorf("failed to decode current entry: %v", err)
+			continue
+		}
+
+		if got, want := leafValue, a.update.GetMutation(); !proto.Equal(got, want) {
+			a.err = ErrRetry
+		}
+	}
+	return nil
+}
+
+// SetProfiles converts a map from names and profiles to a list
+func (b *batch) SetData() {
+	for _, a := range b.indexes {
+		if err := a.mutation.SetCommitment(a.data); err != nil {
+			a.err = err
+		}
+	}
+}
+
+// SetAuthorizedKeys replaces each account's authorized keys with its authorized keys.
+func (b *batch) SetAuthorizedKeys() {
+	for _, a := range b.indexes {
+		// TODO(gbelvin) should we check a.err before trying any new operations?
+		if err := a.mutation.ReplaceAuthorizedKeys(a.authKeys); err != nil {
+			a.err = err
+		}
+	}
+}
+
+// SignMutations returns the list of updates.
+func (b *batch) SignMutations(signers []signatures.Signer) {
+	for _, a := range b.indexes {
+		// Sign Entry
+		update, err := a.mutation.SerializeAndSign(signers)
+		if err != nil {
+			a.err = err
+		}
+		a.update = update
+	}
+}
+
+// SaveMutations writes the mutations to the list of mutations
+func (b *batch) SaveMutations(ctx context.Context) error {
+	// Collect mutations
+	mutations := make([]*pb.EntryUpdate, 0, len(b.indexes))
+	for _, u := range b.indexes {
+		// TODO(gbelvin): skip nill updates?
+		mutations = append(mutations, u.update)
+	}
+
+	// Store the update requests.
+	txn, err := b.factory.NewTxn(ctx)
+	if err != nil {
+		return grpc.Errorf(codes.Internal, "Cannot create transaction")
+	}
+	maxSeq, err := b.storage.BulkWrite(txn, b.domain.MapID, mutations)
+	if err != nil {
+		return err
+	}
+	if err := txn.Commit(); err != nil {
+		glog.Errorf("Cannot commit transaction: %v", err)
+		return grpc.Errorf(codes.Internal, "Cannot commit transaction: %v", err)
+	}
+	return nil
+}

--- a/core/resetserver/server.go
+++ b/core/resetserver/server.go
@@ -1,0 +1,118 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resetserver implements the AccountResetService
+package resetserver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/keytransparency/core/adminstorage"
+	"github.com/google/keytransparency/core/authentication"
+	"github.com/google/keytransparency/core/authorization"
+	"github.com/google/keytransparency/core/crypto/signatures"
+	"github.com/google/keytransparency/core/mutator"
+	"github.com/google/keytransparency/core/transaction"
+	"github.com/google/trillian"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	gpb "github.com/google/keytransparency/core/proto/keytransparency_v1_grpc"
+	pb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
+)
+
+var maxBatchSize = 100
+
+type server struct {
+	auth    authentication.Authenticator
+	authz   authorization.Authorization
+	admin   adminstorage.Storage
+	tmap    trillian.TrillianMapClient
+	storage mutator.MutationStorage
+	factory transaction.Factory
+	signers []signatures.Signer
+	// authorizedKeys []*tpb.PublicKey // Default set of authorized keys
+}
+
+// New returns an AccountResetService
+func New() gpb.AccountRecoveryServiceClient {
+	return &server{}
+}
+
+// CreateAccount creates one account
+func (s *server) CreateAccount(ctx context.Context, in *pb.CreateAccountRequest) (*pb.CreateAccountResponse, error) {
+	ret, err := s.BatchCreateAccount(ctx, &pb.BatchCreateAccountRequest{
+		Accounts:               []*pb.Account{in.Account},
+		AddAccountRecoveryKeys: in.AddAccountRecoveryKeys,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if got, want := len(ret.Errors), 1; got != want {
+		return nil, fmt.Errorf("batch returned %v rows, want %v", got, want)
+	}
+	return nil, status.FromProto(ret[0])
+}
+
+// BatchCreateAccount
+func (s *server) BatchCreateAccount(ctx context.Context, in *pb.BatchCreateAccountRequest) (*pb.BatchCreateAccountResponse, error) {
+	// Authenticate Request.
+	sctx, err := s.auth.ValidateCreds(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if got, want := len(in.GetRequests()), maxBatchSize; got > want {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"len(requests): %v, want < %v", got, want)
+	}
+
+	errors := make([]error, len(in.GetRequests()))
+
+	for i, r := range in.GetRequests() {
+		// TODO(gbelvin): Change IsAuthorized interface to accept domain as input.
+		errors[i] = s.authz.IsAuthorized(0, in.GetAppId(), in.GetUserId, ppb.Permission_WRITE)
+	}
+
+	b, err := s.NewBatch(ctx, in.Accounts)
+	if err != nil {
+		return nil, err
+	}
+	// Assert that existing leaves are empty by not fetching existing data.
+	b.SetData()
+	b.SetAuthorizedKeys()
+	// TODO (gbelvin): support adding a set of authorized keys to everything.
+	b.SignMutations(signers)
+	if err := b.SaveMutations(ctx); err != nil {
+		return nil, err
+	}
+	// Trigger a sequence operation if the batch size is big enough?
+	// Wait for new tree head
+	// Verify new data entries
+	if err := b.GetLeaves(ctx); err != nil {
+		return nil, err
+	}
+
+	// Return results
+	return &pb.BatchCreateAccountResponse{
+		errors: nil,
+	}, nil
+}
+
+func (s *server) waitForNewTreeHead(ctx context.Context) error {
+	// Options
+	// A) Poll the Trillian Log
+	// B) Use channel for new roots
+}


### PR DESCRIPTION
This PR implements a authorized account update service.

The service holds a private key that it uses to sign `UpdateEntryRequests`. 
If authorized by each individual account, this service can make updates to their account on their behalf. Eg. This service could update accounts after performing SMS or email based verification. 

The service is structured in the following way: 
1. The service receives a batch account update request 
2. The service verifies that this request is authorized for this app and each user. 
3. The service creates a UpdateEntryRequests
4. The service queues the update requests
5. Return
--- 
The sequencer then:
1. Reads mutations out of the queue
2. Tests to see if they are valid, authorized mutations for any particular account.
3. Applies the mutations to the map and commits by sending the new map head to the log. 
4. Accounts are updated. 


#588 