### PR TITLE
Split Docker image building from running.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,17 @@ development.
 ## Running the server
 
 ### Install 
-1. [OpenSSL](https://www.openssl.org/community/binaries.html)
 1. [Docker](https://docs.docker.com/engine/installation/) 
    - Docker Engine 1.13.0+ `docker version -f '{{.Server.APIVersion}}'`
+1. [Docker Compose](https://docs.docker.com/compose/install/) 
    - Docker Compose 1.11.0+ `docker-compose --version`
-1. `go get -u github.com/google/keytransparency/...`
-1. `go get -u github.com/google/trillian/...`
-1. `./scripts/prepare_server.sh -f` 
 
 ### Run
 1. Run Key Transparency
 
   ```sh
+$ wget https://raw.githubusercontent.com/google/keytransparency/master/docker-compose.yml
+$ docker-compose pull
 $ docker-compose up -d 
 Creating keytransparency_db_1 ...         done
 Creating keytransparency_map_server_1 ... done
@@ -99,12 +98,24 @@ Creating keytransparency_monitor_1 ...    done
 
 2. Watch it Run
 - `docker-compose logs --tail=0 --follow`
-- [Proof for app1/foo@bar.com](https://localhost:8080/v1/domains/default/users/foo@bar.com?app_id=app1)
+- [Proof for app1/foo@bar.com](https://localhost:8080/v1/domains/default/apps/app1/users/foo@bar.com)
+- [Proof for app1/foo@bar.com](https://localhost:8080/v1/domains/default/apps/app1/users/foo@bar.com)
 - [Server configuration info](https://localhost:8080/v1/domains/default/info)
 - [Prometheus graphs](http://localhost:9090/graph)
 
 ## Development and Testing
-Key Transparency and its [Trillian](https://github.com/google/trillian) backend
-use a [MySQL database](https://github.com/google/trillian/blob/master/README.md#mysql-setup),
-which must be setup in order for the Key Transparency tests to work.
+### Install 
+1. [Go](https://golang.org/doc/install)
+   - Set the `$GOPATH` environment variable. `export GOPATH=$(go env GOPATH)`
+1. [Docker](https://docs.docker.com/engine/installation/) 
+   - Docker Engine 1.13.0+ `docker version -f '{{.Server.APIVersion}}'`
+   - Docker Compose 1.11.0+ `docker-compose --version`
+1. [MySQL](https://github.com/google/trillian/blob/master/README.md#mysql-setup)
+   Key Transparency and its [Trillian](https://github.com/google/trillian) backend
+   need a local MySQL instance to be setup in order for the tests to work.
+1. `go get -u github.com/google/keytransparency/...`
+1. `go get -u github.com/google/trillian/...`
+1. `./scripts/prepare_server.sh -f` 
+1. `make presubmit`
+
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,55 @@
+version: "3"
+services:
+  prometheus:
+    image: us.gcr.io/key-transparency/prometheus:latest
+    build:
+      context: .
+      dockerfile: deploy/prometheus/Dockerfile
+
+  db:
+    image: us.gcr.io/key-transparency/db
+    build:
+      context: ../trillian
+      dockerfile: examples/deployment/docker/db_server/Dockerfile
+
+  log-server:
+    image: us.gcr.io/key-transparency/log-server
+    build: 
+      context: ../trillian
+      dockerfile: server/trillian_log_server/Dockerfile
+
+  log-signer:
+    image: us.gcr.io/key-transparency/log-signer
+    build:
+      context: ../trillian
+      dockerfile: server/trillian_log_signer/Dockerfile
+
+  map-server:
+    image: us.gcr.io/key-transparency/map-server:latest
+    build: 
+      context: ../trillian
+      dockerfile: server/trillian_map_server/Dockerfile
+
+  server:
+    image: us.gcr.io/key-transparency/keytransparency-server:latest
+    build:
+      context: ..
+      dockerfile: ./keytransparency/cmd/keytransparency-server/Dockerfile
+
+  sequencer:
+    image: us.gcr.io/key-transparency/keytransparency-sequencer:latest
+    build:
+      context: ..
+      dockerfile: ./keytransparency/cmd/keytransparency-sequencer/Dockerfile
+
+  init:
+    image: us.gcr.io/key-transparency/init:latest
+    build: 
+      context: .
+      dockerfile: ./deploy/docker/init/Dockerfile 
+
+  monitor:
+    image: us.gcr.io/key-transparency/keytransparency-monitor:latest
+    build:
+      context: ..
+      dockerfile: ./keytransparency/cmd/keytransparency-monitor/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,18 +5,12 @@ services:
       - server
       - sequencer
     image: us.gcr.io/key-transparency/prometheus:latest
-    build:
-      context: .
-      dockerfile: deploy/prometheus/Dockerfile
     restart: always
     ports:
       - 9090:9090
 
   db:
     image: us.gcr.io/key-transparency/db
-    build:
-      context: ../trillian
-      dockerfile: examples/deployment/docker/db_server/Dockerfile
     restart: always
     ports:
       - "3306"
@@ -30,9 +24,6 @@ services:
     depends_on:
       - db
     image: us.gcr.io/key-transparency/log-server
-    build: 
-      context: ../trillian
-      dockerfile: server/trillian_log_server/Dockerfile
     restart: always
     entrypoint:
       - /go/bin/trillian_log_server
@@ -53,9 +44,6 @@ services:
     depends_on:
       - db
     image: us.gcr.io/key-transparency/log-signer
-    build:
-      context: ../trillian
-      dockerfile: server/trillian_log_signer/Dockerfile
     restart: always
     entrypoint: 
       - /go/bin/trillian_log_signer
@@ -79,9 +67,6 @@ services:
     depends_on:
       - db
     image: us.gcr.io/key-transparency/map-server:latest
-    build: 
-      context: ../trillian
-      dockerfile: server/trillian_map_server/Dockerfile
     restart: always
     entrypoint:
       - /go/bin/trillian_map_server
@@ -104,9 +89,6 @@ services:
       - log-server
       - map-server
     image: us.gcr.io/key-transparency/keytransparency-server:latest
-    build:
-      context: ..
-      dockerfile: ./keytransparency/cmd/keytransparency-server/Dockerfile
     restart: always
     ports:
       - "8080:8080" # json & grpc
@@ -135,9 +117,6 @@ services:
       - log-server
       - map-server
     image: us.gcr.io/key-transparency/keytransparency-sequencer:latest
-    build:
-      context: ..
-      dockerfile: ./keytransparency/cmd/keytransparency-sequencer/Dockerfile
     restart: always
     entrypoint:
       - /go/bin/keytransparency-sequencer
@@ -156,9 +135,6 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    build: 
-      context: .
-      dockerfile: ./deploy/docker/init/Dockerfile 
     depends_on: 
       - sequencer
     command:  sequencer:8080 -- curl -k https://sequencer:8080/v1/domains -d'{"domain_id":"default","min_interval":"1s","max_interval":"60s"}'
@@ -168,9 +144,6 @@ services:
       - server
       - sequencer
     image: us.gcr.io/key-transparency/keytransparency-monitor:latest
-    build:
-      context: ..
-      dockerfile: ./keytransparency/cmd/keytransparency-monitor/Dockerfile
     entrypoint:
       - /go/bin/keytransparency-monitor
       - --addr=0.0.0.0:8099

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -23,8 +23,8 @@ function main()
   # create key-pairs:
   ./scripts/prepare_server.sh -f
   #prepareSecrets # TODO(gbelvin): Use secrets volume.
-  docker-compose build
-  docker-compose push
+  docker-compose -f docker-compose.build.yml build
+  docker-compose -f docker-compose.build.yml push
 
   # Deploy all trillian related services.
   kubectl apply -f deploy/kubernetes/.


### PR DESCRIPTION
If a `build` stanza is present in the docker-compose.yml file,
docker-compose pull will not run if the build stanza's paths do
not exist. This prevents consumers from simply pulling the docker
images from the us.gcr repository.

This allows customers to use docker-compose pull to run KeyTransparency
without downloaded the rest of the source code.