### PR TITLE
VRF: NewFromWrappedKey

### DIFF
--- a/core/crypto/vrf/p256/p256.go
+++ b/core/crypto/vrf/p256/p256.go
@@ -217,7 +217,8 @@ func (pk *PublicKey) ProofToHash(m, proof []byte) (index [32]byte, err error) {
 	return sha256.Sum256(vrf), nil
 }
 
-// NewFromWrappedKey creates a signer object from an encrypted private key.
+// NewFromWrappedKey creates a VRF signer object from an encrypted private key.
+// The opque private key must resolve to an `ecdsa.PrivateKey` in order to work.
 func NewFromWrappedKey(ctx context.Context, wrapped proto.Message) (vrf.PrivateKey, error) {
 	// Unwrap.
 	signer, err := keys.NewSigner(ctx, wrapped)

--- a/core/crypto/vrf/p256/p256.go
+++ b/core/crypto/vrf/p256/p256.go
@@ -218,7 +218,7 @@ func (pk *PublicKey) ProofToHash(m, proof []byte) (index [32]byte, err error) {
 }
 
 // NewFromWrappedKey creates a VRF signer object from an encrypted private key.
-// The opque private key must resolve to an `ecdsa.PrivateKey` in order to work.
+// The opaque private key must resolve to an `ecdsa.PrivateKey` in order to work.
 func NewFromWrappedKey(ctx context.Context, wrapped proto.Message) (vrf.PrivateKey, error) {
 	// Unwrap.
 	signer, err := keys.NewSigner(ctx, wrapped)

--- a/core/crypto/vrf/p256/p256.go
+++ b/core/crypto/vrf/p256/p256.go
@@ -22,6 +22,7 @@ package p256
 
 import (
 	"bytes"
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -33,9 +34,12 @@ import (
 	"encoding/binary"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"math/big"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/keytransparency/core/crypto/vrf"
+	"github.com/google/trillian/crypto/keys"
 )
 
 var (
@@ -211,6 +215,22 @@ func (pk *PublicKey) ProofToHash(m, proof []byte) (index [32]byte, err error) {
 		return nilIndex, ErrInvalidVRF
 	}
 	return sha256.Sum256(vrf), nil
+}
+
+// NewFromWrappedKey creates a signer object from an encrypted private key.
+func NewFromWrappedKey(ctx context.Context, wrapped proto.Message) (vrf.PrivateKey, error) {
+	// Unwrap.
+	signer, err := keys.NewSigner(ctx, wrapped)
+	if err != nil {
+		return nil, err
+	}
+
+	switch key := signer.(type) {
+	case *ecdsa.PrivateKey:
+		return NewVRFSigner(key)
+	default:
+		return nil, fmt.Errorf("NewSigner().type: %T, want ecdsa.PrivateKey", key)
+	}
 }
 
 // NewVRFSigner creates a signer object from a private key.

--- a/core/crypto/vrf/p256/p256_test.go
+++ b/core/crypto/vrf/p256/p256_test.go
@@ -74,13 +74,15 @@ func TestH2(t *testing.T) {
 	}
 }
 
-func TestFromWrappedKey(t *testing.T) {
+func TestNewFromWrappedKey(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range []struct {
+		desc   string
 		spec   *keyspb.Specification
 		keygen keys.ProtoGenerator
 	}{
 		{
+			desc: "DER with ECDSA spec",
 			spec: &keyspb.Specification{
 				Params: &keyspb.Specification_EcdsaParams{
 					EcdsaParams: &keyspb.Specification_ECDSA{
@@ -93,38 +95,41 @@ func TestFromWrappedKey(t *testing.T) {
 			},
 		},
 	} {
-		// Generate VRF key.
-		wrapped, err := tc.keygen(ctx, tc.spec)
-		if err != nil {
-			t.Errorf("NewProtoFromSpec failed: %v", err)
-			continue
-		}
-		vrfPriv, err := NewFromWrappedKey(ctx, wrapped)
-		if err != nil {
-			t.Errorf("NewFromWrappedKey failed: %v", err)
-			continue
-		}
-		vrfPublicPB, err := der.ToPublicProto(vrfPriv.Public())
-		if err != nil {
-			t.Errorf("ToPublicProto failed: %v", err)
-			continue
-		}
-		vrfPub, err := NewVRFVerifierFromRawKey(vrfPublicPB.Der)
-		if err != nil {
-			t.Errorf("NewVRFVerifierFromRawKey failed: %v", err)
-			continue
-		}
-		// Test that the public and private components match.
-		m1 := []byte("foobar")
-		index1, proof1 := vrfPriv.Evaluate(m1)
-		index, err := vrfPub.ProofToHash(m1, proof1)
-		if err != nil {
-			t.Errorf("ProofToHash(): %v", err)
-			continue
-		}
-		if got, want := index, index1; got != want {
-			t.Errorf("ProofToInex(%s, %x): %x, want %x", m1, proof1, got, want)
-		}
+		t.Run(tc.desc, func(t *testing.T) {
+			// Generate VRF key.
+			wrapped, err := tc.keygen(ctx, tc.spec)
+			if err != nil {
+				t.Errorf("keygen failed: %v", err)
+				return
+			}
+			vrfPriv, err := NewFromWrappedKey(ctx, wrapped)
+			if err != nil {
+				t.Errorf("NewFromWrappedKey failed: %v", err)
+				return
+			}
+
+			vrfPubDER, err := der.MarshalPublicKey(vrfPriv.Public())
+			if err != nil {
+				t.Errorf("MarshalPublicKey failed: %v", err)
+				return
+			}
+			vrfPub, err := NewVRFVerifierFromRawKey(vrfPubDER)
+			if err != nil {
+				t.Errorf("NewVRFVerifierFromRawKey failed: %v", err)
+				return
+			}
+			// Test that the public and private components match.
+			m := []byte("foobar")
+			indexA, proof := vrfPriv.Evaluate(m)
+			indexB, err := vrfPub.ProofToHash(m, proof)
+			if err != nil {
+				t.Errorf("ProofToHash(): %v", err)
+				return
+			}
+			if got, want := indexB, indexA; got != want {
+				t.Errorf("ProofToHash(%s, %x): %x, want %x", m, proof, got, want)
+			}
+		})
 	}
 }
 
@@ -151,7 +156,7 @@ func TestVRF(t *testing.T) {
 	} {
 		index, err := pk.ProofToHash(tc.m, tc.proof)
 		if got, want := err, tc.err; got != want {
-			t.Errorf("ProofToIndex(%s, %x): %v, want %v", tc.m, tc.proof, got, want)
+			t.Errorf("ProofToHash(%s, %x): %v, want %v", tc.m, tc.proof, got, want)
 		}
 		if err != nil {
 			continue


### PR DESCRIPTION
Trillian supports opaque private key objects which can then be converted
back into private keys by `keys.NewSigner`.  Since VRF requires a
specific key type (ecdsa), not just a `crypto.Signer`, I've added a function to
perform the appropriate checks and type converstion.