### PR TITLE
Create a mutation manipulation object / API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ coverage: main
 check:
 	gometalinter --config=metalinter.json ./...
 
-presubmit: coverage check
+presubmit: test check
 
 proto:
 	go generate ./...

--- a/cmd/keytransparency-client/grpcc/grpc_client.go
+++ b/cmd/keytransparency-client/grpcc/grpc_client.go
@@ -26,7 +26,7 @@ import (
 	"log"
 	"time"
 
-	ktclient "github.com/google/keytransparency/core/client/kt"
+	"github.com/google/keytransparency/core/client/kt"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/crypto/vrf/p256"
@@ -79,7 +79,7 @@ var (
 type Client struct {
 	cli        spb.KeyTransparencyServiceClient
 	vrf        vrf.PublicKey
-	kt         *ktclient.Verifier
+	kt         *kt.Verifier
 	mutator    mutator.Mutator
 	RetryCount int
 	RetryDelay time.Duration
@@ -131,7 +131,7 @@ func New(cc *grpc.ClientConn,
 	return &Client{
 		cli:        spb.NewKeyTransparencyServiceClient(cc),
 		vrf:        vrf,
-		kt:         ktclient.New(vrf, mapHasher, mapPubKey, logVerifier),
+		kt:         kt.New(vrf, mapHasher, mapPubKey, logVerifier),
 		mutator:    entry.New(),
 		RetryCount: 1,
 		RetryDelay: 3 * time.Second,
@@ -240,7 +240,7 @@ func (c *Client) Update(ctx context.Context, userID, appID string, profileData [
 		return nil, fmt.Errorf("VerifyGetEntryResponse(): %v", err)
 	}
 
-	req, err := ktclient.CreateUpdateEntryRequest(&c.trusted, getResp, c.vrf, userID, appID, profileData, signers, authorizedKeys)
+	req, err := kt.CreateUpdateEntryRequest(&c.trusted, getResp, c.vrf, userID, appID, profileData, signers, authorizedKeys)
 	if err != nil {
 		return nil, fmt.Errorf("CreateUpdateEntryRequest: %v", err)
 	}

--- a/cmd/keytransparency-client/grpcc/grpc_client.go
+++ b/cmd/keytransparency-client/grpcc/grpc_client.go
@@ -26,7 +26,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/google/keytransparency/core/client/kt"
+	ktclient "github.com/google/keytransparency/core/client/kt"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/crypto/vrf/p256"
@@ -79,7 +79,7 @@ var (
 type Client struct {
 	cli        spb.KeyTransparencyServiceClient
 	vrf        vrf.PublicKey
-	kt         *kt.Verifier
+	kt         *ktclient.Verifier
 	mutator    mutator.Mutator
 	RetryCount int
 	RetryDelay time.Duration
@@ -131,7 +131,7 @@ func New(cc *grpc.ClientConn,
 	return &Client{
 		cli:        spb.NewKeyTransparencyServiceClient(cc),
 		vrf:        vrf,
-		kt:         kt.New(vrf, mapHasher, mapPubKey, logVerifier),
+		kt:         ktclient.New(vrf, mapHasher, mapPubKey, logVerifier),
 		mutator:    entry.New(),
 		RetryCount: 1,
 		RetryDelay: 3 * time.Second,
@@ -240,7 +240,7 @@ func (c *Client) Update(ctx context.Context, userID, appID string, profileData [
 		return nil, fmt.Errorf("VerifyGetEntryResponse(): %v", err)
 	}
 
-	req, err := c.kt.CreateUpdateEntryRequest(&c.trusted, getResp, c.vrf, userID, appID, profileData, signers, authorizedKeys)
+	req, err := ktclient.CreateUpdateEntryRequest(&c.trusted, getResp, c.vrf, userID, appID, profileData, signers, authorizedKeys)
 	if err != nil {
 		return nil, fmt.Errorf("CreateUpdateEntryRequest: %v", err)
 	}

--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -17,17 +17,12 @@ package kt
 import (
 	"fmt"
 
-	"github.com/google/keytransparency/core/crypto/commitments"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/vrf"
-
-	"github.com/benlaurie/objecthash/go/objecthash"
-	"github.com/golang/protobuf/proto"
-
 	"github.com/google/keytransparency/core/mutator/entry"
-	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 	"github.com/google/trillian"
-	"github.com/google/trillian/crypto/sigpb"
+
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
 )
 
 // CreateUpdateEntryRequest creates UpdateEntryRequest given GetEntryResponse,
@@ -42,72 +37,29 @@ func (v *Verifier) CreateUpdateEntryRequest(
 		return nil, fmt.Errorf("ProofToHash(): %v", err)
 	}
 
-	// Commit to profile.
-	commitmentNonce, err := commitments.GenCommitmentKey()
-	if err != nil {
-		return nil, err
-	}
-	commitment := commitments.Commit(userID, appID, profileData, commitmentNonce)
-
 	oldLeaf := getResp.GetLeafProof().GetLeaf().GetLeafValue()
-	prevEntry, err := entry.FromLeafValue(oldLeaf)
+	mutation, err := entry.NewMutation(oldLeaf, index[:], userID, appID)
 	if err != nil {
 		return nil, fmt.Errorf("Error unmarshaling Entry from leaf proof: %v", err)
 	}
 
-	// Create new Entry.
-	keys := authorizedKeys
-	if len(keys) == 0 {
-		keys = prevEntry.AuthorizedKeys
-	}
-	// TODO(ismail): Change this to plain sha256:
-	previous := objecthash.ObjectHash(prevEntry)
-	entry := &tpb.Entry{
-		Commitment:     commitment,
-		AuthorizedKeys: keys,
-		Previous:       previous[:],
-	}
-
-	// Sign Entry.
-	entryData, err := proto.Marshal(entry)
-	if err != nil {
+	// Update Commitment.
+	if err := mutation.SetCommitment(profileData); err != nil {
 		return nil, err
 	}
-	kv := &tpb.KeyValue{
-		Key:   index[:],
-		Value: entryData,
-	}
-	sigs, err := generateSignatures(kv, signers)
-	if err != nil {
-		return nil, err
-	}
-	signedkv := &tpb.SignedKV{
-		KeyValue:   kv,
-		Signatures: sigs,
-	}
 
-	return &tpb.UpdateEntryRequest{
-		UserId: userID,
-		AppId:  appID,
-		EntryUpdate: &tpb.EntryUpdate{
-			Update: signedkv,
-			Committed: &tpb.Committed{
-				Key:  commitmentNonce,
-				Data: profileData,
-			},
-		},
-		FirstTreeSize: trusted.TreeSize,
-	}, err
-}
-
-func generateSignatures(data interface{}, signers []signatures.Signer) (map[string]*sigpb.DigitallySigned, error) {
-	sigs := make(map[string]*sigpb.DigitallySigned)
-	for _, signer := range signers {
-		sig, err := signer.Sign(data)
-		if err != nil {
+	// Update Authorization.
+	if len(authorizedKeys) != 0 {
+		if err := mutation.ReplaceAuthorizedKeys(authorizedKeys); err != nil {
 			return nil, err
 		}
-		sigs[signer.KeyID()] = sig
 	}
-	return sigs, nil
+
+	// Sign Entry
+	updateRequest, err := mutation.GenerateMutation(signers)
+	if err != nil {
+		return nil, err
+	}
+	updateRequest.FirstTreeSize = trusted.TreeSize
+	return updateRequest, nil
 }

--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/vrf"
 	"github.com/google/keytransparency/core/mutator/entry"
+
 	"github.com/google/trillian"
 
 	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
@@ -56,7 +57,7 @@ func CreateUpdateEntryRequest(
 	}
 
 	// Sign Entry
-	updateRequest, err := mutation.GenerateMutation(signers)
+	updateRequest, err := mutation.SerializeAndSign(signers)
 	if err != nil {
 		return nil, err
 	}

--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2017 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 
 // CreateUpdateEntryRequest creates UpdateEntryRequest given GetEntryResponse,
 // user ID and a profile.
-func (v *Verifier) CreateUpdateEntryRequest(
+func CreateUpdateEntryRequest(
 	trusted *trillian.SignedLogRoot, getResp *tpb.GetEntryResponse,
 	vrfPub vrf.PublicKey, userID, appID string, profileData []byte,
 	signers []signatures.Signer, authorizedKeys []*tpb.PublicKey) (*tpb.UpdateEntryRequest, error) {

--- a/core/mutator/entry/entry.go
+++ b/core/mutator/entry/entry.go
@@ -31,18 +31,18 @@ import (
 	"github.com/google/trillian/crypto/sigpb"
 )
 
-// Entry defines mutations to simply replace the current map value with the
+// Mutator defines mutations to simply replace the current map value with the
 // contents of the mutation.
-type Entry struct{}
+type Mutator struct{}
 
 // New creates a new entry mutator.
-func New() *Entry {
-	return &Entry{}
+func New() *Mutator {
+	return &Mutator{}
 }
 
 // Mutate verifies that this is a valid mutation for this item and applies
 // mutation to value.
-func (*Entry) Mutate(oldValue, update proto.Message) ([]byte, error) {
+func (*Mutator) Mutate(oldValue, update proto.Message) ([]byte, error) {
 	// Ensure that the mutation size is within bounds.
 	if proto.Size(update) > mutator.MaxMutationSize {
 		glog.Warningf("mutation (%v bytes) is larger than the maximum accepted size (%v bytes).", proto.Size(update), mutator.MaxMutationSize)

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -15,7 +15,6 @@
 package entry
 
 import (
-	"bytes"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -25,9 +24,7 @@ import (
 	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
-	"github.com/google/keytransparency/core/mutator"
 
-	"github.com/benlaurie/objecthash/go/objecthash"
 	"github.com/golang/protobuf/proto"
 
 	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
@@ -118,84 +115,6 @@ func signersFromPEMs(t *testing.T, keys [][]byte) []signatures.Signer {
 		signers = append(signers, signer)
 	}
 	return signers
-}
-
-func TestCheckMutation(t *testing.T) {
-	// The passed commitment to createEntry is a dummy value. It is needed to
-	// make the two entries (entryData1 and entryData2) different, otherwise
-	// it is not possible to test all cases.
-	entryData1, err := createEntry([]byte{1}, []string{testPubKey1})
-	if err != nil {
-		t.Fatalf("createEntry()=%v", err)
-	}
-	missingKeyEntryData1, err := createEntry([]byte{1}, []string{})
-	if err != nil {
-		t.Fatalf("createEntry()=%v", err)
-	}
-	entryData2, err := createEntry([]byte{2}, []string{testPubKey2})
-	if err != nil {
-		t.Fatalf("createEntry()=%v", err)
-	}
-	emptyEntryData, err := createEntry([]byte{}, []string{testPubKey1})
-	if err != nil {
-		t.Fatalf("createEntry()=%v", err)
-	}
-	missingKeyEntryData2, err := createEntry([]byte{2}, []string{testPubKey1})
-	if err != nil {
-		t.Fatalf("createEntry()=%v", err)
-	}
-	key := []byte{0}
-	largeKey := bytes.Repeat(key, mutator.MaxMutationSize)
-
-	// Calculate hashes.
-	// nilHash is used as the previous hash value when submitting the very
-	// first mutation.
-	nilHash := objecthash.ObjectHash(nil)
-	// Set hash for first entries correctly, then hash it for the next entry:
-	entryData1.Previous = nilHash[:]
-	hashEntry1 := objecthash.ObjectHash(entryData1)
-	missingKeyEntryData1.Previous = nilHash[:]
-	hashMissingKeyEntry1 := objecthash.ObjectHash(missingKeyEntryData1)
-
-	// Create signers.
-	signers1 := signersFromPEMs(t, [][]byte{[]byte(testPrivKey1)})
-	signers2 := signersFromPEMs(t, [][]byte{[]byte(testPrivKey2)})
-	signers3 := signersFromPEMs(t, [][]byte{[]byte(testPrivKey1), []byte(testPrivKey2)})
-
-	for i, tc := range []struct {
-		key      []byte
-		oldEntry *tpb.Entry
-		newEntry *tpb.Entry
-		previous []byte
-		signers  []signatures.Signer
-		err      error
-	}{
-		{key, entryData2, entryData2, hashEntry1[:], nil, mutator.ErrReplay},    // Replayed mutation
-		{largeKey, entryData1, entryData2, hashEntry1[:], nil, mutator.ErrSize}, // Large mutation
-		{key, entryData1, entryData2, nil, nil, mutator.ErrPreviousHash},        // Invalid previous entry hash
-		{key, nil, entryData1, nil, nil, mutator.ErrPreviousHash},               // Very first mutation, invalid previous entry hash
-		{key, nil, &tpb.Entry{}, nil, nil, mutator.ErrPreviousHash},             // Very first mutation, invalid previous entry hash
-		{key, nil, emptyEntryData, nilHash[:], signers1, nil},                   // Very first mutation, empty commitment, working case
-		{key, nil, entryData1, nilHash[:], signers1, nil},                       // Very first mutation, working case
-		{key, entryData1, entryData2, hashEntry1[:], signers3, nil},             // Second mutation, working case
-		// Test missing keys and signature cases.
-		{key, nil, missingKeyEntryData1, nilHash[:], signers1, mutator.ErrMissingKey},                     // Very first mutation, missing current key
-		{key, nil, entryData1, nilHash[:], []signatures.Signer{}, mutator.ErrInvalidSig},                  // Very first mutation, missing current signature
-		{key, missingKeyEntryData1, entryData2, hashMissingKeyEntry1[:], signers3, mutator.ErrInvalidSig}, // Second mutation, Missing previous authorized key
-		{key, entryData1, entryData2, hashEntry1[:], signers2, mutator.ErrInvalidSig},                     // Second mutation, missing previous signature
-		{key, entryData1, missingKeyEntryData2, hashEntry1[:], signers3, nil},                             // Second mutation, missing current authorized key
-		{key, entryData1, entryData2, hashEntry1[:], signers1, nil},                                       // Second mutation, missing current signature, should work
-	} {
-		// Prepare mutations.
-		mutation, err := prepareMutation(tc.key, tc.newEntry, tc.previous, tc.signers)
-		if err != nil {
-			t.Fatalf("prepareMutation(%v, %v, %v)=%v", tc.key, tc.newEntry, tc.previous, err)
-		}
-
-		if _, got := New().Mutate(tc.oldEntry, mutation); got != tc.err {
-			t.Errorf("%d Mutate(%v, %v)=%v, want %v", i, tc.oldEntry, mutation, got, tc.err)
-		}
-	}
 }
 
 func TestFromLeafValue(t *testing.T) {

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -35,6 +35,10 @@ type Mutation struct {
 }
 
 // NewMutation creates a mutation object from a previous value which can be modified.
+// To create a new value:
+// - Create a new mutation for a user starting with the previous value with NewMutation.
+// - Change the value with SetCommitment and ReplaceAuthorizedKeys.
+// - Finalize the changes and create the mutation with SerializeAndSign.
 func NewMutation(oldValue, index []byte, userID, appID string) (*Mutation, error) {
 	prevEntry, err := FromLeafValue(oldValue)
 	if err != nil {

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -1,0 +1,134 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entry
+
+import (
+	"github.com/benlaurie/objecthash/go/objecthash"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/keytransparency/core/crypto/commitments"
+	"github.com/google/keytransparency/core/crypto/signatures"
+	"github.com/google/keytransparency/core/mutator"
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+	"github.com/google/trillian/crypto/sigpb"
+)
+
+// Mutation provides APIs for manipulating entries.
+type Mutation struct {
+	userID, appID string
+	index         []byte
+	data, nonce   []byte
+
+	prevEntry *tpb.Entry
+	entry     *tpb.Entry
+}
+
+// NewMutation creates a mutation object from a previous value which can be modified.
+func NewMutation(oldValue, index []byte, userID, appID string) (*Mutation, error) {
+	prevEntry, err := FromLeafValue(oldValue)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(ismail): Change this to plain sha256.
+	hash := objecthash.ObjectHash(prevEntry)
+	return &Mutation{
+		userID:    userID,
+		appID:     appID,
+		index:     index,
+		prevEntry: prevEntry,
+		entry: &tpb.Entry{
+			AuthorizedKeys: prevEntry.GetAuthorizedKeys(),
+			Previous:       hash[:],
+			Commitment:     prevEntry.GetCommitment(),
+		},
+	}, nil
+}
+
+// SetCommitment updates entry to be a commitment to data.
+func (m *Mutation) SetCommitment(data []byte) error {
+	// Commit to profile.
+	commitmentNonce, err := commitments.GenCommitmentKey()
+	if err != nil {
+		return err
+	}
+	m.data = data
+	m.nonce = commitmentNonce
+	m.entry.Commitment = commitments.Commit(m.userID, m.appID, data, commitmentNonce)
+	return nil
+}
+
+// ReplaceAuthorizedKeys sets authorized keys to pubkeys.
+// pubkeys must contain at least one key.
+func (m *Mutation) ReplaceAuthorizedKeys(pubkeys []*tpb.PublicKey) error {
+	if got, want := len(pubkeys), 1; got < want {
+		return mutator.ErrMissingKey
+	}
+	m.entry.AuthorizedKeys = pubkeys
+	return nil
+}
+
+// GenerateMutation produces the mutation.
+func (m *Mutation) GenerateMutation(signers []signatures.Signer) (*tpb.UpdateEntryRequest, error) {
+	signedkv, err := m.sign(signers)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check authorization.
+	if err := verifyKeys(m.prevEntry.GetAuthorizedKeys(),
+		m.entry.GetAuthorizedKeys(),
+		signedkv.GetKeyValue(),
+		signedkv.GetSignatures()); err != nil {
+		return nil, err
+	}
+
+	return &tpb.UpdateEntryRequest{
+		UserId: m.userID,
+		AppId:  m.appID,
+		EntryUpdate: &tpb.EntryUpdate{
+			Update: signedkv,
+			Committed: &tpb.Committed{
+				Key:  m.nonce,
+				Data: m.data,
+			},
+		},
+	}, nil
+}
+
+// Sign produces the SignedKV
+func (m *Mutation) sign(signers []signatures.Signer) (*tpb.SignedKV, error) {
+	entryData, err := proto.Marshal(m.entry)
+	if err != nil {
+		return nil, err
+	}
+	kv := &tpb.KeyValue{
+		Key:   m.index,
+		Value: entryData,
+	}
+
+	sigs := make(map[string]*sigpb.DigitallySigned)
+	for _, signer := range signers {
+		sig, err := signer.Sign(kv)
+		if err != nil {
+			return nil, err
+		}
+		sigs[signer.KeyID()] = sig
+	}
+
+	return &tpb.SignedKV{
+		KeyValue:   kv,
+		Signatures: sigs,
+	}, nil
+}

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -79,8 +79,8 @@ func (m *Mutation) ReplaceAuthorizedKeys(pubkeys []*tpb.PublicKey) error {
 	return nil
 }
 
-// GenerateMutation produces the mutation.
-func (m *Mutation) GenerateMutation(signers []signatures.Signer) (*tpb.UpdateEntryRequest, error) {
+// SerializeAndSign produces the mutation.
+func (m *Mutation) SerializeAndSign(signers []signatures.Signer) (*tpb.UpdateEntryRequest, error) {
 	signedkv, err := m.sign(signers)
 	if err != nil {
 		return nil, err

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -26,7 +26,7 @@ func TestReplaceAuthorizedKeys(t *testing.T) {
 		wantErr bool
 	}{
 		{pubKeys: nil, wantErr: true},
-		{pubKeys: []*tpb.PublicKey{&tpb.PublicKey{}}, wantErr: false},
+		{pubKeys: []*tpb.PublicKey{{}}, wantErr: false},
 	} {
 		index := []byte("index")
 		userID := "bob"

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entry
+
+import (
+	"testing"
+
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+)
+
+func TestReplaceAuthorizedKeys(t *testing.T) {
+	for _, tc := range []struct {
+		pubKeys []*tpb.PublicKey
+		wantErr bool
+	}{
+		{pubKeys: nil, wantErr: true},
+		{pubKeys: []*tpb.PublicKey{&tpb.PublicKey{}}, wantErr: false},
+	} {
+		index := []byte("index")
+		userID := "bob"
+		appID := "app1"
+		m, err := NewMutation(nil, index, userID, appID)
+		if err != nil {
+			t.Errorf("NewMutation(): %v", err)
+		}
+
+		err = m.ReplaceAuthorizedKeys(tc.pubKeys)
+		if got, want := err != nil, tc.wantErr; got != want {
+			t.Errorf("ReplaceAuthorizedKeys(%v): %v, wantErr: %v", tc.pubKeys, got, want)
+		}
+	}
+}

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -1,0 +1,134 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package entry
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/benlaurie/objecthash/go/objecthash"
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/google/keytransparency/core/mutator"
+
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+)
+
+// Mutator defines mutations to simply replace the current map value with the
+// contents of the mutation.
+type Mutator struct{}
+
+// New creates a new entry mutator.
+func New() *Mutator {
+	return &Mutator{}
+}
+
+// Mutate verifies that this is a valid mutation for this item and applies
+// mutation to value.
+func (*Mutator) Mutate(oldValue, update proto.Message) ([]byte, error) {
+	// Ensure that the mutation size is within bounds.
+	if proto.Size(update) > mutator.MaxMutationSize {
+		glog.Warningf("mutation (%v bytes) is larger than the maximum accepted size (%v bytes).", proto.Size(update), mutator.MaxMutationSize)
+		return nil, mutator.ErrSize
+	}
+
+	updated, ok := update.(*tpb.SignedKV)
+	if !ok {
+		glog.Warning("received proto.Message is not of type *tpb.SignedKV.")
+		return nil, fmt.Errorf("updateM.(*tpb.SignedKV): _, %v", ok)
+	}
+	var oldEntry *tpb.Entry
+	if oldValue != nil {
+		old, ok := oldValue.(*tpb.Entry)
+		if !ok {
+			glog.Warning("received proto.Message is not of type *tpb.Entry.")
+			return nil, fmt.Errorf("oldValueM.(*tpb.Entry): _, %v", ok)
+		}
+		oldEntry = old
+	}
+
+	kv := updated.GetKeyValue()
+	newEntry := new(tpb.Entry)
+	if err := proto.Unmarshal(kv.Value, newEntry); err != nil {
+		return nil, err
+	}
+
+	// Verify pointer to previous data.
+	// The very first entry will have oldValue=nil, so its hash is the
+	// ObjectHash value of nil.
+	prevEntryHash := objecthash.ObjectHash(oldEntry)
+	if !bytes.Equal(prevEntryHash[:], newEntry.GetPrevious()) {
+		// Check if this mutation is a replay.
+		if oldEntry != nil && proto.Equal(oldEntry, newEntry) {
+			glog.Warningf("mutation is a replay of an old one")
+			return nil, mutator.ErrReplay
+		}
+		glog.Warningf("previous entry hash (%v) does not match the hash provided in this mutation (%v)", prevEntryHash[:], newEntry.GetPrevious())
+		return nil, mutator.ErrPreviousHash
+	}
+
+	// Ensure that the mutation has at least one authorized key to prevent
+	// account lockout.
+	if len(newEntry.GetAuthorizedKeys()) == 0 {
+		glog.Warningf("mutation should contain at least one authorized key")
+		return nil, mutator.ErrMissingKey
+	}
+
+	if err := verifyKeys(oldEntry, kv, updated, newEntry); err != nil {
+		return nil, err
+	}
+
+	return updated.GetKeyValue().GetValue(), nil
+}
+
+// verifyKeys verifies both old and new authorized keys based on the following
+// criteria:
+//   1. At least one signature with a key in the previous entry should exist.
+//   2. The first mutation should contain at least one signature with a key in
+//      in that mutation.
+//   3. Signatures with no matching keys are simply ignored.
+func verifyKeys(prevEntry *tpb.Entry, data interface{}, update *tpb.SignedKV, entry *tpb.Entry) error {
+	var verifiers map[string]signatures.Verifier
+	var err error
+	if prevEntry == nil {
+		verifiers, err = verifiersFromKeys(entry.GetAuthorizedKeys())
+		if err != nil {
+			return err
+		}
+	} else {
+		verifiers, err = verifiersFromKeys(prevEntry.GetAuthorizedKeys())
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := verifyAuthorizedKeys(data, verifiers, update.GetSignatures()); err != nil {
+		return err
+	}
+	return nil
+}
+
+// verifyAuthorizedKeys requires AT LEAST one verifier to have a valid
+// corresponding signature.
+func verifyAuthorizedKeys(data interface{}, verifiers map[string]signatures.Verifier, sigs map[string]*sigpb.DigitallySigned) error {
+	for _, verifier := range verifiers {
+		if sig, ok := sigs[verifier.KeyID()]; ok {
+			if err := verifier.Verify(data, sig); err == nil {
+				return nil
+			}
+		}
+	}
+	return mutator.ErrInvalidSig
+}

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -71,12 +71,12 @@ func TestCheckMutation(t *testing.T) {
 		{key, nil, entryData1, nilHash[:], signers1, nil},                       // Very first mutation, working case
 		{key, entryData1, entryData2, hashEntry1[:], signers3, nil},             // Second mutation, working case
 		// Test missing keys and signature cases.
-		{key, nil, missingKeyEntryData1, nilHash[:], signers1, mutator.ErrMissingKey},                     // Very first mutation, missing current key
-		{key, nil, entryData1, nilHash[:], []signatures.Signer{}, mutator.ErrInvalidSig},                  // Very first mutation, missing current signature
-		{key, missingKeyEntryData1, entryData2, hashMissingKeyEntry1[:], signers3, mutator.ErrInvalidSig}, // Second mutation, Missing previous authorized key
-		{key, entryData1, entryData2, hashEntry1[:], signers2, mutator.ErrInvalidSig},                     // Second mutation, missing previous signature
-		{key, entryData1, missingKeyEntryData2, hashEntry1[:], signers3, nil},                             // Second mutation, missing current authorized key
-		{key, entryData1, entryData2, hashEntry1[:], signers1, nil},                                       // Second mutation, missing current signature, should work
+		{key, nil, missingKeyEntryData1, nilHash[:], signers1, mutator.ErrMissingKey},                       // Very first mutation, missing current key
+		{key, nil, entryData1, nilHash[:], []signatures.Signer{}, mutator.ErrUnauthorized},                  // Very first mutation, missing current signature
+		{key, missingKeyEntryData1, entryData2, hashMissingKeyEntry1[:], signers3, mutator.ErrUnauthorized}, // Second mutation, Missing previous authorized key
+		{key, entryData1, entryData2, hashEntry1[:], signers2, mutator.ErrUnauthorized},                     // Second mutation, missing previous signature
+		{key, entryData1, missingKeyEntryData2, hashEntry1[:], signers3, nil},                               // Second mutation, missing current authorized key
+		{key, entryData1, entryData2, hashEntry1[:], signers1, nil},                                         // Second mutation, missing current signature, should work
 	} {
 		// Prepare mutations.
 		mutation, err := prepareMutation(tc.key, tc.newEntry, tc.previous, tc.signers)

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package entry
 
 import (

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -1,0 +1,91 @@
+package entry
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/keytransparency/core/crypto/signatures"
+	"github.com/google/keytransparency/core/mutator"
+
+	"github.com/benlaurie/objecthash/go/objecthash"
+
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+)
+
+func TestCheckMutation(t *testing.T) {
+	// The passed commitment to createEntry is a dummy value. It is needed to
+	// make the two entries (entryData1 and entryData2) different, otherwise
+	// it is not possible to test all cases.
+	entryData1, err := createEntry([]byte{1}, []string{testPubKey1})
+	if err != nil {
+		t.Fatalf("createEntry()=%v", err)
+	}
+	missingKeyEntryData1, err := createEntry([]byte{1}, []string{})
+	if err != nil {
+		t.Fatalf("createEntry()=%v", err)
+	}
+	entryData2, err := createEntry([]byte{2}, []string{testPubKey2})
+	if err != nil {
+		t.Fatalf("createEntry()=%v", err)
+	}
+	emptyEntryData, err := createEntry([]byte{}, []string{testPubKey1})
+	if err != nil {
+		t.Fatalf("createEntry()=%v", err)
+	}
+	missingKeyEntryData2, err := createEntry([]byte{2}, []string{testPubKey1})
+	if err != nil {
+		t.Fatalf("createEntry()=%v", err)
+	}
+	key := []byte{0}
+	largeKey := bytes.Repeat(key, mutator.MaxMutationSize)
+
+	// Calculate hashes.
+	// nilHash is used as the previous hash value when submitting the very
+	// first mutation.
+	nilHash := objecthash.ObjectHash(nil)
+	// Set hash for first entries correctly, then hash it for the next entry:
+	entryData1.Previous = nilHash[:]
+	hashEntry1 := objecthash.ObjectHash(entryData1)
+	missingKeyEntryData1.Previous = nilHash[:]
+	hashMissingKeyEntry1 := objecthash.ObjectHash(missingKeyEntryData1)
+
+	// Create signers.
+	signers1 := signersFromPEMs(t, [][]byte{[]byte(testPrivKey1)})
+	signers2 := signersFromPEMs(t, [][]byte{[]byte(testPrivKey2)})
+	signers3 := signersFromPEMs(t, [][]byte{[]byte(testPrivKey1), []byte(testPrivKey2)})
+
+	for i, tc := range []struct {
+		key      []byte
+		oldEntry *tpb.Entry
+		newEntry *tpb.Entry
+		previous []byte
+		signers  []signatures.Signer
+		err      error
+	}{
+		{key, entryData2, entryData2, hashEntry1[:], nil, mutator.ErrReplay},    // Replayed mutation
+		{largeKey, entryData1, entryData2, hashEntry1[:], nil, mutator.ErrSize}, // Large mutation
+		{key, entryData1, entryData2, nil, nil, mutator.ErrPreviousHash},        // Invalid previous entry hash
+		{key, nil, entryData1, nil, nil, mutator.ErrPreviousHash},               // Very first mutation, invalid previous entry hash
+		{key, nil, &tpb.Entry{}, nil, nil, mutator.ErrPreviousHash},             // Very first mutation, invalid previous entry hash
+		{key, nil, emptyEntryData, nilHash[:], signers1, nil},                   // Very first mutation, empty commitment, working case
+		{key, nil, entryData1, nilHash[:], signers1, nil},                       // Very first mutation, working case
+		{key, entryData1, entryData2, hashEntry1[:], signers3, nil},             // Second mutation, working case
+		// Test missing keys and signature cases.
+		{key, nil, missingKeyEntryData1, nilHash[:], signers1, mutator.ErrMissingKey},                     // Very first mutation, missing current key
+		{key, nil, entryData1, nilHash[:], []signatures.Signer{}, mutator.ErrInvalidSig},                  // Very first mutation, missing current signature
+		{key, missingKeyEntryData1, entryData2, hashMissingKeyEntry1[:], signers3, mutator.ErrInvalidSig}, // Second mutation, Missing previous authorized key
+		{key, entryData1, entryData2, hashEntry1[:], signers2, mutator.ErrInvalidSig},                     // Second mutation, missing previous signature
+		{key, entryData1, missingKeyEntryData2, hashEntry1[:], signers3, nil},                             // Second mutation, missing current authorized key
+		{key, entryData1, entryData2, hashEntry1[:], signers1, nil},                                       // Second mutation, missing current signature, should work
+	} {
+		// Prepare mutations.
+		mutation, err := prepareMutation(tc.key, tc.newEntry, tc.previous, tc.signers)
+		if err != nil {
+			t.Fatalf("prepareMutation(%v, %v, %v)=%v", tc.key, tc.newEntry, tc.previous, err)
+		}
+
+		if _, got := New().Mutate(tc.oldEntry, mutation); got != tc.err {
+			t.Errorf("%d Mutate(%v, %v)=%v, want %v", i, tc.oldEntry, mutation, got, tc.err)
+		}
+	}
+}

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -35,16 +35,19 @@ var (
 	ErrReplay = errors.New("mutation replay")
 	// ErrSize occurs when the mutation size is larger than the allowed upper
 	// bound.
-	ErrSize = errors.New("mutation is too large")
+	ErrSize = errors.New("mutation: too large")
 	// ErrPreviousHash occurs when the mutation the hash of the previous
 	// entry provided in the mutation does not match the previous entry
 	// itself.
-	ErrPreviousHash = errors.New("previous entry hash does not match the hash provided in the mutation")
+	ErrPreviousHash = errors.New("mutation: previous entry hash does not match the hash provided in the mutation")
 	// ErrMissingKey occurs when a mutation does not have authorized keys.
-	ErrMissingKey = errors.New("missing authorized key(s)")
+	ErrMissingKey = errors.New("mutation: missing authorized key(s)")
 	// ErrInvalidSig occurs when either the current or previous update entry
 	// signature verification fails.
-	ErrInvalidSig = errors.New("invalid signature")
+	ErrInvalidSig = errors.New("mutation: invalid signature")
+	// ErrUnauthorized occurs when the mutation has not been signed by a key in the
+	// previous entry.
+	ErrUnauthorized = errors.New("mutation: unauthorized")
 )
 
 // Mutator verifies mutations and transforms values in the map.


### PR DESCRIPTION
Previously the client code had a giant function for creating mutations. 
I realized that the process of creating a mutation is closely related to verifying a mutation. 

This PR creates
 - A mutation creator `entry.Mutation`
 - A mutation verifier / function`entry.Mutator`  Which verifies and applies a mutation to a previous entry in the tree. 

#588 