### PR TITLE
Remove etcd dependency

### DIFF
--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -44,7 +44,6 @@ import (
 	gauth "github.com/google/keytransparency/impl/google/authentication"
 	_ "github.com/google/trillian/merkle/coniks"    // Register coniks
 	_ "github.com/google/trillian/merkle/objhasher" // Register objhasher
-	_ "github.com/spf13/viper/remote"               // Enable remote configs
 )
 
 var (


### PR DESCRIPTION
This PR removes the unused viper remote configuration feature.
The remote configuration feature was pulling in a whole dependency graph
that includes an unvenored etcd client which has the tendency of
breaking periodically.