### PR TITLE
Feature/multi/monitor

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/google/keytransparency/cmd/serverutil"
 	"github.com/google/keytransparency/core/client/mutationclient"
+	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitorserver"
-	"github.com/google/keytransparency/core/monitorstorage"
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
@@ -99,7 +99,7 @@ func main() {
 		glog.Fatalf("Could not read domain info %v:", err)
 	}
 
-	store := monitorstorage.New()
+	store := fake.NewMonitorStorage()
 	srv := monitorserver.New(store)
 	mopb.RegisterMonitorServiceServer(grpcServer, srv)
 	reflection.Register(grpcServer)

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -74,7 +74,6 @@ func main() {
 	ktclient := gpb.NewKeyTransparencyServiceClient(cc)
 	mcc := gpb.NewMutationServiceClient(cc)
 
-	// Get domain info
 	config, err := ktclient.GetDomainInfo(ctx, &pb.GetDomainInfoRequest{DomainId: *domainID})
 	if err != nil {
 		glog.Exitf("Could not read domain info %v:", err)

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/google/keytransparency/cmd/serverutil"
+	"github.com/google/keytransparency/core/client/mutationclient"
 	"github.com/google/keytransparency/core/monitor/storage"
 	"github.com/google/keytransparency/impl/monitor"
-	"github.com/google/keytransparency/impl/monitor/client"
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
@@ -136,7 +136,7 @@ func main() {
 	}
 	// initialize the mutations API client and feed the responses it got
 	// into the monitor:
-	mutCli := client.New(mcc, *pollPeriod)
+	mutCli := mutationclient.New(mcc, *pollPeriod)
 	responses, errs := mutCli.StartPolling(*domainID, 1)
 	go func() {
 		for {

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/keytransparency/cmd/serverutil"
 	"github.com/google/keytransparency/core/client/mutationclient"
 	"github.com/google/keytransparency/core/monitor/storage"
-	"github.com/google/keytransparency/impl/monitor"
+	"github.com/google/keytransparency/core/monitorserver"
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
@@ -100,7 +100,7 @@ func main() {
 	}
 
 	store := storage.New()
-	srv := monitor.New(store)
+	srv := monitorserver.New(store)
 	mopb.RegisterMonitorServiceServer(grpcServer, srv)
 	reflection.Register(grpcServer)
 	grpc_prometheus.Register(grpcServer)

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -69,7 +69,7 @@ func main() {
 	// Connect to Key Transparency
 	cc, err := dial()
 	if err != nil {
-		glog.Fatalf("Error Dialing %v: %v", ktURL, err)
+		glog.Exitf("Error Dialing %v: %v", ktURL, err)
 	}
 	ktclient := gpb.NewKeyTransparencyServiceClient(cc)
 	mcc := gpb.NewMutationServiceClient(cc)
@@ -77,13 +77,13 @@ func main() {
 	// Get domain info
 	config, err := ktclient.GetDomainInfo(ctx, &pb.GetDomainInfoRequest{DomainId: *domainID})
 	if err != nil {
-		glog.Fatalf("Could not read domain info %v:", err)
+		glog.Exitf("Could not read domain info %v:", err)
 	}
 
 	// Read signing key:
 	key, err := pem.ReadPrivateKeyFile(*signingKey, *signingKeyPassword)
 	if err != nil {
-		glog.Fatalf("Could not create signer from %v: %v", *signingKey, err)
+		glog.Exitf("Could not create signer from %v: %v", *signingKey, err)
 	}
 	signer := crypto.NewSHA256Signer(key)
 	store := fake.NewMonitorStorage()

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/google/keytransparency/cmd/serverutil"
 	"github.com/google/keytransparency/core/client/mutationclient"
-	"github.com/google/keytransparency/core/monitor/storage"
 	"github.com/google/keytransparency/core/monitorserver"
+	"github.com/google/keytransparency/core/monitorstorage"
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/crypto"
@@ -99,7 +99,7 @@ func main() {
 		glog.Fatalf("Could not read domain info %v:", err)
 	}
 
-	store := storage.New()
+	store := monitorstorage.New()
 	srv := monitorserver.New(store)
 	mopb.RegisterMonitorServiceServer(grpcServer, srv)
 	reflection.Register(grpcServer)

--- a/core/client/mutationclient/client.go
+++ b/core/client/mutationclient/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client
+package mutationclient
 
 //
 // This file contains Monitor'c grpc client logic: poll mutations from the

--- a/core/fake/monitorstorage.go
+++ b/core/fake/monitorstorage.go
@@ -1,0 +1,71 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"github.com/google/trillian"
+
+	"github.com/google/keytransparency/core/monitorstorage"
+	pb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
+)
+
+// MonitorStorage is an in-memory store for the monitoring results.
+type MonitorStorage struct {
+	store  map[int64]*monitorstorage.Result
+	latest int64
+}
+
+// NewMonitorStorage returns an in-memory place store monitoring results.
+func NewMonitorStorage() *MonitorStorage {
+	return &MonitorStorage{
+		store: make(map[int64]*monitorstorage.Result),
+	}
+}
+
+// Set internally stores the given data as a MonitoringResult which can be
+// retrieved by Get.
+func (s *MonitorStorage) Set(epoch int64,
+	seenNanos int64,
+	smr *trillian.SignedMapRoot,
+	response *pb.GetMutationsResponse,
+	errorList []error) error {
+	// see if we already processed this epoch:
+	if _, ok := s.store[epoch]; ok {
+		return monitorstorage.ErrAlreadyStored
+	}
+	// if not we just store the value:
+	s.store[epoch] = &monitorstorage.Result{
+		Smr:      smr,
+		Seen:     seenNanos,
+		Response: response,
+		Errors:   errorList,
+	}
+	s.latest = epoch
+	return nil
+}
+
+// Get returns the MonitoringResult for the given epoch. It returns an error
+// if the result does not exist.
+func (s *MonitorStorage) Get(epoch int64) (*monitorstorage.Result, error) {
+	if result, ok := s.store[epoch]; ok {
+		return result, nil
+	}
+	return nil, monitorstorage.ErrNotFound
+}
+
+// LatestEpoch is a convenience method to retrieve the latest stored epoch.
+func (s *MonitorStorage) LatestEpoch() int64 {
+	return s.latest
+}

--- a/core/fake/monitorstorage.go
+++ b/core/fake/monitorstorage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/trillian"
 
 	"github.com/google/keytransparency/core/monitorstorage"
+
 	pb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
 )
 

--- a/core/fake/monitorstorage.go
+++ b/core/fake/monitorstorage.go
@@ -41,7 +41,7 @@ func (s *MonitorStorage) Set(epoch int64, r *monitorstorage.Result) error {
 	return nil
 }
 
-// Get returns the Result for the given epoch. It returns ErrNotFound if the epoch do not exist.
+// Get returns the Result for the given epoch. It returns ErrNotFound if the epoch does not exist.
 func (s *MonitorStorage) Get(epoch int64) (*monitorstorage.Result, error) {
 	if result, ok := s.store[epoch]; ok {
 		return result, nil

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -19,32 +19,50 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
-
+	"github.com/google/keytransparency/core/client/mutationclient"
 	"github.com/google/keytransparency/core/monitorstorage"
-	ktpb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
-	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/merkle/hashers"
+
+	"github.com/golang/glog"
+
+	gpb "github.com/google/keytransparency/core/proto/keytransparency_v1_grpc"
+	pb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
+	tcrypto "github.com/google/trillian/crypto"
 )
 
 // Monitor holds the internal state for a monitor accessing the mutations API
 // and for verifying its responses.
 type Monitor struct {
+	mclient gpb.MutationServiceClient
+	signer  *tcrypto.Signer
+	trusted *trillian.SignedLogRoot
+
 	mapID       int64
+	logVerifier client.LogVerifier
+	store       monitorstorage.Interface
 	mapHasher   hashers.MapHasher
 	mapPubKey   crypto.PublicKey
-	logVerifier client.LogVerifier
-	signer      *tcrypto.Signer
-	trusted     *trillian.SignedLogRoot
-	store       monitorstorage.Interface
 }
 
-// New creates a new instance of the monitor.
-func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcrypto.Signer, store monitorstorage.Interface) (*Monitor, error) {
+// NewFromConfig produces a new monitor from a DomainInfo object.
+func NewFromConfig(mclient gpb.MutationServiceClient,
+	config *pb.GetDomainInfoResponse,
+	signer *tcrypto.Signer,
+	store monitorstorage.Interface) (*Monitor, error) {
+	logTree := config.GetLog()
+	mapTree := config.GetMap()
+	logHasher, err := hashers.NewLogHasher(logTree.GetHashStrategy())
+	if err != nil {
+		glog.Fatalf("Could not initialize log hasher: %v", err)
+	}
+	logPubKey, err := der.UnmarshalPublicKey(logTree.GetPublicKey().GetDer())
+	if err != nil {
+		glog.Fatalf("Failed parsing Log public key: %v", err)
+	}
 	mapHasher, err := hashers.NewMapHasher(mapTree.GetHashStrategy())
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating MapHasher: %v", err)
@@ -53,9 +71,22 @@ func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcry
 	if err != nil {
 		return nil, fmt.Errorf("Could not unmarshal map public key: %v", err)
 	}
+	logVerifier := client.NewLogVerifier(logHasher, logPubKey)
+	return New(mclient, logVerifier,
+		mapTree.TreeId, mapHasher, mapPubKey,
+		signer, store)
+}
+
+// New creates a new instance of the monitor.
+func New(mclient gpb.MutationServiceClient,
+	logVerifier client.LogVerifier,
+	mapID int64, mapHasher hashers.MapHasher, mapPubKey crypto.PublicKey,
+	signer *tcrypto.Signer,
+	store monitorstorage.Interface) (*Monitor, error) {
 	return &Monitor{
-		logVerifier: logverifierCli,
-		mapID:       mapTree.TreeId,
+		mclient:     mclient,
+		logVerifier: logVerifier,
+		mapID:       mapID,
 		mapHasher:   mapHasher,
 		mapPubKey:   mapPubKey,
 		signer:      signer,
@@ -63,10 +94,31 @@ func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcry
 	}, nil
 }
 
+// ProcessLoop continuously fetches mutations and processes them.
+func (m *Monitor) ProcessLoop(domainID string, period time.Duration) {
+	mutCli := mutationclient.New(m.mclient, period)
+	responses, errs := mutCli.StartPolling(domainID, 1)
+	for {
+		select {
+		case mutResp := <-responses:
+			glog.Infof("Received mutations response: %v", mutResp.Epoch)
+			if err := m.Process(mutResp); err != nil {
+				glog.Infof("Error processing mutations response: %v", err)
+			}
+		case err := <-errs:
+			// this is OK if there were no mutations in  between:
+			// TODO(ismail): handle the case when the known maxDuration has
+			// passed and no epoch was issued?
+			glog.Infof("Could not retrieve mutations API response %v", err)
+		}
+	}
+
+}
+
 // Process processes a mutation response received from the keytransparency
 // server. Processing includes verifying, signing and storing the resulting
 // monitoring response.
-func (m *Monitor) Process(resp *ktpb.GetMutationsResponse) error {
+func (m *Monitor) Process(resp *pb.GetMutationsResponse) error {
 	var smr *trillian.SignedMapRoot
 	var err error
 	seen := time.Now().Unix()

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -40,11 +40,11 @@ type Monitor struct {
 	logVerifier client.LogVerifier
 	signer      *tcrypto.Signer
 	trusted     *trillian.SignedLogRoot
-	store       *monitorstorage.Storage
+	store       monitorstorage.Interface
 }
 
 // New creates a new instance of the monitor.
-func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcrypto.Signer, store *monitorstorage.Storage) (*Monitor, error) {
+func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcrypto.Signer, store monitorstorage.Interface) (*Monitor, error) {
 	mapHasher, err := hashers.NewMapHasher(mapTree.GetHashStrategy())
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating MapHasher: %v", err)

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/golang/glog"
 
-	"github.com/google/keytransparency/core/monitor/storage"
+	"github.com/google/keytransparency/core/monitorstorage"
 	ktpb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
 
 	"github.com/google/trillian"
@@ -40,11 +40,11 @@ type Monitor struct {
 	logVerifier client.LogVerifier
 	signer      *tcrypto.Signer
 	trusted     *trillian.SignedLogRoot
-	store       *storage.Storage
+	store       *monitorstorage.Storage
 }
 
 // New creates a new instance of the monitor.
-func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcrypto.Signer, store *storage.Storage) (*Monitor, error) {
+func New(logverifierCli client.LogVerifier, mapTree *trillian.Tree, signer *tcrypto.Signer, store *monitorstorage.Storage) (*Monitor, error) {
 	mapHasher, err := hashers.NewMapHasher(mapTree.GetHashStrategy())
 	if err != nil {
 		return nil, fmt.Errorf("Failed creating MapHasher: %v", err)

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -26,11 +26,11 @@ import (
 	"github.com/google/keytransparency/core/mutator/entry"
 
 	"github.com/golang/glog"
-	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 
-	ktpb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
+	pb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
+	tcrypto "github.com/google/trillian/crypto"
 )
 
 var (
@@ -59,7 +59,7 @@ var (
 // Additionally to the response it takes a complete list of mutations. The list
 // of received mutations may differ from those included in the initial response
 // because of the max. page size.
-func (m *Monitor) VerifyMutationsResponse(in *ktpb.GetMutationsResponse) []error {
+func (m *Monitor) VerifyMutationsResponse(in *pb.GetMutationsResponse) []error {
 	errList := make([]error, 0)
 
 	if m.trusted == nil {
@@ -118,7 +118,7 @@ func (m *Monitor) VerifyMutationsResponse(in *ktpb.GetMutationsResponse) []error
 	return errList
 }
 
-func (m *Monitor) verifyMutations(muts []*ktpb.MutationProof, oldRoot, expectedNewRoot []byte, mapID int64) []error {
+func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNewRoot []byte, mapID int64) []error {
 	errList := make([]error, 0)
 	mutator := entry.New()
 	oldProofNodes := make(map[string][]byte)

--- a/core/monitorserver/monitor_test.go
+++ b/core/monitorserver/monitor_test.go
@@ -22,11 +22,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/keytransparency/core/monitor/storage"
+	"github.com/google/keytransparency/core/monitorstorage"
 )
 
 func TestGetSignedMapRoot(t *testing.T) {
-	srv := New(storage.New())
+	srv := New(monitorstorage.New())
 	_, err := srv.GetSignedMapRoot(context.TODO(), nil)
 	if got, want := err, ErrNothingProcessed; got != want {
 		t.Errorf("GetSignedMapRoot(_, _): %v, want %v", got, want)

--- a/core/monitorserver/monitor_test.go
+++ b/core/monitorserver/monitor_test.go
@@ -22,11 +22,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/keytransparency/core/monitorstorage"
+	"github.com/google/keytransparency/core/fake"
 )
 
 func TestGetSignedMapRoot(t *testing.T) {
-	srv := New(monitorstorage.New())
+	srv := New(fake.NewMonitorStorage())
 	_, err := srv.GetSignedMapRoot(context.TODO(), nil)
 	if got, want := err, ErrNothingProcessed; got != want {
 		t.Errorf("GetSignedMapRoot(_, _): %v, want %v", got, want)

--- a/core/monitorserver/monitor_test.go
+++ b/core/monitorserver/monitor_test.go
@@ -16,7 +16,7 @@
 // key-transparency server's Mutations API and signs Map Roots if it could
 // reconstruct
 // clients can query.
-package monitor
+package monitorserver
 
 import (
 	"context"

--- a/core/monitorserver/server.go
+++ b/core/monitorserver/server.go
@@ -19,7 +19,7 @@
 
 // Package monitor contains an implementation of a Monitor server which can be
 // queried for monitoring results.
-package monitor
+package monitorserver
 
 import (
 	"context"

--- a/core/monitorserver/server.go
+++ b/core/monitorserver/server.go
@@ -79,23 +79,22 @@ func (s *Server) GetSignedMapRootByRevision(ctx context.Context, in *mopb.GetMon
 }
 
 func (s *Server) getResponseByRevision(epoch int64) (*mopb.GetMonitoringResponse, error) {
-	res, err := s.storage.Get(epoch)
+	r, err := s.storage.Get(epoch)
 	if err == monitorstorage.ErrNotFound {
-		return nil, grpc.Errorf(codes.NotFound,
-			"Could not find monitoring response for epoch %d", epoch)
+		return nil, grpc.Errorf(codes.NotFound, "Could not find monitoring response for epoch %d", epoch)
 	}
 
 	resp := &mopb.GetMonitoringResponse{
-		Smr:                res.Smr,
-		SeenTimestampNanos: res.Seen,
+		Smr:                r.Smr,
+		SeenTimestampNanos: r.Seen.UnixNano(),
 	}
 
-	if len(res.Errors) > 0 {
-		for _, err := range res.Errors {
-			resp.Errors = append(resp.Errors, err.Error())
-		}
+	for _, err := range r.Errors {
+		resp.Errors = append(resp.Errors, err.Error())
+	}
+	if len(r.Errors) > 0 {
 		// data to replay the verification steps:
-		resp.ErrorData = res.Response
+		resp.ErrorData = r.Response
 	}
 
 	return resp, nil

--- a/core/monitorserver/server.go
+++ b/core/monitorserver/server.go
@@ -17,7 +17,7 @@
 // reconstruct
 // clients can query.
 
-// Package monitor contains an implementation of a Monitor server which can be
+// Package monitorserver contains an implementation of a Monitor server which can be
 // queried for monitoring results.
 package monitorserver
 
@@ -41,11 +41,11 @@ var (
 // Server holds internal state for the monitor server. It serves monitoring
 // responses via a grpc and HTTP API.
 type Server struct {
-	storage *monitorstorage.Storage
+	storage monitorstorage.Interface
 }
 
 // New creates a new instance of the monitor server.
-func New(storage *monitorstorage.Storage) *Server {
+func New(storage monitorstorage.Interface) *Server {
 	return &Server{
 		storage: storage,
 	}

--- a/core/monitorserver/server.go
+++ b/core/monitorserver/server.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
-	"github.com/google/keytransparency/core/monitor/storage"
+	"github.com/google/keytransparency/core/monitorstorage"
 	mopb "github.com/google/keytransparency/core/proto/monitor_v1_proto"
 )
 
@@ -41,11 +41,11 @@ var (
 // Server holds internal state for the monitor server. It serves monitoring
 // responses via a grpc and HTTP API.
 type Server struct {
-	storage *storage.Storage
+	storage *monitorstorage.Storage
 }
 
 // New creates a new instance of the monitor server.
-func New(storage *storage.Storage) *Server {
+func New(storage *monitorstorage.Storage) *Server {
 	return &Server{
 		storage: storage,
 	}
@@ -80,7 +80,7 @@ func (s *Server) GetSignedMapRootByRevision(ctx context.Context, in *mopb.GetMon
 
 func (s *Server) getResponseByRevision(epoch int64) (*mopb.GetMonitoringResponse, error) {
 	res, err := s.storage.Get(epoch)
-	if err == storage.ErrNotFound {
+	if err == monitorstorage.ErrNotFound {
 		return nil, grpc.Errorf(codes.NotFound,
 			"Could not find monitoring response for epoch %d", epoch)
 	}

--- a/core/monitorstorage/storage.go
+++ b/core/monitorstorage/storage.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package storage holds data produced by the monitor
-package storage
+package monitorstorage
 
 import (
 	"errors"

--- a/core/monitorstorage/storage.go
+++ b/core/monitorstorage/storage.go
@@ -17,6 +17,7 @@ package monitorstorage
 
 import (
 	"errors"
+	"time"
 
 	"github.com/google/trillian"
 
@@ -32,14 +33,21 @@ var (
 	ErrNotFound = errors.New("data for epoch not found")
 )
 
-// Result stores all data
+// Result describes the monitor's attempt to verify the complete transition from
+// SignedMapRoot (SMR) revision T to revision T+1, having been supplied the set
+// of mutations by which to transform SMR T into SMR T+1.
+//
+// Result contains the monitor's signature on SMR T if the monitor believes that
+// the transition from T to T+1 is fully correct. It also contains that time at which
+// the monitor observed SMR, and in cases where the verification did not succeed, a
+// list of errors describing the observed problems, and a collection of data by which
+// others can attempt the same verification.
 type Result struct {
 	// Smr contains the map root signed by the monitor in case all verifications
 	// have passed.
 	Smr *trillian.SignedMapRoot
-	// Seen is the unix timestamp at which the mutations response has been
-	// received.
-	Seen int64
+	// Seen is the timestamp at which the mutations response has been received.
+	Seen time.Time
 	// Errors contains a string representation of the verifications steps that
 	// failed.
 	Errors []error
@@ -48,10 +56,10 @@ type Result struct {
 	Response *pb.GetMutationsResponse
 }
 
-// Interface is the interface for storing monitoring results.
+// Interface is the interface that stores and retrieves monitoring results.
 type Interface interface {
 	// Set stores the monitoring result for a specific epoch.
-	Set(epoch int64, seenNanos int64, smr *trillian.SignedMapRoot, response *pb.GetMutationsResponse, errorList []error) error
+	Set(epoch int64, r *Result) error
 	// Get retrieves the monitoring result for a specific epoch.
 	Get(epoch int64) (*Result, error)
 	// LatestEpoch returns the highest numbered epoch that has been processed.

--- a/core/monitorstorage/storage.go
+++ b/core/monitorstorage/storage.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package storage holds data produced by the monitor
+// Package monitorstorage holds data produced by the monitor
 package monitorstorage
 
 import (

--- a/integration/monitor_test.go
+++ b/integration/monitor_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
-	"github.com/google/keytransparency/core/monitor/storage"
+	"github.com/google/keytransparency/core/monitorstorage"
 	"github.com/google/keytransparency/core/sequencer"
 
 	"github.com/google/trillian/crypto"
@@ -61,7 +61,7 @@ func TestMonitor(t *testing.T) {
 	logTree := resp.Log
 	mapTree := resp.Map
 	_ = logTree
-	store := storage.New()
+	store := monitorstorage.New()
 	// TODO(ismail): setup and use a real logVerifier instead:
 	mon, err := monitor.New(fake.NewFakeTrillianLogVerifier(), mapTree, crypto.NewSHA256Signer(signer), store)
 	if err != nil {

--- a/integration/monitor_test.go
+++ b/integration/monitor_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/google/keytransparency/core/sequencer"
 
 	"github.com/google/trillian/crypto"
+	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/google/trillian/crypto/keyspb"
+	"github.com/google/trillian/merkle/hashers"
 
 	gpb "github.com/google/keytransparency/core/proto/keytransparency_v1_grpc"
 	pb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
@@ -57,16 +59,24 @@ func TestMonitor(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't create signer: %v", err)
 	}
-	logTree := resp.Log
-	mapTree := resp.Map
-	_ = logTree
+	mapTree := resp.GetMap()
+	mapHasher, err := hashers.NewMapHasher(mapTree.GetHashStrategy())
+	if err != nil {
+		t.Fatalf("Failed creating MapHasher: %v", err)
+	}
+	mapPubKey, err := der.UnmarshalPublicKey(mapTree.GetPublicKey().GetDer())
+	if err != nil {
+		t.Fatalf("Could not unmarshal map public key: %v", err)
+	}
 	store := fake.NewMonitorStorage()
 	// TODO(ismail): setup and use a real logVerifier instead:
-	mon, err := monitor.New(fake.NewFakeTrillianLogVerifier(), mapTree, crypto.NewSHA256Signer(signer), store)
+	mcc := gpb.NewMutationServiceClient(env.Conn)
+	mon, err := monitor.New(mcc, fake.NewFakeTrillianLogVerifier(),
+		mapTree.TreeId, mapHasher, mapPubKey,
+		crypto.NewSHA256Signer(signer), store)
 	if err != nil {
 		t.Fatalf("Couldn't create monitor: %v", err)
 	}
-	mcc := gpb.NewMutationServiceClient(env.Conn)
 	mutCli := mutationclient.New(mcc, time.Second)
 
 	for _, tc := range []struct {

--- a/integration/monitor_test.go
+++ b/integration/monitor_test.go
@@ -20,12 +20,12 @@ import (
 	"time"
 
 	"github.com/google/keytransparency/core/client/grpcc"
+	"github.com/google/keytransparency/core/client/mutationclient"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
 	"github.com/google/keytransparency/core/monitor/storage"
 	"github.com/google/keytransparency/core/sequencer"
-	"github.com/google/keytransparency/impl/monitor/client"
 
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
@@ -68,7 +68,7 @@ func TestMonitor(t *testing.T) {
 		t.Fatalf("Couldn't create monitor: %v", err)
 	}
 	mcc := gpb.NewMutationServiceClient(env.Conn)
-	mutCli := client.New(mcc, time.Second)
+	mutCli := mutationclient.New(mcc, time.Second)
 
 	for _, tc := range []struct {
 		// the userIDs to update, if no userIDs are provided, no update request

--- a/integration/monitor_test.go
+++ b/integration/monitor_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
-	"github.com/google/keytransparency/core/monitorstorage"
 	"github.com/google/keytransparency/core/sequencer"
 
 	"github.com/google/trillian/crypto"
@@ -61,7 +60,7 @@ func TestMonitor(t *testing.T) {
 	logTree := resp.Log
 	mapTree := resp.Map
 	_ = logTree
-	store := monitorstorage.New()
+	store := fake.NewMonitorStorage()
 	// TODO(ismail): setup and use a real logVerifier instead:
 	mon, err := monitor.New(fake.NewFakeTrillianLogVerifier(), mapTree, crypto.NewSHA256Signer(signer), store)
 	if err != nil {


### PR DESCRIPTION
This PR 
- Moves the monitor packages into the standard format:
   - `monitorserver`
   - `monitorstorage`
   - `mutationclient` 
- An interface has been defined for `monitorstorage` and the in-memory implementation has been moved to `fake`.
- Application-level logic in `cmd/keytransparency-monitor` has been moved to `monitor`. 
    - A convenience method `monitor.NewFromConfig` has been added to help with setup. 