### PR TITLE
Update vendored objecthash to e06914f

### DIFF
--- a/core/client/gobindclient/client.go
+++ b/core/client/gobindclient/client.go
@@ -97,7 +97,15 @@ func AddKtServer(ktURL string, insecureTLS bool, ktTLSCertPEM []byte, domainInfo
 	if len(domainInfoHash) == 0 {
 		Vlog.Print("Warning: no domainInfoHash provided. Key material from the server will be trusted.")
 	} else {
-		if got := objecthash.ObjectHash(config); !bytes.Equal(got[:], domainInfoHash) {
+		cj, err := objecthash.CommonJSONify(config)
+		if err != nil {
+			return fmt.Errorf("CommonJSONify(): %v", err)
+		}
+		got, err := objecthash.ObjectHash(cj)
+		if err != nil {
+			return fmt.Errorf("ObjectHash(): %v", err)
+		}
+		if !bytes.Equal(got[:], domainInfoHash) {
 			return fmt.Errorf("The KtServer %v returned a domainInfoResponse inconsistent with the provided domainInfoHash", ktURL)
 		}
 	}

--- a/core/crypto/signatures/p256/ecdsa_p256.go
+++ b/core/crypto/signatures/p256/ecdsa_p256.go
@@ -114,7 +114,11 @@ func (s *signer) Sign(data interface{}) (*sigpb.DigitallySigned, error) {
 	if err != nil {
 		return nil, err
 	}
-	hash := objecthash.CommonJSONHash(string(j))
+
+	hash, err := objecthash.CommonJSONHash(string(j))
+	if err != nil {
+		return nil, err
+	}
 
 	var ecSig struct {
 		R, S *big.Int
@@ -227,7 +231,10 @@ func (s *verifier) Verify(data interface{}, sig *sigpb.DigitallySigned) error {
 		log.Print("json.Marshal failed")
 		return signatures.ErrVerify
 	}
-	hash := objecthash.CommonJSONHash(string(j))
+	hash, err := objecthash.CommonJSONHash(string(j))
+	if err != nil {
+		return signatures.ErrVerify
+	}
 
 	var ecdsaSig struct {
 		R, S *big.Int

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -47,7 +47,15 @@ func NewMutation(oldValue, index []byte, userID, appID string) (*Mutation, error
 		return nil, err
 	}
 
-	hash := objecthash.ObjectHash(prevEntry)
+	pej, err := objecthash.CommonJSONify(prevEntry)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := objecthash.ObjectHash(pej)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Mutation{
 		userID:    userID,
 		appID:     appID,

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -67,7 +67,15 @@ func (*Mutator) Mutate(oldValue, update proto.Message) (proto.Message, error) {
 
 	// Verify pointer to previous data.  The very first entry will have
 	// oldValue=nil, so its hash is the ObjectHash value of nil.
-	prevEntryHash := objecthash.ObjectHash(oldEntry)
+	oej, err := objecthash.CommonJSONify(oldEntry)
+	if err != nil {
+		return nil, fmt.Errorf("CommonJSONify: %v", err)
+	}
+	prevEntryHash, err := objecthash.ObjectHash(oej)
+	if err != nil {
+		return nil, fmt.Errorf("ObjectHash: %v", err)
+	}
+
 	if !bytes.Equal(prevEntryHash[:], newEntry.GetPrevious()) {
 		// Check if this mutation is a replay.
 		if oldEntry != nil && proto.Equal(oldEntry, newEntry) {

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -16,6 +16,7 @@ package entry
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"testing"
 
 	"github.com/google/keytransparency/core/crypto/signatures"
@@ -26,12 +27,25 @@ import (
 	tpb "github.com/google/keytransparency/core/proto/keytransparency_v1_proto"
 )
 
+func mustObjectHash(t *testing.T, val interface{}) [sha256.Size]byte {
+	t.Helper()
+	j, err := objecthash.CommonJSONify(val)
+	if err != nil {
+		t.Fatalf("CommonJSONify() err=%v", err)
+	}
+	h, err := objecthash.ObjectHash(j)
+	if err != nil {
+		t.Fatalf("ObjectHash() err=%v", err)
+	}
+	return h
+}
+
 func TestCheckMutation(t *testing.T) {
 	// The passed commitment to createEntry is a dummy value. It is needed to
 	// make the two entries (entryData1 and entryData2) different, otherwise
 	// it is not possible to test all cases.
 	key := []byte{0}
-	nilHash := objecthash.ObjectHash(nil)
+	nilHash := mustObjectHash(t, nil)
 
 	entryData1 := &tpb.Entry{
 		Index:          key,
@@ -39,7 +53,7 @@ func TestCheckMutation(t *testing.T) {
 		AuthorizedKeys: mustPublicKeys([]string{testPubKey1}),
 		Previous:       nilHash[:],
 	}
-	hashEntry1 := objecthash.ObjectHash(entryData1)
+	hashEntry1 := mustObjectHash(t, *entryData1)
 
 	entryData2 := &tpb.Entry{
 		Index:          key,


### PR DESCRIPTION
API changes require:
 * client code to CommonJSONify structs, protobufs, etc. before calling
   objecthash.ObjectHash();
 * client code to handle error returns (earlier objecthash would panic).