### PR TITLE
Cleaner adminstorage.Write function

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -194,11 +194,15 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 		return nil, fmt.Errorf("Duration(%v): %v", in.MaxInterval, err)
 	}
 
-	if err := s.storage.Write(ctx,
-		in.GetDomainId(),
-		mapTree.TreeId, logTree.TreeId,
-		vrfPublicPB.Der, wrapped,
-		minInterval, maxInterval); err != nil {
+	if err := s.storage.Write(ctx, &adminstorage.Domain{
+		Domain:      in.GetDomainId(),
+		MapID:       mapTree.TreeId,
+		LogID:       logTree.TreeId,
+		VRF:         vrfPublicPB,
+		VRFPriv:     wrapped,
+		MinInterval: minInterval,
+		MaxInterval: maxInterval,
+	}); err != nil {
 		return nil, fmt.Errorf("adminstorage.Write(): %v", err)
 	}
 	return &pb.Domain{

--- a/core/adminstorage/admin_storage.go
+++ b/core/adminstorage/admin_storage.go
@@ -41,12 +41,7 @@ type Storage interface {
 	// List returns the full list of domains.
 	List(ctx context.Context, deleted bool) ([]*Domain, error)
 	// Write stores a new instance to storage.
-	Write(ctx context.Context,
-		domainID string,
-		mapID, logID int64,
-		vrfPublicDER []byte, wrappedVRF proto.Message,
-		minInterval, maxInterval time.Duration,
-	) error
+	Write(ctx context.Context, d *Domain) error
 	// Read a configuration from storage.
 	Read(ctx context.Context, domainID string, showDeleted bool) (*Domain, error)
 	// Delete and undelete.

--- a/core/fake/admin_storage.go
+++ b/core/fake/admin_storage.go
@@ -17,11 +17,8 @@ package fake
 import (
 	"context"
 	"fmt"
-	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/keytransparency/core/adminstorage"
-	"github.com/google/trillian/crypto/keyspb"
 )
 
 // AdminStorage implements adminstorage.Storage
@@ -46,22 +43,8 @@ func (a *AdminStorage) List(ctx context.Context, deleted bool) ([]*adminstorage.
 }
 
 // Write adds a new domain.
-func (a *AdminStorage) Write(ctx context.Context,
-	domainID string,
-	mapID int64, logID int64,
-	vrfPublicDER []byte, wrappedVRF proto.Message,
-	minInterval, maxInterval time.Duration,
-) error {
-	a.domains[domainID] = &adminstorage.Domain{
-		Domain:      domainID,
-		MapID:       mapID,
-		LogID:       logID,
-		VRF:         &keyspb.PublicKey{Der: vrfPublicDER},
-		VRFPriv:     wrappedVRF,
-		MinInterval: minInterval,
-		MaxInterval: maxInterval,
-		Deleted:     false,
-	}
+func (a *AdminStorage) Write(ctx context.Context, d *adminstorage.Domain) error {
+	a.domains[d.Domain] = d
 	return nil
 }
 

--- a/core/keyserver/epochs_test.go
+++ b/core/keyserver/epochs_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/keytransparency/core/adminstorage"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/internal"
 	"github.com/google/keytransparency/core/mutator"
@@ -98,7 +99,12 @@ func TestGetMutations(t *testing.T) {
 	fakeMap := fake.NewTrillianMapClient()
 	fakeLog := fake.NewTrillianLogClient()
 	fakeTx := &fakeFactory{}
-	if err := fakeAdmin.Write(ctx, domainID, mapID, 0, nil, nil, 1*time.Second, 5*time.Second); err != nil {
+	if err := fakeAdmin.Write(ctx, &adminstorage.Domain{
+		Domain:      domainID,
+		MapID:       mapID,
+		MinInterval: 1 * time.Second,
+		MaxInterval: 5 * time.Second,
+	}); err != nil {
 		t.Fatalf("admin.Write(): %v", err)
 	}
 	prepare(ctx, t, mapID, fakeMutations, fakeMap)

--- a/impl/sql/adminstorage/admin_storage.go
+++ b/impl/sql/adminstorage/admin_storage.go
@@ -126,13 +126,9 @@ func (s *storage) List(ctx context.Context, showDeleted bool) ([]*adminstorage.D
 	return ret, nil
 }
 
-func (s *storage) Write(ctx context.Context,
-	domainID string,
-	mapID int64, logID int64,
-	vrfPublicDER []byte, wrappedVRF proto.Message,
-	minInterval, maxInterval time.Duration) error {
+func (s *storage) Write(ctx context.Context, d *adminstorage.Domain) error {
 	// Prepare data.
-	anyPB, err := ptypes.MarshalAny(wrappedVRF)
+	anyPB, err := ptypes.MarshalAny(d.VRFPriv)
 	if err != nil {
 		return err
 	}
@@ -147,10 +143,10 @@ func (s *storage) Write(ctx context.Context,
 	}
 	defer writeStmt.Close()
 	_, err = writeStmt.ExecContext(ctx,
-		domainID,
-		mapID, logID,
-		vrfPublicDER, anyData,
-		minInterval.Nanoseconds(), maxInterval.Nanoseconds(),
+		d.Domain,
+		d.MapID, d.LogID,
+		d.VRF.Der, anyData,
+		d.MinInterval.Nanoseconds(), d.MaxInterval.Nanoseconds(),
 		false)
 	return err
 }

--- a/impl/sql/adminstorage/admin_storage_test.go
+++ b/impl/sql/adminstorage/admin_storage_test.go
@@ -66,11 +66,7 @@ func TestList(t *testing.T) {
 		},
 	} {
 		for _, d := range tc.domains {
-			if err := admin.Write(ctx,
-				d.Domain,
-				d.MapID, d.LogID,
-				d.VRF.Der, d.VRFPriv,
-				d.MinInterval, d.MaxInterval); err != nil {
+			if err := admin.Write(ctx, d); err != nil {
 				t.Errorf("Write(): %v", err)
 				continue
 			}
@@ -186,11 +182,7 @@ func TestWriteReadDelete(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			if tc.write {
-				err := admin.Write(ctx,
-					tc.d.Domain,
-					tc.d.MapID, tc.d.LogID,
-					tc.d.VRF.Der, tc.d.VRFPriv,
-					tc.d.MinInterval, tc.d.MaxInterval)
+				err := admin.Write(ctx, &tc.d)
 				if got, want := err != nil, tc.wantWriteErr; got != want {
 					t.Errorf("Write(): %v, want err: %v", err, want)
 					return


### PR DESCRIPTION
Use the adminstorage.Domain object to write directly rather than
giving each piece of the struct as a positional parameter. This makes
the function signature simpler, and eases code maintinance.