### PR TITLE
Remove transactions from mutation api

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/keytransparency/impl/sql/domain"
 	"github.com/google/keytransparency/impl/sql/engine"
 	"github.com/google/keytransparency/impl/sql/mutationstorage"
-	"github.com/google/keytransparency/impl/transaction"
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
@@ -78,7 +77,6 @@ func main() {
 	// Database tables
 	sqldb := openDB()
 	defer sqldb.Close()
-	factory := transaction.NewFactory(sqldb)
 
 	mutations, err := mutationstorage.New(sqldb)
 	if err != nil {
@@ -90,7 +88,7 @@ func main() {
 	}
 
 	// Create servers
-	signer := sequencer.New(domainStorage, tmap, tlog, entry.New(), mutations, factory)
+	signer := sequencer.New(domainStorage, tmap, tlog, entry.New(), mutations)
 	keygen := func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 		return der.NewProtoFromSpec(spec)
 	}

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/keytransparency/impl/sql/domain"
 	"github.com/google/keytransparency/impl/sql/engine"
 	"github.com/google/keytransparency/impl/sql/mutationstorage"
-	"github.com/google/keytransparency/impl/transaction"
 
 	"github.com/golang/glog"
 	"github.com/google/trillian"
@@ -72,7 +71,6 @@ func main() {
 	// Open Resources.
 	sqldb := openDB()
 	defer sqldb.Close()
-	factory := transaction.NewFactory(sqldb)
 
 	creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
 	if err != nil {
@@ -122,7 +120,7 @@ func main() {
 
 	// Create gRPC server.
 	ksvr := keyserver.New(admin, tlog, tmap, tadmin,
-		mutator, auth, authz, factory, mutations)
+		mutator, auth, authz, mutations)
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),

--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -15,7 +15,7 @@
 package fake
 
 import (
-	"github.com/google/keytransparency/core/transaction"
+	"context"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
 )
@@ -33,7 +33,7 @@ func NewMutationStorage() *MutationStorage {
 }
 
 // ReadRange returns the list of mutations
-func (m *MutationStorage) ReadRange(txn transaction.Txn, mapID int64, startSequence uint64, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error) {
+func (m *MutationStorage) ReadRange(ctx context.Context, mapID int64, startSequence uint64, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error) {
 	if startSequence > uint64(len(m.mtns[mapID])) {
 		panic("startSequence > len(m.mtns[mapID])")
 	}
@@ -48,12 +48,12 @@ func (m *MutationStorage) ReadRange(txn transaction.Txn, mapID int64, startSeque
 }
 
 // ReadAll is unimplemented
-func (m *MutationStorage) ReadAll(txn transaction.Txn, mapID int64, startSequence uint64) (uint64, []*pb.EntryUpdate, error) {
+func (m *MutationStorage) ReadAll(ctx context.Context, mapID int64, startSequence uint64) (uint64, []*pb.EntryUpdate, error) {
 	return 0, nil, nil
 }
 
 // Write stores a mutation
-func (m *MutationStorage) Write(txn transaction.Txn, mapID int64, mutation *pb.EntryUpdate) (uint64, error) {
+func (m *MutationStorage) Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (uint64, error) {
 	m.mtns[mapID] = append(m.mtns[mapID], mutation)
 	return uint64(len(m.mtns[mapID])), nil
 }

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -18,11 +18,10 @@
 package mutator
 
 import (
+	"context"
 	"errors"
 
 	"github.com/golang/protobuf/proto"
-
-	"github.com/google/keytransparency/core/transaction"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
 )
@@ -64,12 +63,12 @@ type MutationStorage interface {
 	// count. Note that startSequence is not included in the result.
 	// ReadRange stops when endSequence or count is reached, whichever comes
 	// first. ReadRange also returns the maximum sequence number read.
-	ReadRange(txn transaction.Txn, mapID int64, startSequence, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error)
+	ReadRange(ctx context.Context, mapID int64, startSequence, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error)
 	// ReadAll reads all mutations starting from the given sequence number.
 	// Note that startSequence is not included in the result. ReadAll also
 	// returns the maximum sequence number read.
-	ReadAll(txn transaction.Txn, mapID int64, startSequence uint64) (uint64, []*pb.EntryUpdate, error)
+	ReadAll(ctx context.Context, mapID int64, startSequence uint64) (uint64, []*pb.EntryUpdate, error)
 	// Write saves the mutation in the database. Write returns the sequence
 	// number that is written.
-	Write(txn transaction.Txn, mapID int64, mutation *pb.EntryUpdate) (uint64, error)
+	Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (uint64, error)
 }

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -148,14 +148,13 @@ func NewEnv(t *testing.T) *Env {
 	authz := authorization.New()
 	tlog := fake.NewTrillianLogClient()
 
-	factory := transaction.NewFactory(sqldb)
 	server := keyserver.New(domainStorage, tlog, mapEnv.MapClient, mapEnv.AdminClient,
-		mutator, auth, authz, factory, mutations)
+		mutator, auth, authz, mutations)
 	gsvr := grpc.NewServer()
 	pb.RegisterKeyTransparencyServiceServer(gsvr, server)
 
 	// Sequencer
-	seq := sequencer.New(domainStorage, mapEnv.MapClient, tlog, mutator, mutations, factory)
+	seq := sequencer.New(domainStorage, mapEnv.MapClient, tlog, mutator, mutations)
 
 	addr, lis := Listen(t)
 	go gsvr.Serve(lis)
@@ -185,7 +184,6 @@ func NewEnv(t *testing.T) *Env {
 		Client:     client,
 		Signer:     seq,
 		db:         sqldb,
-		Factory:    factory,
 		Cli:        ktClient,
 		Domain:     domain,
 	}


### PR DESCRIPTION
Transactions are not currently serving any purpose.
There are no sequences of database calls that need to be coordinated
atomically.

The transaction abstraction was orginally created to support atomically
acking an item out of a queue and saving it.
1. The queue and the database can often be using different technologies
that make a single transaction between them not possible.
2. The specifics of the queue, databases, and other subsystems are
implementation details that should be handeled in impl/ rather than
creeping into the apis themselves.