### PR TITLE
Use specific interface 

### DIFF
--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -252,7 +252,7 @@ func GetClient(useClientSecret bool) (*grpcc.Client, error) {
 		return nil, fmt.Errorf("Error reading config: %v", err)
 	}
 
-	return grpcc.NewFromConfig(cc, config)
+	return grpcc.NewFromConfig(spb.NewKeyTransparencyServiceClient(cc), config)
 }
 
 // config selects a source for and returns the client configuration.

--- a/core/client/gobindclient/client.go
+++ b/core/client/gobindclient/client.go
@@ -110,7 +110,7 @@ func AddKtServer(ktURL string, insecureTLS bool, ktTLSCertPEM []byte, domainInfo
 		}
 	}
 
-	client, err := grpcc.NewFromConfig(cc, config)
+	client, err := grpcc.NewFromConfig(ktClient, config)
 	if err != nil {
 		return fmt.Errorf("Error adding the KtServer: %v", err)
 	}

--- a/core/client/grpcc/grpc_client.go
+++ b/core/client/grpcc/grpc_client.go
@@ -88,7 +88,7 @@ type Client struct {
 }
 
 // NewFromConfig creates a new client from a config
-func NewFromConfig(cc *grpc.ClientConn, config *pb.GetDomainInfoResponse) (*Client, error) {
+func NewFromConfig(ktClient gpb.KeyTransparencyServiceClient, config *pb.GetDomainInfoResponse) (*Client, error) {
 	// Log Hasher.
 	logHasher, err := hashers.NewLogHasher(config.GetLog().GetHashStrategy())
 	if err != nil {
@@ -121,18 +121,18 @@ func NewFromConfig(cc *grpc.ClientConn, config *pb.GetDomainInfoResponse) (*Clie
 
 	// TODO(gbelvin): set retry delay.
 	logVerifier := client.NewLogVerifier(logHasher, logPubKey)
-	return New(cc, config.DomainId, vrfPubKey, mapPubKey, mapHasher, logVerifier), nil
+	return New(ktClient, config.DomainId, vrfPubKey, mapPubKey, mapHasher, logVerifier), nil
 }
 
 // New creates a new client.
-func New(cc *grpc.ClientConn,
+func New(ktClient gpb.KeyTransparencyServiceClient,
 	domainID string,
 	vrf vrf.PublicKey,
 	mapPubKey crypto.PublicKey,
 	mapHasher hashers.MapHasher,
 	logVerifier client.LogVerifier) *Client {
 	return &Client{
-		cli:        gpb.NewKeyTransparencyServiceClient(cc),
+		cli:        ktClient,
 		domainID:   domainID,
 		kt:         kt.New(vrf, mapHasher, mapPubKey, logVerifier),
 		mutator:    entry.New(),

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -169,7 +169,8 @@ func NewEnv(t *testing.T) *Env {
 	if err != nil {
 		t.Fatalf("Dial(%v) = %v", addr, err)
 	}
-	client := grpcc.New(cc, domainID, vrfPub, mapPubKey, coniks.Default, fake.NewFakeTrillianLogVerifier())
+	ktClient := gpb.NewKeyTransparencyServiceClient(cc)
+	client := grpcc.New(ktClient, domainID, vrfPub, mapPubKey, coniks.Default, fake.NewFakeTrillianLogVerifier())
 	client.RetryCount = 0
 
 	// Mimic first sequence event
@@ -189,7 +190,7 @@ func NewEnv(t *testing.T) *Env {
 		Signer:     seq,
 		db:         sqldb,
 		Factory:    factory,
-		Cli:        gpb.NewKeyTransparencyServiceClient(cc),
+		Cli:        ktClient,
 		Domain:     resp.Domain,
 	}
 }


### PR DESCRIPTION
We were using a more general interface (grpc.Client) to the Key Transparency client than needed.  