### PR TITLE
Use proto.Equal rather than reflection.DeepEqual

### DIFF
--- a/core/crypto/signatures/p256/ecdsa_p256_test.go
+++ b/core/crypto/signatures/p256/ecdsa_p256_test.go
@@ -20,11 +20,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"math"
-	"reflect"
 	"testing"
 
 	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
+
+	"github.com/golang/protobuf/proto"
 )
 
 const (
@@ -131,7 +132,7 @@ func TestPublicKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verifier.PublicKey() failed: %v", err)
 	}
-	if !reflect.DeepEqual(sPK, vPK) {
+	if !proto.Equal(sPK, vPK) {
 		t.Error("signer.PublicKey() and verifier.PublicKey() should be equal")
 	}
 
@@ -140,10 +141,10 @@ func TestPublicKey(t *testing.T) {
 	if pkBytes == nil {
 		t.Fatalf("pem.Decode could not find a PEM block")
 	}
-	if got, want := sPK.GetDer(), pkBytes.Bytes; !reflect.DeepEqual(got, want) {
+	if got, want := sPK.GetDer(), pkBytes.Bytes; !bytes.Equal(got, want) {
 		t.Errorf("sPK.GetEcdsaVerifyingP256()=%v, want %v", got, want)
 	}
-	if got, want := vPK.GetDer(), pkBytes.Bytes; !reflect.DeepEqual(got, want) {
+	if got, want := vPK.GetDer(), pkBytes.Bytes; !bytes.Equal(got, want) {
 		t.Errorf("vPK.GetEcdsaVerifyingP256()=%v, want %v", got, want)
 	}
 }

--- a/core/crypto/signatures/rsa/rsa_sha256_3072_test.go
+++ b/core/crypto/signatures/rsa/rsa_sha256_3072_test.go
@@ -20,10 +20,11 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"math"
-	"reflect"
 	"testing"
 
 	"github.com/google/keytransparency/core/crypto/signatures"
+
+	"github.com/golang/protobuf/proto"
 )
 
 const (
@@ -225,7 +226,7 @@ func TestPublicKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verifier.PublicKey() failed: %v", err)
 	}
-	if !reflect.DeepEqual(sPK, vPK) {
+	if !proto.Equal(sPK, vPK) {
 		t.Error("signer.PublicKey() and verifier.PublicKey() should be equal")
 	}
 

--- a/core/mutation/mutation_test.go
+++ b/core/mutation/mutation_test.go
@@ -19,14 +19,14 @@ package mutation
 import (
 	"database/sql"
 	"fmt"
-	"reflect"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/internal"
 	"github.com/google/keytransparency/core/transaction"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/any"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -125,7 +125,7 @@ func TestGetMutations(t *testing.T) {
 			t.Errorf("%v: len(resp.Mutations)=%v, want %v", tc.description, got, want)
 		}
 		for i := 0; i < len(resp.Mutations); i++ {
-			if got, want := resp.Mutations[i].Mutation, tc.mutations[i]; !reflect.DeepEqual(got, want) {
+			if got, want := resp.Mutations[i].Mutation, tc.mutations[i]; !proto.Equal(got, want) {
 				t.Errorf("%v: resp.Mutations[i].Update=%v, want %v", tc.description, got, want)
 			}
 		}

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -15,7 +15,6 @@
 package entry
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/google/keytransparency/core/crypto/dev"
@@ -102,7 +101,7 @@ func TestFromLeafValue(t *testing.T) {
 		{[]byte{2, 2, 2, 2, 2, 2, 2}, nil, true}, // no valid proto Message
 		{entryB, entry, false},                   // valid leaf
 	} {
-		if got, _ := FromLeafValue(tc.leafVal); !reflect.DeepEqual(got, tc.want) {
+		if got, _ := FromLeafValue(tc.leafVal); !proto.Equal(got, tc.want) {
 			t.Errorf("FromLeafValue(%v)=%v, _ , want %v", tc.leafVal, got, tc.want)
 			t.Error(i)
 		}


### PR DESCRIPTION
reflection.DeepEqual is not a reliable equality test for protos.
Use proto.Equal for protos as appropriate.