### PR TITLE
Linter cleanup GoMetaLinter:gas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 script:
   - export TRILLIAN_SQL_DRIVER=mysql
   - make
-  - gometalinter --config=metalinter.json ./...
+  - gometalinter --config=gometalinter.json ./...
   - ./coverage.sh
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ coverage: main
 	TRILLIAN_SQL_DRIVER=mysql go test ./... -cover 
 
 check:
-	gometalinter --config=metalinter.json ./...
+	gometalinter --config=gometalinter.json ./...
 
 presubmit: test check
 

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -179,7 +179,7 @@ func transportCreds(ktURL string) (credentials.TransportCredentials, error) {
 	switch {
 	case insecure: // Impatient insecure.
 		return credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, // nolint: gas
 		}), nil
 
 	case ktCert != "": // Custom CA Cert.

--- a/core/client/gobindclient/client.go
+++ b/core/client/gobindclient/client.go
@@ -167,7 +167,7 @@ func transportCreds(ktURL string, insecure bool, ktTLSCertPEM []byte) (credentia
 	case insecure: // Impatient insecure.
 		Vlog.Printf("Warning: Skipping verification of KT Server's TLS certificate.")
 		return credentials.NewTLS(&tls.Config{
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, // nolint: gas
 		}), nil
 
 	case len(ktTLSCertPEM) != 0: // Custom CA Cert.

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -10,5 +10,6 @@
   "Skip": ["core/proto", "impl/proto"],
   "Deadline": "4m", 
   "Cyclo": 18,
-  "Aggregate": true
+  "Aggregate": true,
+  "Exclude": ["Errors unhandled.,LOW,HIGH \\(gas\\)"]
 }

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -67,7 +67,7 @@ func NewDB(t testing.TB) *sql.DB {
 
 // Listen opens a random local port and listens on it.
 func Listen(t testing.TB) (string, net.Listener) {
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("Failed to listen: %v", err)
 	}
@@ -100,7 +100,7 @@ func vrfKeyGen(ctx context.Context, spec *keyspb.Specification) (proto.Message, 
 // NewEnv sets up common resources for tests.
 func NewEnv(t *testing.T) *Env {
 	ctx := context.Background()
-	domainID := fmt.Sprintf("domain %d", rand.Int())
+	domainID := fmt.Sprintf("domain %d", rand.Int()) // nolint: gas
 	sqldb := NewDB(t)
 
 	// We can only run the integration tests if there is a MySQL instance available.


### PR DESCRIPTION
The [Go AST Scanner](https://github.com/GoASTScanner/gas) was [recently](https://github.com/alecthomas/gometalinter/commit/3e602d9013785a8e54137caf409564a966586b85) fixed. This PR makes the needed corrections in this repo.

As a result, the mac firewall will no longer complain when running integration tests!