### PR TITLE
Launch StartSequencingAll in a separate goroutine

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -98,9 +98,14 @@ func main() {
 	glog.Infof("Signer starting")
 
 	// Run servers
-	ctx := context.Background()
-	signer.ListenForNewDomains(ctx, *refresh)
+	cctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		if err := signer.ListenForNewDomains(cctx, *refresh); err != nil {
+			glog.Errorf("StartSequencingAll(): %v", err)
+		}
+	}()
 	run(adminServer)
+	cancel()
 
 	glog.Errorf("Signer exiting")
 }


### PR DESCRIPTION
`StartSequencingAll` was changed from a non-blocking function, to a blocking function that could return an error, per Go style.  This change should have been included in #862

Fixes #868
  