### PR TITLE
Don't return raw grpc interfaces

### DIFF
--- a/core/fake/trillian_log_client.go
+++ b/core/fake/trillian_log_client.go
@@ -21,37 +21,44 @@ import (
 	"google.golang.org/grpc"
 )
 
-type logServer struct {
+// LogServer only stores tree size.
+type LogServer struct {
 	treeSize int64
 }
 
 // NewFakeTrillianLogClient returns a fake trillian log client.
-func NewFakeTrillianLogClient() trillian.TrillianLogClient {
-	return &logServer{}
+func NewFakeTrillianLogClient() *LogServer {
+	return &LogServer{}
 }
 
-func (l *logServer) QueueLeaf(ctx context.Context, in *trillian.QueueLeafRequest, opts ...grpc.CallOption) (*trillian.QueueLeafResponse, error) {
+// QueueLeaf increments the size of the tree.
+func (l *LogServer) QueueLeaf(ctx context.Context, in *trillian.QueueLeafRequest, opts ...grpc.CallOption) (*trillian.QueueLeafResponse, error) {
 	l.treeSize++
 	return nil, nil
 }
 
-func (l *logServer) QueueLeaves(ctx context.Context, in *trillian.QueueLeavesRequest, opts ...grpc.CallOption) (*trillian.QueueLeavesResponse, error) {
+// QueueLeaves is not implemented.
+func (l *LogServer) QueueLeaves(ctx context.Context, in *trillian.QueueLeavesRequest, opts ...grpc.CallOption) (*trillian.QueueLeavesResponse, error) {
 	panic("not implemented")
 }
 
-func (l *logServer) GetInclusionProof(ctx context.Context, in *trillian.GetInclusionProofRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofResponse, error) {
+// GetInclusionProof returns an empty proof.
+func (l *LogServer) GetInclusionProof(ctx context.Context, in *trillian.GetInclusionProofRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofResponse, error) {
 	return &trillian.GetInclusionProofResponse{}, nil
 }
 
-func (l *logServer) GetInclusionProofByHash(ctx context.Context, in *trillian.GetInclusionProofByHashRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofByHashResponse, error) {
+// GetInclusionProofByHash is not implemented.
+func (l *LogServer) GetInclusionProofByHash(ctx context.Context, in *trillian.GetInclusionProofByHashRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofByHashResponse, error) {
 	panic("not implemented")
 }
 
-func (l *logServer) GetConsistencyProof(ctx context.Context, in *trillian.GetConsistencyProofRequest, opts ...grpc.CallOption) (*trillian.GetConsistencyProofResponse, error) {
+// GetConsistencyProof returns an empty proof.
+func (l *LogServer) GetConsistencyProof(ctx context.Context, in *trillian.GetConsistencyProofRequest, opts ...grpc.CallOption) (*trillian.GetConsistencyProofResponse, error) {
 	return &trillian.GetConsistencyProofResponse{}, nil
 }
 
-func (l *logServer) GetLatestSignedLogRoot(ctx context.Context, in *trillian.GetLatestSignedLogRootRequest, opts ...grpc.CallOption) (*trillian.GetLatestSignedLogRootResponse, error) {
+// GetLatestSignedLogRoot returns the current tree size.
+func (l *LogServer) GetLatestSignedLogRoot(ctx context.Context, in *trillian.GetLatestSignedLogRootRequest, opts ...grpc.CallOption) (*trillian.GetLatestSignedLogRootResponse, error) {
 	return &trillian.GetLatestSignedLogRootResponse{
 		SignedLogRoot: &trillian.SignedLogRoot{
 			TreeSize: l.treeSize,
@@ -59,18 +66,22 @@ func (l *logServer) GetLatestSignedLogRoot(ctx context.Context, in *trillian.Get
 	}, nil
 }
 
-func (l *logServer) GetSequencedLeafCount(ctx context.Context, in *trillian.GetSequencedLeafCountRequest, opts ...grpc.CallOption) (*trillian.GetSequencedLeafCountResponse, error) {
+// GetSequencedLeafCount is not implemented.
+func (l *LogServer) GetSequencedLeafCount(ctx context.Context, in *trillian.GetSequencedLeafCountRequest, opts ...grpc.CallOption) (*trillian.GetSequencedLeafCountResponse, error) {
 	panic("not implemented")
 }
 
-func (l *logServer) GetLeavesByIndex(ctx context.Context, in *trillian.GetLeavesByIndexRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByIndexResponse, error) {
+// GetLeavesByIndex is not implemented.
+func (l *LogServer) GetLeavesByIndex(ctx context.Context, in *trillian.GetLeavesByIndexRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByIndexResponse, error) {
 	panic("not implemented")
 }
 
-func (l *logServer) GetLeavesByHash(ctx context.Context, in *trillian.GetLeavesByHashRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByHashResponse, error) {
+// GetLeavesByHash is not implemented.
+func (l *LogServer) GetLeavesByHash(ctx context.Context, in *trillian.GetLeavesByHashRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByHashResponse, error) {
 	panic("not implemented")
 }
 
-func (l *logServer) GetEntryAndProof(ctx context.Context, in *trillian.GetEntryAndProofRequest, opts ...grpc.CallOption) (*trillian.GetEntryAndProofResponse, error) {
+// GetEntryAndProof is not implemented.
+func (l *LogServer) GetEntryAndProof(ctx context.Context, in *trillian.GetEntryAndProofRequest, opts ...grpc.CallOption) (*trillian.GetEntryAndProofResponse, error) {
 	panic("not implemented")
 }

--- a/core/fake/trillian_log_client.go
+++ b/core/fake/trillian_log_client.go
@@ -17,8 +17,9 @@ package fake
 import (
 	"context"
 
-	"github.com/google/trillian"
 	"google.golang.org/grpc"
+
+	tpb "github.com/google/trillian"
 )
 
 // LogServer only stores tree size.
@@ -26,62 +27,62 @@ type LogServer struct {
 	treeSize int64
 }
 
-// NewFakeTrillianLogClient returns a fake trillian log client.
-func NewFakeTrillianLogClient() *LogServer {
+// NewTrillianLogClient returns a fake trillian log client.
+func NewTrillianLogClient() *LogServer {
 	return &LogServer{}
 }
 
 // QueueLeaf increments the size of the tree.
-func (l *LogServer) QueueLeaf(ctx context.Context, in *trillian.QueueLeafRequest, opts ...grpc.CallOption) (*trillian.QueueLeafResponse, error) {
+func (l *LogServer) QueueLeaf(ctx context.Context, in *tpb.QueueLeafRequest, opts ...grpc.CallOption) (*tpb.QueueLeafResponse, error) {
 	l.treeSize++
 	return nil, nil
 }
 
 // QueueLeaves is not implemented.
-func (l *LogServer) QueueLeaves(ctx context.Context, in *trillian.QueueLeavesRequest, opts ...grpc.CallOption) (*trillian.QueueLeavesResponse, error) {
+func (l *LogServer) QueueLeaves(ctx context.Context, in *tpb.QueueLeavesRequest, opts ...grpc.CallOption) (*tpb.QueueLeavesResponse, error) {
 	panic("not implemented")
 }
 
 // GetInclusionProof returns an empty proof.
-func (l *LogServer) GetInclusionProof(ctx context.Context, in *trillian.GetInclusionProofRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofResponse, error) {
-	return &trillian.GetInclusionProofResponse{}, nil
+func (l *LogServer) GetInclusionProof(ctx context.Context, in *tpb.GetInclusionProofRequest, opts ...grpc.CallOption) (*tpb.GetInclusionProofResponse, error) {
+	return &tpb.GetInclusionProofResponse{}, nil
 }
 
 // GetInclusionProofByHash is not implemented.
-func (l *LogServer) GetInclusionProofByHash(ctx context.Context, in *trillian.GetInclusionProofByHashRequest, opts ...grpc.CallOption) (*trillian.GetInclusionProofByHashResponse, error) {
+func (l *LogServer) GetInclusionProofByHash(ctx context.Context, in *tpb.GetInclusionProofByHashRequest, opts ...grpc.CallOption) (*tpb.GetInclusionProofByHashResponse, error) {
 	panic("not implemented")
 }
 
 // GetConsistencyProof returns an empty proof.
-func (l *LogServer) GetConsistencyProof(ctx context.Context, in *trillian.GetConsistencyProofRequest, opts ...grpc.CallOption) (*trillian.GetConsistencyProofResponse, error) {
-	return &trillian.GetConsistencyProofResponse{}, nil
+func (l *LogServer) GetConsistencyProof(ctx context.Context, in *tpb.GetConsistencyProofRequest, opts ...grpc.CallOption) (*tpb.GetConsistencyProofResponse, error) {
+	return &tpb.GetConsistencyProofResponse{}, nil
 }
 
 // GetLatestSignedLogRoot returns the current tree size.
-func (l *LogServer) GetLatestSignedLogRoot(ctx context.Context, in *trillian.GetLatestSignedLogRootRequest, opts ...grpc.CallOption) (*trillian.GetLatestSignedLogRootResponse, error) {
-	return &trillian.GetLatestSignedLogRootResponse{
-		SignedLogRoot: &trillian.SignedLogRoot{
+func (l *LogServer) GetLatestSignedLogRoot(ctx context.Context, in *tpb.GetLatestSignedLogRootRequest, opts ...grpc.CallOption) (*tpb.GetLatestSignedLogRootResponse, error) {
+	return &tpb.GetLatestSignedLogRootResponse{
+		SignedLogRoot: &tpb.SignedLogRoot{
 			TreeSize: l.treeSize,
 		},
 	}, nil
 }
 
 // GetSequencedLeafCount is not implemented.
-func (l *LogServer) GetSequencedLeafCount(ctx context.Context, in *trillian.GetSequencedLeafCountRequest, opts ...grpc.CallOption) (*trillian.GetSequencedLeafCountResponse, error) {
+func (l *LogServer) GetSequencedLeafCount(ctx context.Context, in *tpb.GetSequencedLeafCountRequest, opts ...grpc.CallOption) (*tpb.GetSequencedLeafCountResponse, error) {
 	panic("not implemented")
 }
 
 // GetLeavesByIndex is not implemented.
-func (l *LogServer) GetLeavesByIndex(ctx context.Context, in *trillian.GetLeavesByIndexRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByIndexResponse, error) {
+func (l *LogServer) GetLeavesByIndex(ctx context.Context, in *tpb.GetLeavesByIndexRequest, opts ...grpc.CallOption) (*tpb.GetLeavesByIndexResponse, error) {
 	panic("not implemented")
 }
 
 // GetLeavesByHash is not implemented.
-func (l *LogServer) GetLeavesByHash(ctx context.Context, in *trillian.GetLeavesByHashRequest, opts ...grpc.CallOption) (*trillian.GetLeavesByHashResponse, error) {
+func (l *LogServer) GetLeavesByHash(ctx context.Context, in *tpb.GetLeavesByHashRequest, opts ...grpc.CallOption) (*tpb.GetLeavesByHashResponse, error) {
 	panic("not implemented")
 }
 
 // GetEntryAndProof is not implemented.
-func (l *LogServer) GetEntryAndProof(ctx context.Context, in *trillian.GetEntryAndProofRequest, opts ...grpc.CallOption) (*trillian.GetEntryAndProofResponse, error) {
+func (l *LogServer) GetEntryAndProof(ctx context.Context, in *tpb.GetEntryAndProofRequest, opts ...grpc.CallOption) (*tpb.GetEntryAndProofResponse, error) {
 	panic("not implemented")
 }

--- a/core/mutationserver/mutation_test.go
+++ b/core/mutationserver/mutation_test.go
@@ -123,7 +123,7 @@ func TestGetMutations(t *testing.T) {
 		{"invalid page token", 1, "some_token", 0, nil, "", false},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
-			srv := New(fakeAdmin, fake.NewFakeTrillianLogClient(), fakeMap, fakeMutations, &fakeFactory{})
+			srv := New(fakeAdmin, fake.NewTrillianLogClient(), fakeMap, fakeMutations, &fakeFactory{})
 			resp, err := srv.GetMutations(ctx, &pb.GetMutationsRequest{
 				DomainId:  domainID,
 				Epoch:     tc.epoch,
@@ -175,7 +175,7 @@ func TestLowestSequenceNumber(t *testing.T) {
 		{"some_token", 0, 0, false},
 		{"", 1, 6, true},
 	} {
-		srv := New(fakeAdmin, fake.NewFakeTrillianLogClient(), fakeMap, fakeMutations, &fakeFactory{})
+		srv := New(fakeAdmin, fake.NewTrillianLogClient(), fakeMap, fakeMutations, &fakeFactory{})
 		seq, err := srv.lowestSequenceNumber(ctx, mapID, tc.token, tc.epoch)
 		if got, want := err == nil, tc.success; got != want {
 			t.Errorf("lowestSequenceNumber(%v, %v): err=%v, want %v", tc.token, tc.epoch, got, want)

--- a/core/mutationserver/mutation_test.go
+++ b/core/mutationserver/mutation_test.go
@@ -57,12 +57,12 @@ func updates(t *testing.T, start, end int) []*pb.EntryUpdate {
 	return kvs
 }
 
-func prepare(ctx context.Context, t *testing.T, mapID int64, mutations mutator.MutationStorage, tmap tpb.TrillianMapClient) {
+func prepare(ctx context.Context, t *testing.T, mapID int64, mutations mutator.MutationStorage, tmap *fake.MapServer) {
 	createEpoch(ctx, t, mapID, mutations, tmap, 1, 1, 6)
 	createEpoch(ctx, t, mapID, mutations, tmap, 2, 7, 10)
 }
 
-func createEpoch(ctx context.Context, t *testing.T, mapID int64, mutations mutator.MutationStorage, tmap tpb.TrillianMapClient, epoch int64, start, end int) {
+func createEpoch(ctx context.Context, t *testing.T, mapID int64, mutations mutator.MutationStorage, tmap *fake.MapServer, epoch int64, start, end int) {
 	kvs := updates(t, start, end)
 	for _, kv := range kvs {
 		if _, err := mutations.Write(nil, mapID, kv); err != nil {

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -148,7 +148,7 @@ func NewEnv(t *testing.T) *Env {
 	mutator := entry.New()
 	auth := authentication.NewFake()
 	authz := authorization.New()
-	tlog := fake.NewFakeTrillianLogClient()
+	tlog := fake.NewTrillianLogClient()
 
 	factory := transaction.NewFactory(sqldb)
 	server := keyserver.New(adminStorage, tlog, mapEnv.MapClient, mapEnv.AdminClient,


### PR DESCRIPTION
If the function signatures change, we get a compile time error.
We would, instead, like the error to occur at the point where
the object is used. At this point, an alternate object can be used
if nessesary.