### PR TITLE
Store SignedKV in Trillian Map

### DIFF
--- a/core/client/grpcc/grpc_client.go
+++ b/core/client/grpcc/grpc_client.go
@@ -289,7 +289,7 @@ func (c *Client) Retry(ctx context.Context, req *pb.UpdateEntryRequest, opts ...
 	}
 
 	// Check if the response is a replay.
-	if got, want := leafValue, req.GetEntryUpdate().GetMutation().GetValue(); !proto.Equal(got, want) {
+	if got, want := leafValue, req.GetEntryUpdate().GetMutation(); !proto.Equal(got, want) {
 		return ErrRetry
 	}
 	return nil

--- a/core/crypto/signatures/factory/factory.go
+++ b/core/crypto/signatures/factory/factory.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/p256"
@@ -51,7 +52,7 @@ func NewSignerFromPEM(pemKey []byte) (signatures.Signer, error) {
 func NewVerifierFromBytes(b []byte) (signatures.Verifier, error) {
 	k, err := x509.ParsePKIXPublicKey(b)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("factory: could not parse public key: %v", err)
 	}
 
 	switch pkType := k.(type) {

--- a/core/mutator/entry/entry.go
+++ b/core/mutator/entry/entry.go
@@ -31,9 +31,9 @@ import (
 
 // FromLeafValue takes a trillian.MapLeaf.LeafValue and returns and instantiated
 // Entry or nil if the passes LeafValue was nil.
-func FromLeafValue(value []byte) (*pb.Entry, error) {
+func FromLeafValue(value []byte) (*pb.SignedKV, error) {
 	if value != nil {
-		entry := new(pb.Entry)
+		entry := new(pb.SignedKV)
 		if err := proto.Unmarshal(value, entry); err != nil {
 			glog.Warningf("proto.Unmarshal(%v, _): %v", value, err)
 			return nil, err
@@ -47,7 +47,7 @@ func FromLeafValue(value []byte) (*pb.Entry, error) {
 
 // ToLeafValue converts the update object into a serialized object to store in the map.
 func ToLeafValue(update proto.Message) ([]byte, error) {
-	e, ok := update.(*pb.Entry)
+	e, ok := update.(*pb.SignedKV)
 	if !ok {
 		glog.Warning("received proto.Message is not of type *pb.SignedKV.")
 		return nil, fmt.Errorf("updateM.(*pb.SignedKV): _, %v", ok)

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -53,14 +53,12 @@ func TestCreateAndVerify(t *testing.T) {
 		pubKeys []*keyspb.PublicKey
 		signers []signatures.Signer
 		data    []byte
-		wantErr bool
 	}{
 		{
 			old:     nil,
-			pubKeys: []*keyspb.PublicKey{mustPublicKey(testPubKey1)},
+			pubKeys: mustPublicKeys([]string{testPubKey1}),
 			signers: []signatures.Signer{createSigner(t, testPrivKey1)},
 			data:    []byte("foo"),
-			wantErr: false,
 		},
 	} {
 		index := []byte{}
@@ -76,12 +74,12 @@ func TestCreateAndVerify(t *testing.T) {
 			t.Errorf("SetCommitment(%v): %v", tc.data, err)
 			continue
 		}
-		err = m.ReplaceAuthorizedKeys(tc.pubKeys)
-		if got, want := err != nil, tc.wantErr; got != want {
-			t.Errorf("ReplaceAuthorizedKeys(%v): %v, wantErr: %v", tc.pubKeys, got, want)
+		if err = m.ReplaceAuthorizedKeys(tc.pubKeys); err != nil {
+			t.Errorf("ReplaceAuthorizedKeys(%v): %v", tc.pubKeys, err)
+			continue
 		}
 		update, err := m.SerializeAndSign(tc.signers)
-		if got, want := err != nil, tc.wantErr; got != want {
+		if err != nil {
 			t.Errorf("SerializeAndSign(%v): %v", tc.signers, err)
 			continue
 		}
@@ -95,9 +93,7 @@ func TestCreateAndVerify(t *testing.T) {
 		if _, err := f.Mutate(oldValue, update.GetEntryUpdate().GetMutation()); err != nil {
 			t.Errorf("Mutate(%v): %v", update.GetEntryUpdate().GetMutation(), err)
 		}
-
 	}
-
 }
 
 func createSigner(t *testing.T, privKey string) signatures.Signer {

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -42,7 +42,7 @@ func New() *Mutator {
 
 // Mutate verifies that this is a valid mutation for this item and applies
 // mutation to value. Repeated applications of Mutate on the same input produce
-// the same output.
+// the same output. OldValue and update are both SignedKV protos.
 func (*Mutator) Mutate(oldValue, update proto.Message) (proto.Message, error) {
 	// Ensure that the mutation size is within bounds.
 	if proto.Size(update) > mutator.MaxMutationSize {
@@ -55,9 +55,9 @@ func (*Mutator) Mutate(oldValue, update proto.Message) (proto.Message, error) {
 		glog.Warning("received proto.Message is not of type *pb.SignedKV.")
 		return nil, fmt.Errorf("updateM.(*pb.SignedKV): _, %v", ok)
 	}
-	var oldEntry *pb.Entry
+	var oldEntry *pb.SignedKV
 	if oldValue != nil {
-		old, ok := oldValue.(*pb.Entry)
+		old, ok := oldValue.(*pb.SignedKV)
 		if !ok {
 			glog.Warning("received proto.Message is not of type *pb.Entry.")
 			return nil, fmt.Errorf("oldValueM.(*pb.Entry): _, %v", ok)
@@ -67,13 +67,12 @@ func (*Mutator) Mutate(oldValue, update proto.Message) (proto.Message, error) {
 
 	newEntry := updated.Value
 
-	// Verify pointer to previous data.
-	// The very first entry will have oldValue=nil, so its hash is the
-	// ObjectHash value of nil.
+	// Verify pointer to previous data.  The very first entry will have
+	// oldValue=nil, so its hash is the ObjectHash value of nil.
 	prevEntryHash := objecthash.ObjectHash(oldEntry)
 	if !bytes.Equal(prevEntryHash[:], newEntry.GetPrevious()) {
 		// Check if this mutation is a replay.
-		if oldEntry != nil && proto.Equal(oldEntry, newEntry) {
+		if oldEntry != nil && proto.Equal(oldEntry, updated) {
 			glog.Warningf("mutation is a replay of an old one")
 			return nil, mutator.ErrReplay
 		}
@@ -90,14 +89,14 @@ func (*Mutator) Mutate(oldValue, update proto.Message) (proto.Message, error) {
 
 	kv := *updated
 	kv.Signatures = nil
-	if err := verifyKeys(oldEntry.GetAuthorizedKeys(),
+	if err := verifyKeys(oldEntry.GetValue().GetAuthorizedKeys(),
 		newEntry.GetAuthorizedKeys(),
 		kv,
 		updated.GetSignatures()); err != nil {
 		return nil, err
 	}
 
-	return updated.GetValue(), nil
+	return updated, nil
 }
 
 // verifyKeys verifies both old and new authorized keys based on the following

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -92,7 +92,8 @@ func (*Mutator) Mutate(oldValue, update proto.Message) (proto.Message, error) {
 	if err := verifyKeys(oldEntry.GetValue().GetAuthorizedKeys(),
 		newEntry.GetAuthorizedKeys(),
 		kv,
-		updated.GetSignatures()); err != nil {
+		updated.GetSignatures(),
+	); err != nil {
 		return nil, err
 	}
 

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -233,7 +233,7 @@ func (s *Sequencer) applyMutations(mutations []*pb.SignedKV, leaves []*trillian.
 	retMap := make(map[[32]byte]*trillian.MapLeaf)
 	for _, m := range mutations {
 		index := m.GetIndex()
-		var oldValue *pb.Entry // If no map leaf was found, oldValue will be nil.
+		var oldValue *pb.SignedKV // If no map leaf was found, oldValue will be nil.
 		if leaf, ok := leafMap[toArray(index)]; ok {
 			var err error
 			oldValue, err = entry.FromLeafValue(leaf.GetLeafValue())

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -85,15 +85,15 @@ func TestEmptyGetAndUpdate(t *testing.T) {
 
 	// Create lists of signers.
 	signer1 := createSigner(t, testPrivKey1)
-	signer2 := createSigner(t, testPrivKey2)
 	signers1 := []signatures.Signer{signer1}
+	signer2 := createSigner(t, testPrivKey2)
 	signers2 := []signatures.Signer{signer1, signer2}
 	signers3 := []signatures.Signer{signer2}
 
 	// Create lists of authorized keys
 	authorizedKey1 := getAuthorizedKey(testPubKey1)
-	authorizedKey2 := getAuthorizedKey(testPubKey2)
 	authorizedKeys1 := []*keyspb.PublicKey{authorizedKey1}
+	authorizedKey2 := getAuthorizedKey(testPubKey2)
 	authorizedKeys2 := []*keyspb.PublicKey{authorizedKey1, authorizedKey2}
 	authorizedKeys3 := []*keyspb.PublicKey{authorizedKey2}
 


### PR DESCRIPTION
As planned in #770.

This change puts the signatures used to authorize key changes in the
Trillian map. This allows the monitor to verify that updates were
properly authorized according to each leaf's authorized_keys policy.