### PR TITLE
Upgrade to python3 for docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 addons:
   apt:
     packages:
-    - python-pip
+    - python3-pip
     - parallel
 
 install:
@@ -37,7 +37,7 @@ after_success:
 before_deploy:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  - pip install docker-compose
+  - sudo pip3 install docker-compose
   - docker --version
   - docker-compose --version
   - if [ ! -d "$HOME/google-cloud-sdk/bin" ]; then rm -rf $HOME/google-cloud-sdk;


### PR DESCRIPTION
It looks like python2 on travis is outdated.  This tries upgrading to python3 as the solution. 
sudo for pip-install is also required. 

```
/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#snimissingwarning.
  SNIMissingWarning
```