### PR TITLE
Send sequence numbers along with values in ReadBatch

### DIFF
--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -33,7 +33,7 @@ func NewMutationStorage() *MutationStorage {
 }
 
 // ReadPage paginates through the list of mutations
-func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.EntryUpdate, error) {
+func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.Entry, error) {
 	if start > int64(len(m.mtns[mapID])) {
 		panic("start > len(m.mtns[mapID])")
 	}
@@ -44,7 +44,12 @@ func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, p
 	if end > int64(len(m.mtns[mapID])) {
 		end = int64(len(m.mtns[mapID]))
 	}
-	return end, m.mtns[mapID][start:end], nil
+	entryupdates := m.mtns[mapID][start:end]
+	entries := make([]*pb.Entry, 0, len(entryupdates))
+	for _, e := range entryupdates {
+		entries = append(entries, e.Mutation)
+	}
+	return end, entries, nil
 }
 
 // ReadBatch is unimplemented

--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
+	"github.com/google/keytransparency/core/mutator"
 )
 
 // MutationStorage implements mutator.Mutation
@@ -53,7 +54,7 @@ func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, p
 }
 
 // ReadBatch is unimplemented
-func (m *MutationStorage) ReadBatch(context.Context, int64, int64, int32) (int64, []*pb.EntryUpdate, error) {
+func (m *MutationStorage) ReadBatch(context.Context, int64, int64, int32) (int64, []*mutator.Mutation, error) {
 	return 0, nil, nil
 }
 

--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -54,7 +54,7 @@ func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, p
 }
 
 // ReadBatch is unimplemented
-func (m *MutationStorage) ReadBatch(context.Context, int64, int64, int32) (int64, []*mutator.Mutation, error) {
+func (m *MutationStorage) ReadBatch(context.Context, int64, int64, int32) (int64, []*mutator.QueueMessage, error) {
 	return 0, nil, nil
 }
 

--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -45,12 +45,12 @@ func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, p
 	if end > int64(len(m.mtns[mapID])) {
 		end = int64(len(m.mtns[mapID]))
 	}
-	entryupdates := m.mtns[mapID][start:end]
-	entries := make([]*pb.Entry, 0, len(entryupdates))
-	for _, e := range entryupdates {
-		entries = append(entries, e.Mutation)
+	entryUpdates := m.mtns[mapID][start:end]
+	mutations := make([]*pb.Entry, 0, len(entryUpdates))
+	for _, e := range entryUpdates {
+		mutations = append(mutations, e.Mutation)
 	}
-	return end, entries, nil
+	return end, mutations, nil
 }
 
 // ReadBatch is unimplemented

--- a/core/keyserver/epochs.go
+++ b/core/keyserver/epochs.go
@@ -105,16 +105,16 @@ func (s *Server) ListMutations(ctx context.Context, in *pb.ListMutationsRequest)
 		return nil, err
 	}
 	// Read mutations from the database.
-	maxSequence, mRange, err := s.mutations.ReadPage(ctx, domain.MapID, lowestSeq, highestSeq, in.PageSize)
+	maxSequence, entries, err := s.mutations.ReadPage(ctx, domain.MapID, lowestSeq, highestSeq, in.PageSize)
 	if err != nil {
 		glog.Errorf("mutations.ReadRange(%v, %v, %v): %v", lowestSeq, highestSeq, in.PageSize, err)
 		return nil, status.Error(codes.Internal, "Reading mutations range failed")
 	}
