### PR TITLE
Catch log initialized errors

### DIFF
--- a/core/fake/trillian_log_client.go
+++ b/core/fake/trillian_log_client.go
@@ -24,7 +24,7 @@ import (
 
 // LogServer only stores tree size.
 type LogServer struct {
-	treeSize int64
+	TreeSize int64
 }
 
 // NewTrillianLogClient returns a fake trillian log client.
@@ -34,7 +34,7 @@ func NewTrillianLogClient() *LogServer {
 
 // QueueLeaf increments the size of the tree.
 func (l *LogServer) QueueLeaf(context.Context, *tpb.QueueLeafRequest, ...grpc.CallOption) (*tpb.QueueLeafResponse, error) {
-	l.treeSize++
+	l.TreeSize++
 	return nil, nil
 }
 
@@ -62,7 +62,7 @@ func (*LogServer) GetConsistencyProof(context.Context, *tpb.GetConsistencyProofR
 func (l *LogServer) GetLatestSignedLogRoot(context.Context, *tpb.GetLatestSignedLogRootRequest, ...grpc.CallOption) (*tpb.GetLatestSignedLogRootResponse, error) {
 	return &tpb.GetLatestSignedLogRootResponse{
 		SignedLogRoot: &tpb.SignedLogRoot{
-			TreeSize: l.treeSize,
+			TreeSize: l.TreeSize,
 		},
 	}, nil
 }

--- a/core/fake/trillian_map_client.go
+++ b/core/fake/trillian_map_client.go
@@ -61,6 +61,9 @@ func (m *MapServer) GetLeavesByRevision(ctx context.Context, in *tpb.GetMapLeave
 	}
 	return &tpb.GetMapLeavesResponse{
 		MapLeafInclusion: leaves,
+		MapRoot: &tpb.SignedMapRoot{
+			MapRevision: in.GetRevision(),
+		},
 	}, nil
 }
 
@@ -68,7 +71,7 @@ func (m *MapServer) GetLeavesByRevision(ctx context.Context, in *tpb.GetMapLeave
 func (m *MapServer) SetLeaves(ctx context.Context, in *tpb.SetMapLeavesRequest, opts ...grpc.CallOption) (*tpb.SetMapLeavesResponse, error) {
 	m.revision++
 	m.roots[m.revision] = &tpb.SignedMapRoot{
-		Metadata:    in.Metadata,
+		Metadata:    in.GetMetadata(),
 		MapRevision: m.revision,
 	}
 	return nil, nil

--- a/core/keyserver/epochs.go
+++ b/core/keyserver/epochs.go
@@ -56,7 +56,7 @@ func (s *Server) GetEpoch(ctx context.Context, in *pb.GetEpochRequest) (*pb.Epoc
 		Revision: in.Epoch,
 	})
 	if err != nil {
-		glog.Errorf("GetEpoch(); GetSignedMapRootByRevision(%v, %v): %v", domain.MapID, in.Epoch, err)
+		glog.Errorf("GetEpoch(): GetSignedMapRootByRevision(%v, %v): %v", domain.MapID, in.Epoch, err)
 		return nil, err
 	}
 
@@ -80,7 +80,7 @@ func (s *Server) GetEpoch(ctx context.Context, in *pb.GetEpochRequest) (*pb.Epoc
 
 // GetEpochStream is a streaming API similar to ListMutations.
 func (*Server) GetEpochStream(in *pb.GetEpochRequest, stream pb.KeyTransparency_GetEpochStreamServer) error {
-	return status.Errorf(codes.Unimplemented, "GetEpochStream is unimplemented")
+	return status.Error(codes.Unimplemented, "GetEpochStream is unimplemented")
 }
 
 // ListMutations returns the mutations that created an epoch.
@@ -133,7 +133,7 @@ func (s *Server) ListMutations(ctx context.Context, in *pb.ListMutationsRequest)
 
 // ListMutationsStream is a streaming list of mutations in a specific epoch.
 func (*Server) ListMutationsStream(in *pb.ListMutationsRequest, stream pb.KeyTransparency_ListMutationsStreamServer) error {
-	return status.Errorf(codes.Unimplemented, "ListMutationStream is unimplemented")
+	return status.Error(codes.Unimplemented, "ListMutationStream is unimplemented")
 }
 
 // logProof holds the proof for a signed map root up to signed log root.
@@ -161,7 +161,7 @@ func (s *Server) logProofs(ctx context.Context, d *domain.Domain, firstTreeSize 
 		})
 	if err != nil {
 		glog.Errorf("logProofs(): log.GetInclusionProof(%v, %v, %v): %v", d.LogID, epoch, secondTreeSize, err)
-		return nil, status.Error(codes.Internal, "Cannot fetch log inclusion proof")
+		return nil, status.Errorf(codes.Internal, "Cannot fetch log inclusion proof: %v", err)
 	}
 	return &logProof{
 		LogRoot:        logRoot,

--- a/core/keyserver/epochs.go
+++ b/core/keyserver/epochs.go
@@ -160,6 +160,46 @@ func (s *Server) logProofs(ctx context.Context, d *domain.Domain, firstTreeSize 
 	return logRoot, logConsistency, logInclusion.GetProof(), nil
 }
 
+// latestLogRootProof returns the lastest SignedLogRoot and it's consistency proof.
+func (s *Server) latestLogRootProof(ctx context.Context, d *domain.Domain, firstTreeSize int64) (*tpb.SignedLogRoot, *tpb.Proof, error) {
+
+	sth, err := s.latestLogRoot(ctx, d)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Consistency proof.
+	secondTreeSize := sth.GetTreeSize()
+	var logConsistency *tpb.GetConsistencyProofResponse
+	if firstTreeSize != 0 {
+		logConsistency, err = s.tlog.GetConsistencyProof(ctx,
+			&tpb.GetConsistencyProofRequest{
+				LogId:          d.LogID,
+				FirstTreeSize:  firstTreeSize,
+				SecondTreeSize: secondTreeSize,
+			})
+		if err != nil {
+			glog.Errorf("tlog.GetConsistency(%v, %v, %v): %v",
+				d.LogID, firstTreeSize, secondTreeSize, err)
+			return nil, nil, status.Errorf(codes.Internal, "Cannot fetch log consistency proof")
+		}
+	}
+	return sth, logConsistency.GetProof(), nil
+}
+
+// latestRevision returns the latest map revision, given the latest sth.
+// The log is the authoritative source of the latest revision.
+func latestRevision(sth *tpb.SignedLogRoot) (int64, error) {
+	treeSize := sth.GetTreeSize()
+	// TreeSize = max_index + 1 because the log starts at index 0.
+	maxIndex := treeSize - 1
+
+	// The revision of the map is its index in the log.
+	if maxIndex < 0 {
+		return 0, status.Errorf(codes.Internal, "log is uninitialized")
+	}
+	return maxIndex, nil
+}
+
 // parseToken returns the sequence number in token.
 // If token is unset, return 0.
 func parseToken(token string) (int64, error) {

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -106,11 +106,11 @@ func (s *Server) GetEntry(ctx context.Context, in *pb.GetEntryRequest) (*pb.GetE
 	if err != nil {
 		return nil, err
 	}
-
 	resp := &pb.GetEntryResponse{
 		LogRoot:        sth,
 		LogConsistency: consistencyProof.GetHashes(),
 	}
+
 	proto.Merge(resp, entryProof)
 	return resp, nil
 }

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -96,7 +96,7 @@ func (s *Server) GetEntry(ctx context.Context, in *pb.GetEntryRequest) (*pb.GetE
 	if err != nil {
 		return nil, err
 	}
-	revision, err := latestRevision(sth)
+	revision, err := mapRevisionFor(sth)
 	if err != nil {
 		glog.Errorf("latestRevision(log %v, sth%v): %v", d.LogID, sth, err)
 		return nil, err
@@ -120,7 +120,7 @@ func (s *Server) GetEntry(ctx context.Context, in *pb.GetEntryRequest) (*pb.GetE
 // - LogRoot
 // - LogConsistency
 func (s *Server) getEntryByRevision(ctx context.Context, sth *tpb.SignedLogRoot, d *domain.Domain, userID, appID string, revision int64) (*pb.GetEntryResponse, error) {
-	if revision < int64(0) {
+	if revision < 0 {
 		return nil, status.Errorf(codes.InvalidArgument,
 			"Revision is %v, want >= 0", revision)
 	}
@@ -164,7 +164,7 @@ func (s *Server) getEntryByRevision(ctx context.Context, sth *tpb.SignedLogRoot,
 		&tpb.GetInclusionProofRequest{
 			LogId: d.LogID,
 			// SignedMapRoot must be placed in the log at MapRevision.
-			// MapRevisions start at 1. Log leaves start at 1.
+			// MapRevisions start at 0. Log leaves start at 0.
 			LeafIndex: getResp.GetMapRoot().GetMapRevision(),
 			TreeSize:  secondTreeSize,
 		})
@@ -206,7 +206,7 @@ func (s *Server) ListEntryHistory(ctx context.Context, in *pb.ListEntryHistoryRe
 	if err != nil {
 		return nil, err
 	}
-	currentEpoch, err := latestRevision(sth)
+	currentEpoch, err := mapRevisionFor(sth)
 	if err != nil {
 		glog.Errorf("latestRevision(log %v, sth%v): %v", d.LogID, sth, err)
 		return nil, err

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -382,42 +382,4 @@ func (s *Server) latestLogRoot(ctx context.Context, d *domain.Domain) (*tpb.Sign
 	return sth, nil
 }
 
-// latestLogRootProof returns the lastest SignedLogRoot and it's consistency proof.
-func (s *Server) latestLogRootProof(ctx context.Context, d *domain.Domain, firstTreeSize int64) (*tpb.SignedLogRoot, *tpb.Proof, error) {
-
-	sth, err := s.latestLogRoot(ctx, d)
-	if err != nil {
-		return nil, nil, err
-	}
-	// Consistency proof.
-	secondTreeSize := sth.GetTreeSize()
-	var logConsistency *tpb.GetConsistencyProofResponse
-	if firstTreeSize != 0 {
-		logConsistency, err = s.tlog.GetConsistencyProof(ctx,
-			&tpb.GetConsistencyProofRequest{
-				LogId:          d.LogID,
-				FirstTreeSize:  firstTreeSize,
-				SecondTreeSize: secondTreeSize,
-			})
-		if err != nil {
-			glog.Errorf("tlog.GetConsistency(%v, %v, %v): %v",
-				d.LogID, firstTreeSize, secondTreeSize, err)
-			return nil, nil, status.Errorf(codes.Internal, "Cannot fetch log consistency proof")
-		}
-	}
-	return sth, logConsistency.GetProof(), nil
-}
-
-// latestRevision returns the latest map revision, given the latest sth.
-// The log is the authoritative source of the latest revision.
-func latestRevision(sth *tpb.SignedLogRoot) (int64, error) {
-	treeSize := sth.GetTreeSize()
-	// TreeSize = max_index + 1 because the log starts at index 0.
-	maxIndex := treeSize - 1
-
-	// The revision of the map is its index in the log.
-	if maxIndex < 0 {
-		return 0, status.Errorf(codes.Internal, "log is uninitialized")
-	}
-	return maxIndex, nil
-}
+		return [32]byte{}, nil, err

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -1,0 +1,100 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyserver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/keytransparency/core/domain"
+	"github.com/google/keytransparency/core/fake"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
+)
+
+func TestLatestRevision(t *testing.T) {
+	ctx := context.Background()
+	mapID := int64(2)
+	fakeAdmin := fake.NewDomainStorage()
+	fakeMap := fake.NewTrillianMapClient()
+	fakeLog := fake.NewTrillianLogClient()
+
+	if err := fakeAdmin.Write(ctx, &domain.Domain{
+		DomainID:    domainID,
+		MapID:       mapID,
+		MinInterval: 1 * time.Second,
+		MaxInterval: 5 * time.Second,
+	}); err != nil {
+		t.Fatalf("admin.Write(): %v", err)
+	}
+
+	// Advance the Map's revision without touching the log.
+	fakeMap.SetLeaves(ctx, nil) // Revision 1
+	fakeMap.SetLeaves(ctx, nil) // Revision 2
+	fakeMap.SetLeaves(ctx, nil) // Revision 3
+	fakeMap.SetLeaves(ctx, nil) // Revision 4
+
+	srv := &Server{
+		domains: fakeAdmin,
+		tlog:    fakeLog,
+		tmap:    fakeMap,
+		indexFunc: func(context.Context, *domain.Domain, string, string) ([32]byte, []byte, error) {
+			return [32]byte{}, []byte(""), nil
+		},
+	}
+
+	for _, tc := range []struct {
+		desc     string
+		treeSize int64
+		wantErr  codes.Code
+		wantRev  int64
+	}{
+		{desc: "not initialized", treeSize: 0, wantErr: codes.Internal},
+		{desc: "log controls revision", treeSize: 2, wantErr: codes.OK, wantRev: 1},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeLog.TreeSize = tc.treeSize
+			// Test GetEntry
+			resp, err := srv.GetEntry(ctx, &pb.GetEntryRequest{
+				DomainId: domainID,
+			})
+			if got, want := status.Code(err), tc.wantErr; got != want {
+				t.Errorf("GetEntry(): %v, want %v", err, want)
+			}
+			if err == nil {
+				if got, want := resp.Smr.MapRevision, tc.wantRev; got != want {
+					t.Errorf("GetEntry().Rev: %v, want %v", got, want)
+				}
+			}
+
+			// Test GetEntryHistory
+			resp2, err := srv.ListEntryHistory(ctx, &pb.ListEntryHistoryRequest{
+				DomainId: domainID,
+			})
+			if got, want := status.Code(err), tc.wantErr; got != want {
+				t.Errorf("ListEntryHistory(): %v, want %v", err, tc.wantErr)
+			}
+			if err == nil {
+				if got, want := resp2.Values[0].Smr.MapRevision, tc.wantRev; got != want {
+					t.Errorf("ListEntryHistory().Rev: %v, want %v", got, want)
+				}
+			}
+		})
+	}
+
+}

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -67,32 +67,35 @@ func TestLatestRevision(t *testing.T) {
 		{desc: "not initialized", treeSize: 0, wantErr: codes.Internal},
 		{desc: "log controls revision", treeSize: 2, wantErr: codes.OK, wantRev: 1},
 	} {
-		t.Run(tc.desc, func(t *testing.T) {
+		t.Run(tc.desc+" GetEntry", func(t *testing.T) {
 			fakeLog.TreeSize = tc.treeSize
-			// Test GetEntry
 			resp, err := srv.GetEntry(ctx, &pb.GetEntryRequest{
 				DomainId: domainID,
 			})
 			if got, want := status.Code(err), tc.wantErr; got != want {
 				t.Errorf("GetEntry(): %v, want %v", err, want)
 			}
-			if err == nil {
-				if got, want := resp.Smr.MapRevision, tc.wantRev; got != want {
-					t.Errorf("GetEntry().Rev: %v, want %v", got, want)
-				}
+			if err != nil {
+				return
 			}
-
-			// Test GetEntryHistory
+			if got, want := resp.Smr.MapRevision, tc.wantRev; got != want {
+				t.Errorf("GetEntry().Rev: %v, want %v", got, want)
+			}
+		})
+		t.Run(tc.desc+" GetEntryHistory", func(t *testing.T) {
+			fakeLog.TreeSize = tc.treeSize
 			resp2, err := srv.ListEntryHistory(ctx, &pb.ListEntryHistoryRequest{
 				DomainId: domainID,
 			})
 			if got, want := status.Code(err), tc.wantErr; got != want {
 				t.Errorf("ListEntryHistory(): %v, want %v", err, tc.wantErr)
 			}
-			if err == nil {
-				if got, want := resp2.Values[0].Smr.MapRevision, tc.wantRev; got != want {
-					t.Errorf("ListEntryHistory().Rev: %v, want %v", got, want)
-				}
+			if err != nil {
+				return
+			}
+			i := len(resp2.Values) - 1 // Get last value.
+			if got, want := resp2.Values[i].Smr.MapRevision, tc.wantRev; got != want {
+				t.Errorf("ListEntryHistory().Rev: %v, want %v", got, want)
 			}
 		})
 	}


### PR DESCRIPTION
One of the first things the KeyTransparency sequencer does when initializing a fresh domain (Trillian Log / Map pair), is to put the Map's initial 0'th SignedMapHead into the Log at index 0.  This establishes the 1:1 relationship between Map revisions and the Log indexes at which they must be stored.  If this, however, does not occur, it causes follow on errors that would be nice to catch in a single place. 

Secondly, because clients verify that `SignedMapHead`s are included in the Trillian Log, the key server must not serve any data from a Map revision (SMH) that the Log has not sequenced and signed yet. The `SignedLogRoot` (STH) is effectively the source of truth for what map revision to serve. This was not accurately implemented in `GetEpochHistory` which was using the latest SMH rather than STH as it's source of truth for the `currentEpoch`. 

This PR refactors a few functions in `keyserver.go` to 
- Clearly define the latest SignedLogRoot as the source of truth for the latest map revision. 
- Establish a single code path for both retrieving the `currentEpoch` and verifying that it meets our initialized expectations.  