### PR TITLE
Add domainID to mutation

### DIFF
--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -41,7 +41,7 @@ func CreateUpdateEntryRequest(
 	}
 
 	oldLeaf := getResp.GetLeafProof().GetLeaf().GetLeafValue()
-	mutation := entry.NewMutation(index[:], userID, appID)
+	mutation := entry.NewMutation(index[:], domainID, appID, userID)
 	if err := mutation.SetPrevious(oldLeaf); err != nil {
 		return nil, fmt.Errorf("Error unmarshaling Entry from leaf proof: %v", err)
 	}
@@ -63,7 +63,6 @@ func CreateUpdateEntryRequest(
 	if err != nil {
 		return nil, err
 	}
-	updateRequest.DomainId = domainID
 	updateRequest.FirstTreeSize = trusted.TreeSize
 	return updateRequest, nil
 }

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
 )
 
+const domainID = "default"
+
 func TestReplaceAuthorizedKeys(t *testing.T) {
 	for _, tc := range []struct {
 		pubKeys []*keyspb.PublicKey
@@ -35,7 +37,7 @@ func TestReplaceAuthorizedKeys(t *testing.T) {
 		index := []byte("index")
 		userID := "bob"
 		appID := "app1"
-		m := NewMutation(index, userID, appID)
+		m := NewMutation(index, domainID, appID, userID)
 		err := m.ReplaceAuthorizedKeys(tc.pubKeys)
 		if got, want := err != nil, tc.wantErr; got != want {
 			t.Errorf("ReplaceAuthorizedKeys(%v): %v, wantErr: %v", tc.pubKeys, got, want)
@@ -61,7 +63,7 @@ func TestCreateAndVerify(t *testing.T) {
 		userID := "alice"
 		appID := "app1"
 
-		m := NewMutation(index, userID, appID)
+		m := NewMutation(index, domainID, appID, userID)
 		if err := m.SetPrevious(tc.old); err != nil {
 			t.Errorf("NewMutation(%v): %v", tc.old, err)
 			continue


### PR DESCRIPTION
This removes the need for callers to set the domainID in the request before sending