-	indexes := make([][]byte, 0, len(mRange))
-	mutations := make([]*pb.MutationProof, 0, len(mRange))
-	for _, m := range mRange {
-		mutations = append(mutations, &pb.MutationProof{Mutation: m.Mutation})
-		indexes = append(indexes, m.Mutation.GetIndex())
+	indexes := make([][]byte, 0, len(entries))
+	mutations := make([]*pb.MutationProof, 0, len(entries))
+	for _, e := range entries {
+		mutations = append(mutations, &pb.MutationProof{Mutation: e})
+		indexes = append(indexes, e.GetIndex())
 	}
 	// Get leaf proofs.
 	proofs, err := s.inclusionProofs(ctx, in.DomainId, indexes, in.Epoch-1)

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -56,6 +56,13 @@ type Mutator interface {
 	Mutate(value, mutation proto.Message) (proto.Message, error)
 }
 
+// Mutation represents a change to a user, and associated data.
+type Mutation struct {
+	ID        int64
+	Mutation  *pb.Entry
+	ExtraData *pb.Comitted
+}
+
 // MutationStorage reads and writes mutations to the database.
 type MutationStorage interface {
 	// ReadPage returns mutations in the interval (start, end] for mapID.

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -72,7 +72,7 @@ type MutationStorage interface {
 	// ReadBatch returns mutations in the interval (start, ∞] for mapID.
 	// ReadBatch will not return more than batchSize entries.
 	// Returns the maximum sequence number returned.
-	ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*pb.EntryUpdate, error)
+	ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*Mutation, error)
 	// Write saves the mutation in the database. Write returns the sequence
 	// number that is written.
 	Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (int64, error)

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -60,7 +60,7 @@ type Mutator interface {
 type Mutation struct {
 	ID        int64
 	Mutation  *pb.Entry
-	ExtraData *pb.Comitted
+	ExtraData *pb.Committed
 }
 
 // MutationStorage reads and writes mutations to the database.
@@ -68,7 +68,7 @@ type MutationStorage interface {
 	// ReadPage returns mutations in the interval (start, end] for mapID.
 	// pageSize specifies the maximum number of items to return.
 	// Returns the maximum sequence number returned.
-	ReadPage(ctx context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.EntryUpdate, error)
+	ReadPage(ctx context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.Entry, error)
 	// ReadBatch returns mutations in the interval (start, ∞] for mapID.
 	// ReadBatch will not return more than batchSize entries.
 	// Returns the maximum sequence number returned.

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -56,8 +56,8 @@ type Mutator interface {
 	Mutate(value, mutation proto.Message) (proto.Message, error)
 }
 
-// Mutation represents a change to a user, and associated data.
-type Mutation struct {
+// QueueMessage represents a change to a user, and associated data.
+type QueueMessage struct {
 	ID        int64
 	Mutation  *pb.Entry
 	ExtraData *pb.Committed
@@ -72,7 +72,7 @@ type MutationStorage interface {
 	// ReadBatch returns mutations in the interval (start, ∞] for mapID.
 	// ReadBatch will not return more than batchSize entries.
 	// Returns the maximum sequence number returned.
-	ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*Mutation, error)
+	ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*QueueMessage, error)
 	// Write saves the mutation in the database. Write returns the sequence
 	// number that is written.
 	Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (int64, error)

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -228,7 +228,7 @@ func toArray(b []byte) [32]byte {
 // Multiple mutations for the same leaf will be applied to provided leaf.
 // The last valid mutation for each leaf is included in the output.
 // Returns a list of map leaves that should be updated.
-func (s *Sequencer) applyMutations(mutations []*tpb.EntryUpdate, leaves []*trillian.MapLeaf) ([]*trillian.MapLeaf, error) {
+func (s *Sequencer) applyMutations(mutations []*mutator.Mutation, leaves []*trillian.MapLeaf) ([]*trillian.MapLeaf, error) {
 	// Put leaves in a map from index to leaf value.
 	leafMap := make(map[[32]byte]*trillian.MapLeaf)
 	for _, l := range leaves {
@@ -260,7 +260,7 @@ func (s *Sequencer) applyMutations(mutations []*tpb.EntryUpdate, leaves []*trill
 		}
 
 		// Serialize commitment.
-		extraData, err := proto.Marshal(m.Committed)
+		extraData, err := proto.Marshal(m.ExtraData)
 		if err != nil {
 			glog.Warningf("Marshal(committed proto): %v", err)
 			continue

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -228,7 +228,7 @@ func toArray(b []byte) [32]byte {
 // Multiple mutations for the same leaf will be applied to provided leaf.
 // The last valid mutation for each leaf is included in the output.
 // Returns a list of map leaves that should be updated.
-func (s *Sequencer) applyMutations(mutations []*mutator.Mutation, leaves []*trillian.MapLeaf) ([]*trillian.MapLeaf, error) {
+func (s *Sequencer) applyMutations(mutations []*mutator.QueueMessage, leaves []*trillian.MapLeaf) ([]*trillian.MapLeaf, error) {
 	// Put leaves in a map from index to leaf value.
 	leafMap := make(map[[32]byte]*trillian.MapLeaf)
 	for _, l := range leaves {

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -86,7 +86,7 @@ func (m *mutations) ReadPage(ctx context.Context, mapID, start, end int64, pageS
 // ReadAll reads all mutations starting from the given sequence number. Note that
 // startSequence is not included in the result. ReadAll also returns the maximum
 // sequence number read.
-func (m *mutations) ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*mutator.Mutation, error) {
+func (m *mutations) ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*mutator.QueueMessage, error) {
 	readStmt, err := m.db.Prepare(readAllExpr)
 	if err != nil {
 		return 0, nil, err
@@ -100,8 +100,8 @@ func (m *mutations) ReadBatch(ctx context.Context, mapID, start int64, batchSize
 	return readRows(rows)
 }
 
-func readRows(rows *sql.Rows) (int64, []*mutator.Mutation, error) {
-	results := make([]*mutator.Mutation, 0)
+func readRows(rows *sql.Rows) (int64, []*mutator.QueueMessage, error) {
+	results := make([]*mutator.QueueMessage, 0)
 	maxSequence := int64(0)
 	for rows.Next() {
 		var sequence int64
@@ -116,7 +116,7 @@ func readRows(rows *sql.Rows) (int64, []*mutator.Mutation, error) {
 		if err := proto.Unmarshal(mData, mutation); err != nil {
 			return 0, nil, err
 		}
-		results = append(results, &mutator.Mutation{
+		results = append(results, &mutator.QueueMessage{
 			ID:        sequence,
 			Mutation:  mutation.Mutation,
 			ExtraData: mutation.Committed,

--- a/impl/sql/mutationstorage/mutations_test.go
+++ b/impl/sql/mutationstorage/mutations_test.go
@@ -38,8 +38,8 @@ func newDB(t testing.TB) *sql.DB {
 	return db
 }
 
-func genUpdate(i int) *mutator.Mutation {
-	return &mutator.Mutation{
+func genUpdate(i int) *mutator.QueueMessage {
+	return &mutator.QueueMessage{
 		ID: int64(i),
 		Mutation: &pb.Entry{
 			Index:      []byte(fmt.Sprintf("index%d", i)),
@@ -54,7 +54,7 @@ func genUpdate(i int) *mutator.Mutation {
 
 func fillDB(ctx context.Context, t *testing.T, m mutator.MutationStorage) {
 	for _, mtn := range []struct {
-		update      *mutator.Mutation
+		update      *mutator.QueueMessage
 		outSequence int64
 	}{
 		{update: genUpdate(1), outSequence: 1},
@@ -196,7 +196,7 @@ func TestReadBatch(t *testing.T) {
 		description   string
 		startSequence int64
 		maxSequence   int64
-		mutations     []*mutator.Mutation
+		mutations     []*mutator.QueueMessage
 		batchSize     int32
 	}{
 		{
@@ -210,7 +210,7 @@ func TestReadBatch(t *testing.T) {
 			description:   "read all mutations",
 			startSequence: 0,
 			maxSequence:   5,
-			mutations: []*mutator.Mutation{
+			mutations: []*mutator.QueueMessage{
 				genUpdate(1),
 				genUpdate(2),
 				genUpdate(3),
@@ -223,7 +223,7 @@ func TestReadBatch(t *testing.T) {
 			description:   "read half of the mutations",
 			startSequence: 2,
 			maxSequence:   5,
-			mutations: []*mutator.Mutation{
+			mutations: []*mutator.QueueMessage{
 				genUpdate(3),
 				genUpdate(4),
 				genUpdate(5),
@@ -234,7 +234,7 @@ func TestReadBatch(t *testing.T) {
 			description:   "limit by batch",
 			startSequence: 2,
 			maxSequence:   3,
-			mutations: []*mutator.Mutation{
+			mutations: []*mutator.QueueMessage{
 				genUpdate(3),
 			},
 			batchSize: 1,
@@ -243,7 +243,7 @@ func TestReadBatch(t *testing.T) {
 			description:   "read last mutation",
 			startSequence: 4,
 			maxSequence:   5,
-			mutations: []*mutator.Mutation{
+			mutations: []*mutator.QueueMessage{
 				genUpdate(5),
 			},
 			batchSize: 10,

--- a/impl/sql/mutationstorage/mutations_test.go
+++ b/impl/sql/mutationstorage/mutations_test.go
@@ -94,14 +94,14 @@ func TestReadPage(t *testing.T) {
 		endSequence   int64
 		count         int32
 		maxSequence   int64
-		mutations     []*pb.EntryUpdate
+		mutations     []*pb.Entry
 	}{
 		{
 			description: "read a single mutation",
 			endSequence: 1,
 			count:       1,
 			maxSequence: 1,
-			mutations:   []*pb.EntryUpdate{genUpdate(1)},
+			mutations:   []*pb.Entry{genUpdate(1).Mutation},
 		},
 		{
 			description:   "empty mutations list",
@@ -115,12 +115,12 @@ func TestReadPage(t *testing.T) {
 			endSequence:   5,
 			count:         5,
 			maxSequence:   5,
-			mutations: []*pb.EntryUpdate{
-				genUpdate(1),
-				genUpdate(2),
-				genUpdate(3),
-				genUpdate(4),
-				genUpdate(5),
+			mutations: []*pb.Entry{
+				genUpdate(1).Mutation,
+				genUpdate(2).Mutation,
+				genUpdate(3).Mutation,
+				genUpdate(4).Mutation,
+				genUpdate(5).Mutation,
 			},
 		},
 		{
@@ -129,10 +129,10 @@ func TestReadPage(t *testing.T) {
 			endSequence:   5,
 			count:         3,
 			maxSequence:   5,
-			mutations: []*pb.EntryUpdate{
-				genUpdate(3),
-				genUpdate(4),
-				genUpdate(5),
+			mutations: []*pb.Entry{
+				genUpdate(3).Mutation,
+				genUpdate(4).Mutation,
+				genUpdate(5).Mutation,
 			},
 		},
 		{
@@ -141,10 +141,10 @@ func TestReadPage(t *testing.T) {
 			endSequence:   5,
 			count:         5,
 			maxSequence:   5,
-			mutations: []*pb.EntryUpdate{
-				genUpdate(3),
-				genUpdate(4),
-				genUpdate(5),
+			mutations: []*pb.Entry{
+				genUpdate(3).Mutation,
+				genUpdate(4).Mutation,
+				genUpdate(5).Mutation,
 			},
 		},
 		{
@@ -152,10 +152,10 @@ func TestReadPage(t *testing.T) {
 			endSequence: 5,
 			count:       3,
 			maxSequence: 3,
-			mutations: []*pb.EntryUpdate{
-				genUpdate(1),
-				genUpdate(2),
-				genUpdate(3),
+			mutations: []*pb.Entry{
+				genUpdate(1).Mutation,
+				genUpdate(2).Mutation,
+				genUpdate(3).Mutation,
 			},
 		},
 	} {


### PR DESCRIPTION
This PR allows sequence numbers to be transmitted in the mutation objects themselves. 

This is in preparation for creating a proper queue who's `mutator.Mutation` objects can be properly dequeued and consumed by the sequencer without enforcing a strict ordering over mutations.