### PR TITLE
Implement GetEpochStream

### DIFF
--- a/impl/sequencerservice/server.go
+++ b/impl/sequencerservice/server.go
@@ -1,0 +1,56 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sequencerservice contains the implementation of the sequencer service
+// defined in core/impl/proto/sequencer_v1_service.
+package sequencerservice
+
+import (
+	"github.com/golang/glog"
+	"github.com/google/keytransparency/core/sequencer"
+
+	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_types"
+	spb "github.com/google/keytransparency/impl/proto/sequencer_v1_service"
+)
+
+// Server implements the sequencer service server.
+type Server struct {
+	seq *sequencer.Sequencer
+}
+
+// New creates a new instance of a sequencer service server.
+func New(seq *sequencer.Sequencer) *Server {
+	return &Server{
+		seq: seq,
+	}
+}
+
+// GetEpochs is a streaming API that sends epoch mutations upon creation.
+func (s *Server) GetEpochs(in *tpb.GetEpochsRequest, stream spb.SequencerService_GetEpochsServer) error {
+	ch := make(chan *tpb.GetMutationsResponse, 1)
+	s.seq.RegisterMutationsChannel(ch)
+	go listen(ch, stream)
+	return nil
+}
+
+func listen(ch chan *tpb.GetMutationsResponse, stream spb.SequencerService_GetEpochsServer) {
+	for mutations := range ch {
+		resp := &tpb.GetEpochsResponse{
+			Mutations: mutations,
+		}
+		if err := stream.Send(resp); err != nil {
+			glog.Errorf("SequencerService_GetEpochsServer.Send(%v) failed: %v", resp, err)
+		}
+	}
+}

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -127,7 +127,7 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 			if got, want := err, grpcc.ErrRetry; got != want {
 				t.Fatalf("Update(%v): %v, want %v", tc.userID, got, want)
 			}
-			if err := env.Signer.CreateEpoch(bctx, true); err != nil {
+			if _, err := env.Signer.CreateEpoch(bctx, true); err != nil {
 				t.Errorf("CreateEpoch(_): %v", err)
 			}
 			if err := env.Client.Retry(tc.ctx, req); err != nil {
@@ -187,7 +187,7 @@ func TestUpdateValidation(t *testing.T) {
 			if got, want := err, grpcc.ErrRetry; got != want {
 				t.Fatalf("Update(%v): %v, want %v", tc.userID, got, want)
 			}
-			if err := env.Signer.CreateEpoch(bctx, true); err != nil {
+			if _, err := env.Signer.CreateEpoch(bctx, true); err != nil {
 				t.Errorf("CreateEpoch(_): %v", err)
 			}
 			if err := env.Client.Retry(tc.ctx, req); err != nil {
@@ -277,7 +277,7 @@ func (e *Env) setupHistory(ctx context.Context, userID string, signers []signatu
 				return fmt.Errorf("Update(%v, %v)=(_, %v), want (_, %v)", userID, i, got, want)
 			}
 		}
-		if err := e.Signer.CreateEpoch(ctx, true); err != nil {
+		if _, err := e.Signer.CreateEpoch(ctx, true); err != nil {
 			return fmt.Errorf("CreateEpoch(_): %v", err)
 		}
 	}

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -180,7 +180,7 @@ func NewEnv(t *testing.T) *Env {
 	if err := signer.Initialize(ctx); err != nil {
 		t.Fatalf("signer.Initialize() = %v", err)
 	}
-	if err := signer.CreateEpoch(ctx, true); err != nil {
+	if _, err := signer.CreateEpoch(ctx, true); err != nil {
 		t.Fatalf("CreateEpoch(_): %v", err)
 	}
 


### PR DESCRIPTION
This PR implements the server side of the sequencer service defined in PR #793.

Whenever a frontend calls the `GetEpochs` API and creates a gRPC stream, the backend registers a Go channel with the sequencer. When a new epoch is created the sequencer pushes all relevant mutations information through these channels. Then, the sequencer service sends this information to frontends over the created gRPC stream.