### PR TITLE
 Set a maximum batch size for sequencing

### DIFF
--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -32,28 +32,28 @@ func NewMutationStorage() *MutationStorage {
 	}
 }
 
-// ReadRange returns the list of mutations
-func (m *MutationStorage) ReadRange(ctx context.Context, mapID int64, startSequence uint64, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error) {
-	if startSequence > uint64(len(m.mtns[mapID])) {
-		panic("startSequence > len(m.mtns[mapID])")
+// ReadPage paginates through the list of mutations
+func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.EntryUpdate, error) {
+	if start > int64(len(m.mtns[mapID])) {
+		panic("start > len(m.mtns[mapID])")
 	}
-	// Adjust endSequence.
-	if endSequence-startSequence > uint64(count) {
-		endSequence = startSequence + uint64(count)
+	// Adjust end.
+	if end-start > int64(pageSize) {
+		end = start + int64(pageSize)
 	}
-	if endSequence > uint64(len(m.mtns[mapID])) {
-		endSequence = uint64(len(m.mtns[mapID]))
+	if end > int64(len(m.mtns[mapID])) {
+		end = int64(len(m.mtns[mapID]))
 	}
-	return endSequence, m.mtns[mapID][startSequence:endSequence], nil
+	return end, m.mtns[mapID][start:end], nil
 }
 
-// ReadAll is unimplemented
-func (m *MutationStorage) ReadAll(ctx context.Context, mapID int64, start uint64, count int) (uint64, []*pb.EntryUpdate, error) {
+// ReadBatch is unimplemented
+func (m *MutationStorage) ReadBatch(context.Context, int64, int64, int32) (int64, []*pb.EntryUpdate, error) {
 	return 0, nil, nil
 }
 
 // Write stores a mutation
-func (m *MutationStorage) Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (uint64, error) {
+func (m *MutationStorage) Write(_ context.Context, mapID int64, mutation *pb.EntryUpdate) (int64, error) {
 	m.mtns[mapID] = append(m.mtns[mapID], mutation)
-	return uint64(len(m.mtns[mapID])), nil
+	return int64(len(m.mtns[mapID])), nil
 }

--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -48,7 +48,7 @@ func (m *MutationStorage) ReadRange(ctx context.Context, mapID int64, startSeque
 }
 
 // ReadAll is unimplemented
-func (m *MutationStorage) ReadAll(ctx context.Context, mapID int64, startSequence uint64) (uint64, []*pb.EntryUpdate, error) {
+func (m *MutationStorage) ReadAll(ctx context.Context, mapID int64, start uint64, count int) (uint64, []*pb.EntryUpdate, error) {
 	return 0, nil, nil
 }
 

--- a/core/keyserver/epochs_test.go
+++ b/core/keyserver/epochs_test.go
@@ -172,7 +172,7 @@ func TestLowestSequenceNumber(t *testing.T) {
 	for _, tc := range []struct {
 		token     string
 		epoch     int64
-		lowestSeq uint64
+		lowestSeq int64
 		success   bool
 	}{
 		{"", 0, 0, true},

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -67,7 +67,8 @@ type MutationStorage interface {
 	// ReadAll reads all mutations starting from the given sequence number.
 	// Note that startSequence is not included in the result. ReadAll also
 	// returns the maximum sequence number read.
-	ReadAll(ctx context.Context, mapID int64, startSequence uint64) (uint64, []*pb.EntryUpdate, error)
+	// ReadAll will not return more than count entries.
+	ReadAll(ctx context.Context, mapID int64, startSequence uint64, count int) (uint64, []*pb.EntryUpdate, error)
 	// Write saves the mutation in the database. Write returns the sequence
 	// number that is written.
 	Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (uint64, error)

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -58,18 +58,15 @@ type Mutator interface {
 
 // MutationStorage reads and writes mutations to the database.
 type MutationStorage interface {
-	// ReadRange reads all mutations for a specific given mapID and sequence
-	// range. The range is identified by a starting sequence number and a
-	// count. Note that startSequence is not included in the result.
-	// ReadRange stops when endSequence or count is reached, whichever comes
-	// first. ReadRange also returns the maximum sequence number read.
-	ReadRange(ctx context.Context, mapID int64, startSequence, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error)
-	// ReadAll reads all mutations starting from the given sequence number.
-	// Note that startSequence is not included in the result. ReadAll also
-	// returns the maximum sequence number read.
-	// ReadAll will not return more than count entries.
-	ReadAll(ctx context.Context, mapID int64, startSequence uint64, count int) (uint64, []*pb.EntryUpdate, error)
+	// ReadPage returns mutations in the interval (start, end] for mapID.
+	// pageSize specifies the maximum number of items to return.
+	// Returns the maximum sequence number returned.
+	ReadPage(ctx context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.EntryUpdate, error)
+	// ReadBatch returns mutations in the interval (start, ∞] for mapID.
+	// ReadBatch will not return more than batchSize entries.
+	// Returns the maximum sequence number returned.
+	ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*pb.EntryUpdate, error)
 	// Write saves the mutation in the database. Write returns the sequence
 	// number that is written.
-	Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (uint64, error)
+	Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (int64, error)
 }

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -64,13 +64,13 @@ func New(db *sql.DB) (mutator.MutationStorage, error) {
 // startSequence is not included in the result. ReadRange stops when endSequence
 // or count is reached, whichever comes first. ReadRange also returns the maximum
 // sequence number read.
-func (m *mutations) ReadRange(ctx context.Context, mapID int64, startSequence, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error) {
+func (m *mutations) ReadPage(ctx context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.EntryUpdate, error) {
 	readStmt, err := m.db.Prepare(readRangeExpr)
 	if err != nil {
 		return 0, nil, err
 	}
 	defer readStmt.Close()
-	rows, err := readStmt.QueryContext(ctx, mapID, startSequence, endSequence, count)
+	rows, err := readStmt.QueryContext(ctx, mapID, start, end, pageSize)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -81,13 +81,13 @@ func (m *mutations) ReadRange(ctx context.Context, mapID int64, startSequence, e
 // ReadAll reads all mutations starting from the given sequence number. Note that
 // startSequence is not included in the result. ReadAll also returns the maximum
 // sequence number read.
-func (m *mutations) ReadAll(ctx context.Context, mapID int64, startSequence uint64, count int) (uint64, []*pb.EntryUpdate, error) {
+func (m *mutations) ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*pb.EntryUpdate, error) {
 	readStmt, err := m.db.Prepare(readAllExpr)
 	if err != nil {
 		return 0, nil, err
 	}
 	defer readStmt.Close()
-	rows, err := readStmt.QueryContext(ctx, mapID, startSequence, count)
+	rows, err := readStmt.QueryContext(ctx, mapID, start, batchSize)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -95,11 +95,11 @@ func (m *mutations) ReadAll(ctx context.Context, mapID int64, startSequence uint
 	return readRows(rows)
 }
 
-func readRows(rows *sql.Rows) (uint64, []*pb.EntryUpdate, error) {
+func readRows(rows *sql.Rows) (int64, []*pb.EntryUpdate, error) {
 	results := make([]*pb.EntryUpdate, 0)
-	maxSequence := uint64(0)
+	maxSequence := int64(0)
 	for rows.Next() {
-		var sequence uint64
+		var sequence int64
 		var mData []byte
 		if err := rows.Scan(&sequence, &mData); err != nil {
 			return 0, nil, err
@@ -121,7 +121,7 @@ func readRows(rows *sql.Rows) (uint64, []*pb.EntryUpdate, error) {
 
 // Write saves the mutation in the database. Write returns the auto-inserted
 // sequence number.
-func (m *mutations) Write(ctx context.Context, mapID int64, update *pb.EntryUpdate) (uint64, error) {
+func (m *mutations) Write(ctx context.Context, mapID int64, update *pb.EntryUpdate) (int64, error) {
 	index := update.GetMutation().GetIndex()
 	mData, err := proto.Marshal(update)
 	if err != nil {
@@ -141,7 +141,7 @@ func (m *mutations) Write(ctx context.Context, mapID int64, update *pb.EntryUpda
 	if err != nil {
 		return 0, err
 	}
-	return uint64(sequence), nil
+	return sequence, nil
 }
 
 // Create creates new database tables.

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -39,7 +39,7 @@ const (
 	readAllExpr = `
  	SELECT Sequence, Mutation FROM Mutations
  	WHERE MapID = ? AND Sequence > ?
-	ORDER BY Sequence ASC;`
+	ORDER BY Sequence ASC LIMIT ?;`
 )
 
 type mutations struct {
@@ -81,13 +81,13 @@ func (m *mutations) ReadRange(ctx context.Context, mapID int64, startSequence, e
 // ReadAll reads all mutations starting from the given sequence number. Note that
 // startSequence is not included in the result. ReadAll also returns the maximum
 // sequence number read.
-func (m *mutations) ReadAll(ctx context.Context, mapID int64, startSequence uint64) (uint64, []*pb.EntryUpdate, error) {
+func (m *mutations) ReadAll(ctx context.Context, mapID int64, startSequence uint64, count int) (uint64, []*pb.EntryUpdate, error) {
 	readStmt, err := m.db.Prepare(readAllExpr)
 	if err != nil {
 		return 0, nil, err
 	}
 	defer readStmt.Close()
-	rows, err := readStmt.QueryContext(ctx, mapID, startSequence)
+	rows, err := readStmt.QueryContext(ctx, mapID, startSequence, count)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/impl/sql/mutationstorage/mutations_test.go
+++ b/impl/sql/mutationstorage/mutations_test.go
@@ -79,22 +79,6 @@ func write(ctx context.Context, m mutator.MutationStorage, mutation *pb.EntryUpd
 	return nil
 }
 
-func readRange(ctx context.Context, m mutator.MutationStorage, startSequence uint64, endSequence uint64, count int32) (uint64, []*pb.EntryUpdate, error) {
-	maxSequence, results, err := m.ReadRange(ctx, mapID, startSequence, endSequence, count)
-	if err != nil {
-		return 0, nil, fmt.Errorf("ReadRange(%v, %v): %v, want nil", startSequence, count, err)
-	}
-	return maxSequence, results, nil
-}
-
-func readAll(ctx context.Context, m mutator.MutationStorage, startSequence uint64) (uint64, []*pb.EntryUpdate, error) {
-	maxSequence, results, err := m.ReadAll(ctx, mapID, startSequence)
-	if err != nil {
-		return 0, nil, fmt.Errorf("ReadRange(%v): %v, want nil", startSequence, err)
-	}
-	return maxSequence, results, nil
-}
-
 func TestReadRange(t *testing.T) {
 	ctx := context.Background()
 	db := newDB(t)
@@ -175,7 +159,7 @@ func TestReadRange(t *testing.T) {
 			},
 		},
 	} {
-		maxSequence, results, err := readRange(ctx, m, tc.startSequence, tc.endSequence, tc.count)
+		maxSequence, results, err := m.ReadRange(ctx, mapID, tc.startSequence, tc.endSequence, tc.count)
 		if err != nil {
 			t.Errorf("%v: failed to read mutations: %v", tc.description, err)
 		}
@@ -246,7 +230,8 @@ func TestReadAll(t *testing.T) {
 			},
 		},
 	} {
-		maxSequence, results, err := readAll(ctx, m, tc.startSequence)
+		maxcount := 1000
+		maxSequence, results, err := m.ReadAll(ctx, mapID, tc.startSequence, maxcount)
 		if err != nil {
 			t.Errorf("%v: failed to read mutations: %v", tc.description, err)
 		}


### PR DESCRIPTION
Prevent a crazy number of mutations from going into a single epoch
and overloading the trillian map.

DiffBase #896 