### PR TITLE
Intelligent Update strategy: replace blind Retry with WaitForSTH

### DIFF
--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -88,7 +88,6 @@ User email MUST match the OAuth account used to authorize the update.
 		if err != nil {
 			return fmt.Errorf("updateKeys() failed: %v", err)
 		}
-		// TODO: fill signers and authorizedKeys.
 		u := &tpb.User{
 			DomainId:       viper.GetString("domain"),
 			AppId:          appID,

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	tpb "github.com/google/keytransparency/core/api/type/type_proto"
 )
 
 var (
@@ -87,7 +89,14 @@ User email MUST match the OAuth account used to authorize the update.
 			return fmt.Errorf("updateKeys() failed: %v", err)
 		}
 		// TODO: fill signers and authorizedKeys.
-		if _, err := c.Update(ctx, userID, appID, profileData, signers, authorizedKeys); err != nil {
+		u := &tpb.User{
+			DomainId:       viper.GetString("domain"),
+			AppId:          appID,
+			UserId:         userID,
+			PublicKeyData:  profileData,
+			AuthorizedKeys: authorizedKeys,
+		}
+		if _, err := c.Update(ctx, u, signers); err != nil {
 			return fmt.Errorf("update failed: %v", err)
 		}
 		fmt.Printf("New key for %v: %x\n", userID, data)

--- a/core/client/grpcc/get_and_verify.go
+++ b/core/client/grpcc/get_and_verify.go
@@ -1,0 +1,39 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcc
+
+import (
+	"context"
+
+	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
+)
+
+// VerifiedGetEntry fetches and verifies the results of GetEntry.
+func (c *Client) VerifiedGetEntry(ctx context.Context, appID, userID string) (*pb.GetEntryResponse, error) {
+	e, err := c.cli.GetEntry(ctx, &pb.GetEntryRequest{
+		DomainId:      c.domainID,
+		UserId:        userID,
+		AppId:         appID,
+		FirstTreeSize: c.trusted.TreeSize,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.kt.VerifyGetEntryResponse(ctx, c.domainID, appID, userID, &c.trusted, e); err != nil {
+		return nil, err
+	}
+	return e, nil
+}

--- a/core/client/grpcc/grpc_client.go
+++ b/core/client/grpcc/grpc_client.go
@@ -229,17 +229,18 @@ func (c *Client) Update(ctx context.Context, u *tpb.User, signers []signatures.S
 	if got, want := u.DomainId, c.domainID; got != want {
 		return nil, fmt.Errorf("u.DomainID: %v, want %v", got, want)
 	}
-	// 1. pb.User + ExistingEntry -> Mutation
+	// 1. pb.User + ExistingEntry -> Mutation.
 	m, err := c.newMutation(ctx, u)
 	if err != nil {
 		return nil, err
 	}
 
+	// 2. Queue Mutation.
 	if err := c.QueueMutation(ctx, m, signers); err != nil {
 		return nil, err
 	}
 
-	// 3. Wait for update
+	// 3. Wait for update.
 	m, err = c.WaitForUserUpdate(ctx, m)
 	for i := 0; i < c.RetryCount; i++ {
 		switch err {

--- a/core/client/grpcc/grpc_client.go
+++ b/core/client/grpcc/grpc_client.go
@@ -35,12 +35,15 @@ import (
 
 	"github.com/google/trillian"
 	"github.com/google/trillian/client"
+	"github.com/google/trillian/client/backoff"
 	"github.com/google/trillian/crypto/keys/der"
-	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/merkle/hashers"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	tpb "github.com/google/keytransparency/core/api/type/type_proto"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
 )
 
@@ -53,10 +56,15 @@ const (
 )
 
 var (
-	// ErrRetry occurs when an update request has been submitted, but the
-	// results of the update are not visible on the server yet. The client
-	// must retry until the request is visible.
-	ErrRetry = errors.New("update not present on server yet")
+	// ErrRetry occurs when an update has been queued, but the
+	// results of the update differ from the one requested.
+	// This indicates that a separate update was in-flight while
+	// this update was being submitted. To continue, the client
+	// should make a fresh update and try again.
+	ErrRetry = errors.New("client: update race condition - try again")
+	// ErrWait occurs when an update has been queued, but no change has been
+	// observed in the user's account yet.
+	ErrWait = errors.New("client: update not present yet - wait some more")
 	// ErrIncomplete occurs when the server indicates that requested epochs
 	// are not available.
 	ErrIncomplete = errors.New("incomplete account history")
@@ -142,20 +150,10 @@ func New(ktClient pb.KeyTransparencyClient,
 
 // GetEntry returns an entry if it exists, and nil if it does not.
 func (c *Client) GetEntry(ctx context.Context, userID, appID string, opts ...grpc.CallOption) ([]byte, *trillian.SignedMapRoot, error) {
-	e, err := c.cli.GetEntry(ctx, &pb.GetEntryRequest{
-		DomainId:      c.domainID,
-		UserId:        userID,
-		AppId:         appID,
-		FirstTreeSize: c.trusted.TreeSize,
-	}, opts...)
+	e, err := c.VerifiedGetEntry(ctx, appID, userID)
 	if err != nil {
 		return nil, nil, err
 	}
-
-	if err := c.kt.VerifyGetEntryResponse(ctx, c.domainID, appID, userID, &c.trusted, e); err != nil {
-		return nil, nil, err
-	}
-
 	// Empty case.
 	if e.GetCommitted() == nil {
 		return nil, e.GetSmr(), nil
@@ -225,70 +223,162 @@ func (c *Client) ListHistory(ctx context.Context, userID, appID string, start, e
 	return profiles, nil
 }
 
-// Update creates an UpdateEntryRequest for a user, attempt to submit it multiple
-// times depending on RetryCount.
-func (c *Client) Update(ctx context.Context, appID, userID string, profileData []byte,
-	signers []signatures.Signer, authorizedKeys []*keyspb.PublicKey,
-	opts ...grpc.CallOption) (*entry.Mutation, error) {
-	getResp, err := c.cli.GetEntry(ctx, &pb.GetEntryRequest{
-		DomainId:      c.domainID,
-		UserId:        userID,
-		AppId:         appID,
-		FirstTreeSize: c.trusted.TreeSize,
-	}, opts...)
+// Update creates an UpdateEntryRequest for a user,
+// attempt to submit it multiple times depending on RetryCount.
+func (c *Client) Update(ctx context.Context, u *tpb.User, signers []signatures.Signer) (*entry.Mutation, error) {
+	if got, want := u.DomainId, c.domainID; got != want {
+		return nil, fmt.Errorf("u.DomainID: %v, want %v", got, want)
+	}
+	// 1. pb.User + ExistingEntry -> Mutation
+	m, err := c.newMutation(ctx, u)
 	if err != nil {
-		return nil, fmt.Errorf("GetEntry(%v): %v", userID, err)
-	}
-	Vlog.Printf("Got current entry...")
-
-	if err := c.kt.VerifyGetEntryResponse(ctx, c.domainID, appID, userID, &c.trusted, getResp); err != nil {
-		return nil, fmt.Errorf("VerifyGetEntryResponse(): %v", err)
+		return nil, err
 	}
 
-	m, err := c.kt.NewMutation(c.domainID, appID, userID, profileData, authorizedKeys,
-		getResp.GetVrfProof(), getResp.GetLeafProof().GetLeaf().GetLeafValue())
-	if err != nil {
-		return nil, fmt.Errorf("CreateUpdateEntryRequest: %v", err)
+	if err := c.QueueMutation(ctx, m, signers); err != nil {
+		return nil, err
 	}
 
-	err = c.Retry(ctx, m, signers, opts...)
-	// Retry submitting until an inclusion proof is returned.
-	for i := 0; err == ErrRetry && i < c.RetryCount; i++ {
-		time.Sleep(c.RetryDelay)
-		err = c.Retry(ctx, m, signers, opts...)
+	// 3. Wait for update
+	m, err = c.WaitForUserUpdate(ctx, m)
+	for i := 0; i < c.RetryCount; i++ {
+		switch err {
+		case ErrWait:
+			// Try again.
+		case ErrRetry:
+			if err := c.QueueMutation(ctx, m, signers); err != nil {
+				return nil, err
+			}
+		default:
+			return m, err
+		}
+		m, err = c.WaitForUserUpdate(ctx, m)
 	}
 	return m, err
 }
 
-// Retry takes take a mutation, signs, and sends it again, and updates the back pointer with the current leaf value.
-func (c *Client) Retry(ctx context.Context, m *entry.Mutation, signers []signatures.Signer, opts ...grpc.CallOption) error {
-	req, err := m.SerializeAndSign(signers, c.trusted.TreeSize)
+// QueueMutation signs m and sends it to the server.
+func (c *Client) QueueMutation(ctx context.Context, m *entry.Mutation, signers []signatures.Signer) error {
+	req, err := m.SerializeAndSign(signers, c.trusted.GetTreeSize())
 	if err != nil {
 		return fmt.Errorf("SerializeAndSign(): %v", err)
 	}
 
 	Vlog.Printf("Sending Update request...")
-	updateResp, err := c.cli.UpdateEntry(ctx, req, opts...)
+	// 2. Queue Mutation
+	_, err = c.cli.UpdateEntry(ctx, req)
+	return err
+}
+
+// newMutation fetches the current index and value for a user and prepares a mutation.
+func (c *Client) newMutation(ctx context.Context, u *tpb.User) (*entry.Mutation, error) {
+	e, err := c.VerifiedGetEntry(ctx, u.AppId, u.UserId)
 	if err != nil {
-		return fmt.Errorf("cli.UpdateEntry(): %v", err)
+		return nil, err
+	}
+	oldLeaf := e.GetLeafProof().GetLeaf().GetLeafValue()
+	Vlog.Printf("Got current entry...")
+
+	index, err := c.kt.Index(e.GetVrfProof(), u.DomainId, u.AppId, u.UserId)
+	if err != nil {
+		return nil, err
+	}
+
+	mutation := entry.NewMutation(index, u.DomainId, u.AppId, u.UserId)
+
+	if err := mutation.SetPrevious(oldLeaf, true); err != nil {
+		return nil, err
+	}
+
+	if err := mutation.SetCommitment(u.PublicKeyData); err != nil {
+		return nil, err
+	}
+
+	if len(u.AuthorizedKeys) != 0 {
+		if err := mutation.ReplaceAuthorizedKeys(u.AuthorizedKeys); err != nil {
+			return nil, err
+		}
+	}
+
+	return mutation, nil
+}
+
+// WaitForUserUpdate waits for the STH to be updated, indicating the next epoch has been created,
+// it then queries the current value for the user and checks it against the requested mutation.
+// If the current value has not changed, WaitForUpdate returns ErrWaitSomeMore.
+// If the current value has changed, but does not match the requested mutation,
+// WaitForUpdate returns a new mutation, built with the current value and ErrRetry.
+// If the current value matches the request, no mutation and no error are returned.
+func (c *Client) WaitForUserUpdate(ctx context.Context, m *entry.Mutation) (*entry.Mutation, error) {
+	sth := &c.trusted
+	// Wait for STH to change.
+	if err := c.WaitForSTHUpdate(ctx, sth); err != nil {
+		return nil, err
+	}
+
+	// GetEntry.
+	e, err := c.VerifiedGetEntry(ctx, m.AppID, m.UserID)
+	if err != nil {
+		return nil, err
 	}
 	Vlog.Printf("Got current entry...")
 
-	// Validate response.
-	if err := c.kt.VerifyGetEntryResponse(ctx, c.domainID, req.AppId, req.UserId, &c.trusted, updateResp.GetProof()); err != nil {
-		return fmt.Errorf("VerifyGetEntryResponse(): %v", err)
+	// Verify.
+	cntLeaf := e.GetLeafProof().GetLeaf().GetLeafValue()
+	cntValue, err := entry.FromLeafValue(cntLeaf)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case m.EqualsRequested(cntValue):
+		return nil, nil
+	case m.EqualsPrevious(cntValue):
+		return m, ErrWait
+	default:
+		// Race condition: some change got in first.
+		// Value has changed, but it's not what we asked for.
+		// Retry based on new cnt value.
+
+		// To break the tie between two devices that are fighting
+		// each other, this error should be propogated back to the user.
+		copyPreviousLeafData := false
+		if err := m.SetPrevious(cntLeaf, copyPreviousLeafData); err != nil {
+			return nil, fmt.Errorf("waitforupdate: SetPrevious(): %v", err)
+		}
+		return m, errors.New("client: update race condition - try again")
+	}
+}
+
+// WaitForSTHUpdate blocks until the log root reported by the server has moved
+// beyond sth or times out.
+func (c *Client) WaitForSTHUpdate(ctx context.Context, sth *trillian.SignedLogRoot) error {
+	b := &backoff.Backoff{
+		Min:    100 * time.Millisecond,
+		Max:    10 * time.Second,
+		Factor: 1.2,
+		Jitter: true,
 	}
 
-	cntLeaf := updateResp.GetProof().GetLeafProof().GetLeaf().GetLeafValue()
-	equal, err := m.Check(cntLeaf)
-	if err != nil {
-		return fmt.Errorf("mutation.Check(): %v", err)
+	for {
+		select {
+		case <-time.After(b.Duration()):
+			resp, err := c.cli.GetLatestEpoch(ctx, &pb.GetLatestEpochRequest{
+				DomainId:      c.domainID,
+				FirstTreeSize: sth.TreeSize,
+			})
+			if err != nil {
+				return err
+			}
+			if resp.GetLogRoot().TreeSize <= sth.TreeSize {
+				// The LogRoot is not updated yet.
+				// Wait some more.
+				continue
+			}
+			return nil // We're done!
+
+		case <-ctx.Done():
+			return status.Errorf(codes.DeadlineExceeded,
+				"Timed out waiting for sth update: %v", ctx.Err())
+		}
 	}
-	if err := m.SetPrevious(cntLeaf, false); err != nil {
-		return fmt.Errorf("mutation.SetPrevious(): %v", err)
-	}
-	if !equal {
-		return ErrRetry
-	}
-	return nil
 }

--- a/core/client/kt/requests.go
+++ b/core/client/kt/requests.go
@@ -19,44 +19,14 @@ import (
 	"fmt"
 
 	"github.com/google/keytransparency/core/crypto/vrf"
-	"github.com/google/keytransparency/core/mutator/entry"
-	"github.com/google/trillian/crypto/keyspb"
 )
 
-func (v *Verifier) index(vrfProof []byte, domainID, appID, userID string) ([]byte, error) {
+// Index computes the index from a VRF proof.
+func (v *Verifier) Index(vrfProof []byte, domainID, appID, userID string) ([]byte, error) {
 	uid := vrf.UniqueID(userID, appID)
 	index, err := v.vrf.ProofToHash(uid, vrfProof)
 	if err != nil {
 		return nil, fmt.Errorf("vrf.ProofToHash(%v, %v): %v", appID, userID, err)
 	}
 	return index[:], nil
-}
-
-// NewMutation creates a Mutation given the userID, desired state, and previous entry.
-func (v *Verifier) NewMutation(
-	domainID, appID, userID string,
-	profileData []byte, authorizedKeys []*keyspb.PublicKey,
-	vrfProof, oldLeaf []byte) (
-	*entry.Mutation, error) {
-
-	index, err := v.index(vrfProof, domainID, appID, userID)
-	if err != nil {
-		return nil, err
-	}
-	mutation := entry.NewMutation(index, domainID, appID, userID)
-	if err := mutation.SetPrevious(oldLeaf, true); err != nil {
-		return nil, err
-	}
-
-	if err := mutation.SetCommitment(profileData); err != nil {
-		return nil, err
-	}
-
-	if len(authorizedKeys) != 0 {
-		if err := mutation.ReplaceAuthorizedKeys(authorizedKeys); err != nil {
-			return nil, err
-		}
-	}
-
-	return mutation, nil
 }

--- a/core/client/kt/verify.go
+++ b/core/client/kt/verify.go
@@ -93,7 +93,7 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, domainID, appID, 
 	}
 	Vlog.Printf("✓ Commitment verified.")
 
-	index, err := v.index(in.GetVrfProof(), domainID, appID, userID)
+	index, err := v.Index(in.GetVrfProof(), domainID, appID, userID)
 	if err != nil {
 		Vlog.Printf("✗ VRF verification failed.")
 		return err

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -94,13 +94,8 @@ func TestCreateAndVerify(t *testing.T) {
 			continue
 		}
 
-		newLeaf, err := ToLeafValue(newEntry)
-		if err != nil {
-			t.Errorf("ToLeafValue(): %v", err)
-			continue
-		}
-		if equal, err := m.Check(newLeaf); err != nil || !equal {
-			t.Errorf("Check(): %v, %v", equal, err)
+		if !m.EqualsRequested(newEntry) {
+			t.Errorf("EqualsRequested(): false")
 		}
 	}
 }

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -162,7 +162,6 @@ func NewEnv() (*Env, error) {
 	}
 	ktClient := pb.NewKeyTransparencyClient(cc)
 	client := grpcc.New(ktClient, domainID, vrfPub, mapPubKey, coniks.Default, fake.NewFakeTrillianLogVerifier())
-	client.RetryCount = 0
 
 	return &Env{
 		Env: &integration.Env{


### PR DESCRIPTION
This PR supports reliable testing and more efficient bandwidth usage.
Rather than blindly re-sending the UpdateEntryRequest every few seconds
until the change is observed, this commit adopts a slightly more
intelligent strategy:
1. Observe current SignedLogRoot
2. Queue update request
3. Wait for a new epoch to be created
4. Query the user's account
5. Compare against the desired state.
   a. Wait some more
   b. Recreate request and try again
   c. Do nothing, it worked :-)

This strategy is more accomadating to non-determinism in the Log.
Because we wait for concrete state changes, we can be confident of what
the resulting values should or should not be, making testing feasible.