### PR TITLE
Index mutations by domainID

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -131,7 +131,7 @@ func (s *Server) fetchDomain(ctx context.Context, d *domain.Domain) (*pb.Domain,
 		return nil, err
 	}
 	return &pb.Domain{
-		DomainId:    d.Domain,
+		DomainId:    d.DomainID,
 		Log:         logTree,
 		Map:         mapTree,
 		Vrf:         d.VRF,
@@ -195,7 +195,7 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 	}
 
 	if err := s.domains.Write(ctx, &domain.Domain{
-		Domain:      in.GetDomainId(),
+		DomainID:    in.GetDomainId(),
 		MapID:       mapTree.TreeId,
 		LogID:       logTree.TreeId,
 		VRF:         vrfPublicPB,

--- a/core/domain/storage.go
+++ b/core/domain/storage.go
@@ -25,10 +25,10 @@ import (
 
 // Domain stores configuration information for a single Key Transparency instance.
 type Domain struct {
-	Domain string
-	MapID  int64
-	LogID  int64
-	VRF    *keyspb.PublicKey
+	DomainID string
+	MapID    int64
+	LogID    int64
+	VRF      *keyspb.PublicKey
 
 	VRFPriv                  proto.Message
 	MinInterval, MaxInterval time.Duration

--- a/core/fake/domain_storage.go
+++ b/core/fake/domain_storage.go
@@ -44,7 +44,7 @@ func (a *DomainStorage) List(ctx context.Context, deleted bool) ([]*domain.Domai
 
 // Write adds a new domain.
 func (a *DomainStorage) Write(ctx context.Context, d *domain.Domain) error {
-	a.domains[d.Domain] = d
+	a.domains[d.DomainID] = d
 	return nil
 }
 

--- a/core/fake/mutation_storage.go
+++ b/core/fake/mutation_storage.go
@@ -23,29 +23,29 @@ import (
 
 // MutationStorage implements mutator.Mutation
 type MutationStorage struct {
-	mtns map[int64][]*pb.EntryUpdate
+	mtns map[string][]*pb.EntryUpdate
 }
 
 // NewMutationStorage returns a fake mutator.Mutation
 func NewMutationStorage() *MutationStorage {
 	return &MutationStorage{
-		mtns: make(map[int64][]*pb.EntryUpdate),
+		mtns: make(map[string][]*pb.EntryUpdate),
 	}
 }
 
 // ReadPage paginates through the list of mutations
-func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.Entry, error) {
-	if start > int64(len(m.mtns[mapID])) {
-		panic("start > len(m.mtns[mapID])")
+func (m *MutationStorage) ReadPage(_ context.Context, domainID string, start, end int64, pageSize int32) (int64, []*pb.Entry, error) {
+	if start > int64(len(m.mtns[domainID])) {
+		panic("start > len(m.mtns[domainID])")
 	}
 	// Adjust end.
 	if end-start > int64(pageSize) {
 		end = start + int64(pageSize)
 	}
-	if end > int64(len(m.mtns[mapID])) {
-		end = int64(len(m.mtns[mapID]))
+	if end > int64(len(m.mtns[domainID])) {
+		end = int64(len(m.mtns[domainID]))
 	}
-	entryUpdates := m.mtns[mapID][start:end]
+	entryUpdates := m.mtns[domainID][start:end]
 	mutations := make([]*pb.Entry, 0, len(entryUpdates))
 	for _, e := range entryUpdates {
 		mutations = append(mutations, e.Mutation)
@@ -54,12 +54,12 @@ func (m *MutationStorage) ReadPage(_ context.Context, mapID, start, end int64, p
 }
 
 // ReadBatch is unimplemented
-func (m *MutationStorage) ReadBatch(context.Context, int64, int64, int32) (int64, []*mutator.QueueMessage, error) {
+func (m *MutationStorage) ReadBatch(context.Context, string, int64, int32) (int64, []*mutator.QueueMessage, error) {
 	return 0, nil, nil
 }
 
 // Write stores a mutation
-func (m *MutationStorage) Write(_ context.Context, mapID int64, mutation *pb.EntryUpdate) (int64, error) {
-	m.mtns[mapID] = append(m.mtns[mapID], mutation)
-	return int64(len(m.mtns[mapID])), nil
+func (m *MutationStorage) Write(_ context.Context, domainID string, mutation *pb.EntryUpdate) (int64, error) {
+	m.mtns[domainID] = append(m.mtns[domainID], mutation)
+	return int64(len(m.mtns[domainID])), nil
 }

--- a/core/keyserver/epochs.go
+++ b/core/keyserver/epochs.go
@@ -105,7 +105,7 @@ func (s *Server) ListMutations(ctx context.Context, in *pb.ListMutationsRequest)
 		return nil, err
 	}
 	// Read mutations from the database.
-	maxSequence, entries, err := s.mutations.ReadPage(ctx, domain.MapID, lowestSeq, highestSeq, in.PageSize)
+	maxSequence, entries, err := s.mutations.ReadPage(ctx, domain.Domain, lowestSeq, highestSeq, in.PageSize)
 	if err != nil {
 		glog.Errorf("mutations.ReadRange(%v, %v, %v): %v", lowestSeq, highestSeq, in.PageSize, err)
 		return nil, status.Error(codes.Internal, "Reading mutations range failed")

--- a/core/keyserver/epochs.go
+++ b/core/keyserver/epochs.go
@@ -105,7 +105,7 @@ func (s *Server) ListMutations(ctx context.Context, in *pb.ListMutationsRequest)
 		return nil, err
 	}
 	// Read mutations from the database.
-	maxSequence, entries, err := s.mutations.ReadPage(ctx, domain.Domain, lowestSeq, highestSeq, in.PageSize)
+	maxSequence, entries, err := s.mutations.ReadPage(ctx, domain.DomainID, lowestSeq, highestSeq, in.PageSize)
 	if err != nil {
 		glog.Errorf("mutations.ReadRange(%v, %v, %v): %v", lowestSeq, highestSeq, in.PageSize, err)
 		return nil, status.Error(codes.Internal, "Reading mutations range failed")

--- a/core/keyserver/epochs_test.go
+++ b/core/keyserver/epochs_test.go
@@ -97,7 +97,7 @@ func TestGetMutations(t *testing.T) {
 	fakeMap := fake.NewTrillianMapClient()
 	fakeLog := fake.NewTrillianLogClient()
 	if err := fakeAdmin.Write(ctx, &domain.Domain{
-		Domain:      domainID,
+		DomainID:    domainID,
 		MapID:       mapID,
 		MinInterval: 1 * time.Second,
 		MaxInterval: 5 * time.Second,

--- a/core/keyserver/epochs_test.go
+++ b/core/keyserver/epochs_test.go
@@ -54,15 +54,15 @@ func updates(t *testing.T, start, end int) []*pb.EntryUpdate {
 	return kvs
 }
 
-func prepare(ctx context.Context, t *testing.T, mapID int64, mutations mutator.MutationStorage, tmap *fake.MapServer) {
-	createEpoch(ctx, t, mapID, mutations, tmap, 1, 1, 6)
-	createEpoch(ctx, t, mapID, mutations, tmap, 2, 7, 10)
+func prepare(ctx context.Context, t *testing.T, domainID string, mutations mutator.MutationStorage, tmap *fake.MapServer) {
+	createEpoch(ctx, t, domainID, mutations, tmap, 1, 1, 6)
+	createEpoch(ctx, t, domainID, mutations, tmap, 2, 7, 10)
 }
 
-func createEpoch(ctx context.Context, t *testing.T, mapID int64, mutations mutator.MutationStorage, tmap *fake.MapServer, epoch int64, start, end int) {
+func createEpoch(ctx context.Context, t *testing.T, domainID string, mutations mutator.MutationStorage, tmap *fake.MapServer, epoch int64, start, end int) {
 	kvs := updates(t, start, end)
 	for _, kv := range kvs {
-		if _, err := mutations.Write(ctx, mapID, kv); err != nil {
+		if _, err := mutations.Write(ctx, domainID, kv); err != nil {
 			t.Fatalf("mutations.Write failed: %v", err)
 		}
 	}
@@ -104,7 +104,7 @@ func TestGetMutations(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("admin.Write(): %v", err)
 	}
-	prepare(ctx, t, mapID, fakeMutations, fakeMap)
+	prepare(ctx, t, domainID, fakeMutations, fakeMap)
 
 	for _, tc := range []struct {
 		description string
@@ -167,7 +167,7 @@ func TestLowestSequenceNumber(t *testing.T) {
 	fakeMap := fake.NewTrillianMapClient()
 	fakeAdmin := &fake.DomainStorage{}
 	mapID := int64(1)
-	prepare(ctx, t, mapID, fakeMutations, fakeMap)
+	prepare(ctx, t, domainID, fakeMutations, fakeMap)
 
 	for _, tc := range []struct {
 		token     string

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -321,7 +321,7 @@ func (s *Server) UpdateEntry(ctx context.Context, in *pb.UpdateEntryRequest) (*p
 	}
 
 	// Save mutation to the database.
-	if err := s.queue.Send(ctx, domain.Domain, in.GetEntryUpdate()); err != nil {
+	if err := s.queue.Send(ctx, domain.DomainID, in.GetEntryUpdate()); err != nil {
 		glog.Errorf("mutations.Write failed: %v", err)
 		return nil, status.Errorf(codes.Internal, "Mutation write error")
 	}

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -321,7 +321,7 @@ func (s *Server) UpdateEntry(ctx context.Context, in *pb.UpdateEntryRequest) (*p
 	}
 
 	// Save mutation to the database.
-	if err := s.queue.Send(ctx, domain.MapID, in.GetEntryUpdate()); err != nil {
+	if err := s.queue.Send(ctx, domain.Domain, in.GetEntryUpdate()); err != nil {
 		glog.Errorf("mutations.Write failed: %v", err)
 		return nil, status.Errorf(codes.Internal, "Mutation write error")
 	}

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -69,9 +69,9 @@ type QueueMessage struct {
 // receivers.
 type MutationQueue interface {
 	// Send submits an item to the queue
-	Send(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) error
+	Send(ctx context.Context, domainID string, mutation *pb.EntryUpdate) error
 	// NewReceiver starts receiving messages sent to the queue. As batches become ready, receiveFunc will be called.
-	NewReceiver(ctx context.Context, last time.Time, mapID, start int64, receiveFunc ReceiveFunc, rOpts ReceiverOptions) Receiver
+	NewReceiver(ctx context.Context, last time.Time, domainID string, start int64, receiveFunc ReceiveFunc, ropts ReceiverOptions) Receiver
 }
 
 // ReceiveFunc receives updates from the queue.
@@ -103,12 +103,12 @@ type MutationStorage interface {
 	// ReadPage returns mutations in the interval (start, end] for mapID.
 	// pageSize specifies the maximum number of items to return.
 	// Returns the maximum sequence number returned.
-	ReadPage(ctx context.Context, mapID, start, end int64, pageSize int32) (int64, []*pb.Entry, error)
+	ReadPage(ctx context.Context, domainID string, start, end int64, pageSize int32) (int64, []*pb.Entry, error)
 	// ReadBatch returns mutations in the interval (start, ∞] for mapID.
 	// ReadBatch will not return more than batchSize entries.
 	// Returns the maximum sequence number returned.
-	ReadBatch(ctx context.Context, mapID, start int64, batchSize int32) (int64, []*QueueMessage, error)
+	ReadBatch(ctx context.Context, domainID string, start int64, batchSize int32) (int64, []*QueueMessage, error)
 	// Write saves the mutation in the database. Write returns the sequence
 	// number that is written.
-	Write(ctx context.Context, mapID int64, mutation *pb.EntryUpdate) (int64, error)
+	Write(ctx context.Context, domainID string, mutation *pb.EntryUpdate) (int64, error)
 }

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -144,9 +144,9 @@ func (s *Sequencer) ListenForNewDomains(ctx context.Context, refresh time.Durati
 				return fmt.Errorf("admin.List(): %v", err)
 			}
 			for _, d := range domains {
-				if _, ok := s.receivers[d.Domain]; !ok {
-					glog.Infof("StartSigning domain: %v", d.Domain)
-					s.receivers[d.Domain] = s.NewReceiver(ctx, d, d.MinInterval, d.MaxInterval)
+				if _, ok := s.receivers[d.DomainID]; !ok {
+					glog.Infof("StartSigning domain: %v", d.DomainID)
+					s.receivers[d.DomainID] = s.NewReceiver(ctx, d, d.MinInterval, d.MaxInterval)
 				}
 			}
 		case <-ctx.Done():
@@ -192,7 +192,7 @@ func (s *Sequencer) NewReceiver(ctx context.Context, domain *domain.Domain, minI
 	}
 	start := meta.GetHighestFullyCompletedSeq()
 
-	return s.queue.NewReceiver(ctx, last, domain.Domain, start, func(mutations []*mutator.QueueMessage) error {
+	return s.queue.NewReceiver(ctx, last, domain.DomainID, start, func(mutations []*mutator.QueueMessage) error {
 		return s.createEpoch(ctx, domain, mutations)
 	}, mutator.ReceiverOptions{
 		MaxBatchSize: MaxBatchSize,

--- a/impl/sql/domain/storage.go
+++ b/impl/sql/domain/storage.go
@@ -108,7 +108,7 @@ func (s *storage) List(ctx context.Context, showDeleted bool) ([]*domain.Domain,
 		var pubkey, anyData []byte
 		d := &domain.Domain{}
 		if err := rows.Scan(
-			&d.Domain,
+			&d.DomainID,
 			&d.MapID, &d.LogID,
 			&pubkey, &anyData,
 			&d.MinInterval, &d.MaxInterval,
@@ -143,7 +143,7 @@ func (s *storage) Write(ctx context.Context, d *domain.Domain) error {
 	}
 	defer writeStmt.Close()
 	_, err = writeStmt.ExecContext(ctx,
-		d.Domain,
+		d.DomainID,
 		d.MapID, d.LogID,
 		d.VRF.Der, anyData,
 		d.MinInterval.Nanoseconds(), d.MaxInterval.Nanoseconds(),
@@ -166,7 +166,7 @@ func (s *storage) Read(ctx context.Context, domainID string, showDeleted bool) (
 	d := &domain.Domain{}
 	var pubkey, anyData []byte
 	if err := readStmt.QueryRowContext(ctx, domainID).Scan(
-		&d.Domain,
+		&d.DomainID,
 		&d.MapID, &d.LogID,
 		&pubkey, &anyData,
 		&d.MinInterval, &d.MaxInterval,

--- a/impl/sql/domain/storage_test.go
+++ b/impl/sql/domain/storage_test.go
@@ -46,7 +46,7 @@ func TestList(t *testing.T) {
 		{
 			domains: []*domain.Domain{
 				{
-					Domain:      "domain1",
+					DomainID:    "domain1",
 					MapID:       1,
 					LogID:       2,
 					VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -55,7 +55,7 @@ func TestList(t *testing.T) {
 					MaxInterval: 5 * time.Second,
 				},
 				{
-					Domain:      "domain2",
+					DomainID:    "domain2",
 					MapID:       1,
 					LogID:       2,
 					VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -109,7 +109,7 @@ func TestWriteReadDelete(t *testing.T) {
 			desc:  "Success",
 			write: true,
 			d: domain.Domain{
-				Domain:      "testdomain",
+				DomainID:    "testdomain",
 				MapID:       1,
 				LogID:       2,
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -122,7 +122,7 @@ func TestWriteReadDelete(t *testing.T) {
 			desc:  "Duplicate DomainID",
 			write: true,
 			d: domain.Domain{
-				Domain:      "testdomain",
+				DomainID:    "testdomain",
 				MapID:       1,
 				LogID:       2,
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -135,7 +135,7 @@ func TestWriteReadDelete(t *testing.T) {
 		{
 			desc: "Delete",
 			d: domain.Domain{
-				Domain:      "testdomain",
+				DomainID:    "testdomain",
 				MapID:       1,
 				LogID:       2,
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -151,7 +151,7 @@ func TestWriteReadDelete(t *testing.T) {
 		{
 			desc: "Read deleted",
 			d: domain.Domain{
-				Domain:      "testdomain",
+				DomainID:    "testdomain",
 				MapID:       1,
 				LogID:       2,
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -167,7 +167,7 @@ func TestWriteReadDelete(t *testing.T) {
 		{
 			desc: "Undelete",
 			d: domain.Domain{
-				Domain:      "testdomain",
+				DomainID:    "testdomain",
 				MapID:       1,
 				LogID:       2,
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -193,13 +193,13 @@ func TestWriteReadDelete(t *testing.T) {
 				}
 			}
 			if tc.setDelete {
-				if err := admin.SetDelete(ctx, tc.d.Domain, tc.isDeleted); err != nil {
-					t.Errorf("SetDelete(%v, %v): %v", tc.d.Domain, tc.isDeleted, err)
+				if err := admin.SetDelete(ctx, tc.d.DomainID, tc.isDeleted); err != nil {
+					t.Errorf("SetDelete(%v, %v): %v", tc.d.DomainID, tc.isDeleted, err)
 					return
 				}
 			}
 
-			domain, err := admin.Read(ctx, tc.d.Domain, tc.readDeleted)
+			domain, err := admin.Read(ctx, tc.d.DomainID, tc.readDeleted)
 			if got, want := err != nil, tc.wantReadErr; got != want {
 				t.Errorf("Read(): %v, want err: %v", err, want)
 			}

--- a/impl/sql/mutationstorage/mutations_test.go
+++ b/impl/sql/mutationstorage/mutations_test.go
@@ -28,7 +28,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-const mapID = 0
+const domainID = "default"
 
 func newDB(t testing.TB) *sql.DB {
 	db, err := sql.Open("sqlite3", ":memory:")
@@ -73,7 +73,7 @@ func fillDB(ctx context.Context, t *testing.T, m mutator.MutationStorage) {
 }
 
 func write(ctx context.Context, m mutator.MutationStorage, mutation *pb.EntryUpdate, outSequence int64) error {
-	sequence, err := m.Write(ctx, mapID, mutation)
+	sequence, err := m.Write(ctx, domainID, mutation)
 	if err != nil {
 		return fmt.Errorf("Write(%v): %v, want nil", mutation, err)
 	}
@@ -164,7 +164,7 @@ func TestReadPage(t *testing.T) {
 			},
 		},
 	} {
-		maxSequence, results, err := m.ReadPage(ctx, mapID, tc.startSequence, tc.endSequence, tc.count)
+		maxSequence, results, err := m.ReadPage(ctx, domainID, tc.startSequence, tc.endSequence, tc.count)
 		if err != nil {
 			t.Errorf("%v: failed to read mutations: %v", tc.description, err)
 		}
@@ -249,7 +249,7 @@ func TestReadBatch(t *testing.T) {
 			batchSize: 10,
 		},
 	} {
-		maxSequence, results, err := m.ReadBatch(ctx, mapID, tc.startSequence, tc.batchSize)
+		maxSequence, results, err := m.ReadBatch(ctx, domainID, tc.startSequence, tc.batchSize)
 		if err != nil {
 			t.Errorf("%v: failed to read mutations: %v", tc.description, err)
 		}

--- a/impl/sql/mutationstorage/mysql.go
+++ b/impl/sql/mutationstorage/mysql.go
@@ -24,7 +24,7 @@ var (
 	createStmt = []string{
 		`
 	CREATE TABLE IF NOT EXISTS Mutations (
-		MapID    BIGINT        NOT NULL,
+		DomainID VARCHAR(30)   NOT NULL,
 		Sequence INTEGER       NOT NULL PRIMARY KEY AUTO_INCREMENT,
                 MIndex   VARBINARY(32) NOT NULL,
 		Mutation BLOB          NOT NULL

--- a/impl/sql/mutationstorage/queue_test.go
+++ b/impl/sql/mutationstorage/queue_test.go
@@ -55,7 +55,7 @@ func TestRecieverChan(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			for i := 0; i < tc.send; i++ {
-				if err := m.Send(ctx, mapID, &pb.EntryUpdate{}); err != nil {
+				if err := m.Send(ctx, domainID, &pb.EntryUpdate{}); err != nil {
 					t.Fatalf("Could not fill queue: %v", err)
 				}
 			}
@@ -63,13 +63,9 @@ func TestRecieverChan(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(tc.wantCalls)
 			count := 0
-			r, ok := m.NewReceiver(ctx, tc.last, mapID, tc.start, func(msgs []*mutator.QueueMessage) error {
+			r, ok := m.NewReceiver(ctx, tc.last, domainID, tc.start, func([]*mutator.QueueMessage) error {
 				count++
 				wg.Done()
-				t.Logf("Callback %v", count)
-				for _, i := range msgs {
-					t.Logf("   with item %v", i.ID)
-				}
 				return nil
 			}, mutator.ReceiverOptions{
 				MaxBatchSize: 1,

--- a/impl/sql/mutationstorage/sqlite.go
+++ b/impl/sql/mutationstorage/sqlite.go
@@ -24,7 +24,7 @@ var (
 	createStmt = []string{
 		`
 	CREATE TABLE IF NOT EXISTS Mutations (
-		MapID    BIGINT        NOT NULL,
+		DomainID VARCHAR(30)   NOT NULL,
 		Sequence INTEGER       NOT NULL PRIMARY KEY AUTOINCREMENT,
                 MIndex   VARBINARY(32) NOT NULL,
 		Mutation BLOB          NOT NULL

--- a/integration/testutil.go
+++ b/integration/testutil.go
@@ -160,9 +160,9 @@ func NewEnv(t *testing.T) *Env {
 	seq := sequencer.New(domainStorage, mapEnv.MapClient, tlog, entry.New(), mutations, queue)
 	// Only sequence when explicitly asked with receiver.Flush()
 	d := &domaindef.Domain{
-		Domain: domainID,
-		LogID:  logID,
-		MapID:  mapID,
+		DomainID: domainID,
+		LogID:    logID,
+		MapID:    mapID,
 	}
 	receiver := seq.NewReceiver(ctx, d, 60*time.Hour, 60*time.Hour)
 	receiver.Flush(ctx)


### PR DESCRIPTION
This PR switches the mutation storage table from using `mapID` as the primary mutation key and replaces it with `domainID`.  This achieves a slightly cleaner abstraction and brings internal and external APIs into alignment. 
  