### PR TITLE
Mutation.SetPrevious

### DIFF
--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -41,8 +41,8 @@ func CreateUpdateEntryRequest(
 	}
 
 	oldLeaf := getResp.GetLeafProof().GetLeaf().GetLeafValue()
-	mutation, err := entry.NewMutation(oldLeaf, index[:], userID, appID)
-	if err != nil {
+	mutation := entry.NewMutation(index[:], userID, appID)
+	if err := mutation.SetPrevious(oldLeaf); err != nil {
 		return nil, fmt.Errorf("Error unmarshaling Entry from leaf proof: %v", err)
 	}
 

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -35,12 +35,8 @@ func TestReplaceAuthorizedKeys(t *testing.T) {
 		index := []byte("index")
 		userID := "bob"
 		appID := "app1"
-		m, err := NewMutation(nil, index, userID, appID)
-		if err != nil {
-			t.Errorf("NewMutation(): %v", err)
-		}
-
-		err = m.ReplaceAuthorizedKeys(tc.pubKeys)
+		m := NewMutation(index, userID, appID)
+		err := m.ReplaceAuthorizedKeys(tc.pubKeys)
 		if got, want := err != nil, tc.wantErr; got != want {
 			t.Errorf("ReplaceAuthorizedKeys(%v): %v, wantErr: %v", tc.pubKeys, got, want)
 		}
@@ -65,8 +61,8 @@ func TestCreateAndVerify(t *testing.T) {
 		userID := "alice"
 		appID := "app1"
 
-		m, err := NewMutation(tc.old, index, userID, appID)
-		if err != nil {
+		m := NewMutation(index, userID, appID)
+		if err := m.SetPrevious(tc.old); err != nil {
 			t.Errorf("NewMutation(%v): %v", tc.old, err)
 			continue
 		}
@@ -74,7 +70,7 @@ func TestCreateAndVerify(t *testing.T) {
 			t.Errorf("SetCommitment(%v): %v", tc.data, err)
 			continue
 		}
-		if err = m.ReplaceAuthorizedKeys(tc.pubKeys); err != nil {
+		if err := m.ReplaceAuthorizedKeys(tc.pubKeys); err != nil {
 			t.Errorf("ReplaceAuthorizedKeys(%v): %v", tc.pubKeys, err)
 			continue
 		}


### PR DESCRIPTION
This separates the process of creating a mutation for a user
from setting the previous value of entry. We may want to
set the previous entry separately in some cases.