### PR TITLE
Add domainID to keyserver 

### DIFF
--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -79,6 +79,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.keytransparency.yaml)")
 
+	RootCmd.PersistentFlags().String("domain", "google.com", "Domain within the KT server")
 	RootCmd.PersistentFlags().String("kt-url", "35.184.134.53:8080", "URL of Key Transparency server")
 	RootCmd.PersistentFlags().String("kt-cert", "genfiles/server.crt", "Path to public key for Key Transparency")
 	RootCmd.PersistentFlags().Bool("autoconfig", true, "Fetch config info from the server's /v1/domain/info")
@@ -257,10 +258,13 @@ func GetClient(useClientSecret bool) (*grpcc.Client, error) {
 // config selects a source for and returns the client configuration.
 func config(ctx context.Context, cc *grpc.ClientConn) (*kpb.GetDomainInfoResponse, error) {
 	autoConfig := viper.GetBool("autoconfig")
+	domain := viper.GetString("domain")
 	switch {
 	case autoConfig:
 		ktClient := spb.NewKeyTransparencyServiceClient(cc)
-		return ktClient.GetDomainInfo(ctx, &kpb.GetDomainInfoRequest{})
+		return ktClient.GetDomainInfo(ctx, &kpb.GetDomainInfoRequest{
+			DomainId: domain,
+		})
 	default:
 		return readConfigFromDisk()
 	}

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -59,7 +59,6 @@ var (
 	mapURL = flag.String("map-url", "", "URL of Trilian Map Server")
 
 	// Info to send Signed Map Heads to a Trillian Log.
-	logID  = flag.Int64("log-id", 0, "Trillian Log ID")
 	logURL = flag.String("log-url", "", "URL of Trillian Log Server for Signed Map Heads")
 )
 
@@ -135,10 +134,6 @@ func main() {
 	mutations, err := mutations.New(sqldb)
 	if err != nil {
 		glog.Exitf("Failed to create mutations object: %v", err)
-	}
-	admin, err := adminstorage.New(sqldb)
-	if err != nil {
-		glog.Exitf("Failed to create adminstorage object: %v", err)
 	}
 
 	mutator := entry.New()

--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -32,7 +32,7 @@ import (
 // user ID and a profile.
 func CreateUpdateEntryRequest(
 	trusted *trillian.SignedLogRoot, getResp *tpb.GetEntryResponse,
-	vrfPub vrf.PublicKey, userID, appID string, profileData []byte,
+	vrfPub vrf.PublicKey, domainID, userID, appID string, profileData []byte,
 	signers []signatures.Signer, authorizedKeys []*keyspb.PublicKey) (*tpb.UpdateEntryRequest, error) {
 	// Extract index from a prior GetEntry call.
 	index, err := vrfPub.ProofToHash(vrf.UniqueID(userID, appID), getResp.VrfProof)
@@ -63,6 +63,7 @@ func CreateUpdateEntryRequest(
 	if err != nil {
 		return nil, err
 	}
+	updateRequest.DomainId = domainID
 	updateRequest.FirstTreeSize = trusted.TreeSize
 	return updateRequest, nil
 }


### PR DESCRIPTION
Rather than passing a single logID, mapID, and vrf key to the keyserver, this PR now passes a reference to `adminstorage`, where each of these items can be looked up based on the domainID in the incoming gRPC request. 

This PR also makes the first adjustments to the integration tests to start using the admin API.  
Further PRs will complete the process as we add domainID support to other modules. 

This PR makes a cosmetic change:  Edited files will show a move toward using `pb` and `gpb` as the renamed imports for protos and service protos. 

#534   