### PR TITLE
Use a real Trillian Log in integration tests!

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -174,11 +174,11 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 	// Generate VRF key.
 	wrapped, err := s.keygen(ctx, vrfKeySpec)
 	if err != nil {
-		return nil, fmt.Errorf("keygen: %v", err)
+		return nil, fmt.Errorf("adminserver: keygen(): %v", err)
 	}
 	vrfPriv, err := p256.NewFromWrappedKey(ctx, wrapped)
 	if err != nil {
-		return nil, fmt.Errorf("NewFromWrappedKey(): %v", err)
+		return nil, fmt.Errorf("adminserver: NewFromWrappedKey(): %v", err)
 	}
 	vrfPublicPB, err := der.ToPublicProto(vrfPriv.Public())
 	if err != nil {
@@ -190,26 +190,26 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 	logTreeArgs.Tree.Description = fmt.Sprintf("KT domain %s's SMH Log", in.GetDomainId())
 	logTree, err := client.CreateAndInitTree(ctx, &logTreeArgs, s.logAdmin, s.tmap, s.tlog)
 	if err != nil {
-		return nil, fmt.Errorf("CreateTree(log): %v", err)
+		return nil, fmt.Errorf("adminserver: CreateTree(log): %v", err)
 	}
 	mapTreeArgs := *mapArgs
 	mapTreeArgs.Tree.Description = fmt.Sprintf("KT domain %s's Map", in.GetDomainId())
 	mapTree, err := client.CreateAndInitTree(ctx, &mapTreeArgs, s.mapAdmin, s.tmap, s.tlog)
 	if err != nil {
-		return nil, fmt.Errorf("CreateAndInitTree(map): %v", err)
+		return nil, fmt.Errorf("adminserver: CreateAndInitTree(map): %v", err)
 	}
 	minInterval, err := ptypes.Duration(in.MinInterval)
 	if err != nil {
-		return nil, fmt.Errorf("Duration(%v): %v", in.MinInterval, err)
+		return nil, fmt.Errorf("adminserver: Duration(%v): %v", in.MinInterval, err)
 	}
 	maxInterval, err := ptypes.Duration(in.MaxInterval)
 	if err != nil {
-		return nil, fmt.Errorf("Duration(%v): %v", in.MaxInterval, err)
+		return nil, fmt.Errorf("adminserver: Duration(%v): %v", in.MaxInterval, err)
 	}
 
 	// Initialize log with first map root.
 	if err := s.initialize(ctx, logTree, mapTree); err != nil {
-		return nil, fmt.Errorf("initialize of log %v and map %v failed: %v",
+		return nil, fmt.Errorf("adminserver: initialize of log %v and map %v failed: %v",
 			logTree.TreeId, mapTree.TreeId, err)
 	}
 
@@ -222,7 +222,7 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 		MinInterval: minInterval,
 		MaxInterval: maxInterval,
 	}); err != nil {
-		return nil, fmt.Errorf("adminstorage.Write(): %v", err)
+		return nil, fmt.Errorf("adminserver: domains.Write(): %v", err)
 	}
 	glog.Infof("Created domain %v", in.GetDomainId())
 	return &pb.Domain{
@@ -242,7 +242,7 @@ func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) err
 
 	logClient, err := client.NewFromTree(s.tlog, logTree)
 	if err != nil {
-		return fmt.Errorf("could not create log client: %v", err)
+		return fmt.Errorf("adminserver: could not create log client: %v", err)
 	}
 
 	// Wait for the latest log root to become available.
@@ -255,7 +255,7 @@ func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) err
 	mapRoot, err := s.tmap.GetSignedMapRoot(ctx,
 		&tpb.GetSignedMapRootRequest{MapId: mapID})
 	if err != nil {
-		return fmt.Errorf("GetSignedMapRoot(%v): %v", mapID, err)
+		return fmt.Errorf("adminserver: GetSignedMapRoot(%v): %v", mapID, err)
 	}
 
 	// If the tree is empty and the map is empty,
@@ -273,7 +273,7 @@ func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) err
 	}
 
 	if err := logClient.AddLeaf(ctx, smrJSON); err != nil {
-		return fmt.Errorf("trillianLog.AddLeaf(): %v", err)
+		return fmt.Errorf("adminserver: log.AddLeaf(): %v", err)
 	}
 	return nil
 }

--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -50,9 +50,16 @@ func TestCreateRead(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create trillian map server: %v", err)
 	}
-	tlog := fake.NewTrillianLogClient()
 
-	svr := New(tlog, mapEnv.Map, mapEnv.Admin, mapEnv.Admin, storage, vrfKeyGen)
+	// Log server
+	numSequencers := 1
+	unused := ""
+	logEnv, err := integration.NewLogEnv(ctx, numSequencers, unused)
+	if err != nil {
+		t.Fatalf("Failed to create trillian log server: %v", err)
+	}
+
+	svr := New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin, storage, vrfKeyGen)
 
 	for _, tc := range []struct {
 		domainID                 string

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -284,7 +284,7 @@ func (c *Client) newMutation(ctx context.Context, u *tpb.User) (*entry.Mutation,
 	return mutation, nil
 }
 
-// WaitForUserUpdate repeately waits for the mutation to be applied.
+// WaitForUserUpdate waits for the mutation to be applied or the context to timeout or cancel.
 func (c *Client) WaitForUserUpdate(ctx context.Context, m *entry.Mutation) (*entry.Mutation, error) {
 	for {
 		m, err := c.waitOnceForUserUpdate(ctx, m)
@@ -349,9 +349,15 @@ func (c *Client) waitOnceForUserUpdate(ctx context.Context, m *entry.Mutation) (
 	}
 }
 
+// sthForRevision returns the minimum STH.TreeSize that will contain the map revision.
+// Map revision N is stored at Log index N, the minimum TreeSize will be N+1.
+func sthForRevision(revision int64) int64 {
+	return revision + 1
+}
+
 // WaitForRevision waits until a given map revision is available.
 func (c *Client) WaitForRevision(ctx context.Context, revision int64) error {
-	return c.WaitForSTHUpdate(ctx, revision+1)
+	return c.WaitForSTHUpdate(ctx, sthForRevision(revision))
 }
 
 // WaitForSTHUpdate blocks until the log root reported by the server has moved

--- a/core/client/get_and_verify.go
+++ b/core/client/get_and_verify.go
@@ -17,6 +17,7 @@ package client
 import (
 	"context"
 
+	"github.com/golang/glog"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
 )
 
@@ -36,6 +37,7 @@ func (c *Client) VerifiedGetEntry(ctx context.Context, appID, userID string) (*p
 		return nil, err
 	}
 	c.trusted = *e.GetLogRoot()
+	glog.Infof("VerifiedGetEntry: Trusted root updated to TreeSize %v", c.trusted.TreeSize)
 	Vlog.Printf("✓ Log root updated.")
 
 	return e, nil

--- a/core/fake/trillian_log_client.go
+++ b/core/fake/trillian_log_client.go
@@ -101,3 +101,13 @@ func (l *LogServer) InitLog(ctx context.Context, in *tpb.InitLogRequest, opts ..
 	l.TreeSize = 0
 	return &tpb.InitLogResponse{}, nil
 }
+
+// AddSequencedLeaf adds a single leaf with an assigned sequence number.
+func (l *LogServer) AddSequencedLeaf(ctx context.Context, in *tpb.AddSequencedLeafRequest, opts ...grpc.CallOption) (*tpb.AddSequencedLeafResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "")
+}
+
+// AddSequencedLeaves Adds a batch of leaves with assigned sequence numbers to the tree.
+func (l *LogServer) AddSequencedLeaves(ctx context.Context, in *tpb.AddSequencedLeavesRequest, opts ...grpc.CallOption) (*tpb.AddSequencedLeavesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "")
+}

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -181,7 +181,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Check profile.
-			if err := env.checkProfile(tc.userID, appID, tc.want); err != nil {
+			if err := env.checkProfile(ctx, tc.userID, appID, tc.want); err != nil {
 				t.Errorf("checkProfile(%v, %v) failed: %v", tc.userID, tc.want, err)
 			}
 			// Update profile.
@@ -210,8 +210,8 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 
 // checkProfile ensures that the returned profile is as expected along with the
 // keys it carries.
-func (e *Env) checkProfile(userID, appID string, want bool) error {
-	profile, _, err := e.Client.GetEntry(context.Background(), userID, appID)
+func (e *Env) checkProfile(ctx context.Context, userID, appID string, want bool) error {
+	profile, _, err := e.Client.GetEntry(ctx, userID, appID)
 	if err != nil {
 		return fmt.Errorf("GetEntry(%v): %v, want nil", userID, err)
 	}

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/google/keytransparency/core/authentication"
-	"github.com/google/keytransparency/core/client"
 	"github.com/google/keytransparency/core/crypto/dev"
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/crypto/signatures/factory"
@@ -201,7 +200,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 				}
 				env.Receiver.Flush(tc.ctx)
 				if _, err := env.Client.WaitForUserUpdate(tc.ctx, m); err != nil {
-					t.Errorf("Retry(%v): %v, want nil", m, err)
+					t.Errorf("WaitForUserUpdate(%v): %v, want nil", m, err)
 				}
 			}
 		})
@@ -265,10 +264,10 @@ func TestUpdateValidation(ctx context.Context, env *Env, t *testing.T) {
 			}
 			env.Receiver.Flush(tc.ctx)
 			if _, err := env.Client.WaitForUserUpdate(tc.ctx, m); err != nil {
-				t.Errorf("Retry(%v): %v, want nil", m, err)
+				t.Errorf("WaitForUserUpdate(): %v, want nil", err)
 			}
 		} else {
-			if got, want := err, client.ErrWait; got == want {
+			if got, want := err, context.DeadlineExceeded; got == want {
 				t.Fatalf("Update(%v): %v, don't want %v", tc.userID, got, want)
 			}
 		}
@@ -329,9 +328,9 @@ func (e *Env) setupHistory(ctx context.Context, domain *pb.Domain, userID string
 	// that the user is submitting. The user profile history contains the
 	// following profiles:
 	// Profile Value: err nil 1  2  2  2  3  3  4  5  5 5 5 5 5 6 6 5 7 7
-	// Map Revision:  0  1  2  3  4  5  6  7  8  9  10 ...
-	// Log Max Index: 0  1  2  3  4  5  6  7  8  9  10 ...
-	// Log TreeSize:  0  1  2  3  4  5  6  7  8  9  10 ...
+	// Map Revision:  1  2  3  4  5  6  7  8  9  10 ...
+	// Log Max Index: 1  2  3  4  5  6  7  8  9  10 ...
+	// Log TreeSize:  2  3  4  5  6  7  8  9  10 11 ...
 	// Note that profile 5 is submitted twice by the user to test that
 	// filtering case.
 	for i, p := range [][]byte{
@@ -350,11 +349,18 @@ func (e *Env) setupHistory(ctx context.Context, domain *pb.Domain, userID string
 			cctx, cancel := context.WithTimeout(ctx, updateTimeout)
 			defer cancel()
 			// The first update response is always a retry.
-			if _, err := e.Client.Update(cctx, u, signers); err != context.DeadlineExceeded {
+			m, err := e.Client.Update(cctx, u, signers)
+			if err != context.DeadlineExceeded {
 				return fmt.Errorf("Update(%v, %v): %v, want %v", userID, i, err, context.DeadlineExceeded)
 			}
+			e.Receiver.Flush(ctx)
+			if _, err := e.Client.WaitForUserUpdate(ctx, m); err != nil {
+				return fmt.Errorf("WaitForUserUpdate(%v): %v, want nil", m, err)
+			}
+		} else {
+			// Create an empty epoch.
+			e.Receiver.Flush(ctx)
 		}
-		e.Receiver.Flush(ctx)
 	}
 	return nil
 }

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -119,6 +119,9 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 		}
 
 		env.Receiver.Flush(ctx)
+		if err := env.Client.WaitForRevision(ctx, tc.queryEpoch); err != nil {
+			t.Fatalf("WaitForRevision(): %v", err)
+		}
 
 		domainID := env.Domain.DomainId
 		cctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)

--- a/core/keyserver/epochs.go
+++ b/core/keyserver/epochs.go
@@ -180,6 +180,9 @@ func (s *Server) logProofs(ctx context.Context, d *domain.Domain, firstTreeSize 
 
 	// Inclusion proof.
 	secondTreeSize := logRoot.GetTreeSize()
+	if epoch >= secondTreeSize {
+		return nil, status.Errorf(codes.NotFound, "keyserver: Epoch %v has not been released yet", epoch)
+	}
 	logInclusion, err := s.tlog.GetInclusionProof(ctx,
 		&tpb.GetInclusionProofRequest{
 			LogId: d.LogID,

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -83,7 +83,7 @@ func vrfKeyGen(ctx context.Context, spec *keyspb.Specification) (proto.Message, 
 // NewEnv sets up common resources for tests.
 func NewEnv() (*Env, error) {
 	ctx := context.Background()
-	domainID := fmt.Sprintf("domain %d", rand.Int()) // nolint: gas
+	domainID := fmt.Sprintf("domain_%d", rand.Int()) // nolint: gas
 	db, err := testdb.New(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("env: failed to open database: %v", err)

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc"
+
 	"github.com/google/keytransparency/core/adminserver"
 	"github.com/google/keytransparency/core/authentication"
 	"github.com/google/keytransparency/core/client"
@@ -34,23 +36,19 @@ import (
 	"github.com/google/keytransparency/core/mutator"
 	"github.com/google/keytransparency/core/mutator/entry"
 	"github.com/google/keytransparency/core/sequencer"
-
 	"github.com/google/keytransparency/impl/authorization"
 	"github.com/google/keytransparency/impl/sql/domain"
 	"github.com/google/keytransparency/impl/sql/mutationstorage"
-
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/storage/testdb"
-
-	"google.golang.org/grpc"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
 	domaindef "github.com/google/keytransparency/core/domain"
 	tclient "github.com/google/trillian/client"
 	_ "github.com/google/trillian/merkle/coniks"    // Register hasher
 	_ "github.com/google/trillian/merkle/objhasher" // Register hasher
-	maptest "github.com/google/trillian/testonly/integration"
+	ttest "github.com/google/trillian/testonly/integration"
 	_ "github.com/mattn/go-sqlite3" // Use sqlite database for testing.
 )
 
@@ -71,7 +69,8 @@ func Listen() (string, net.Listener, error) {
 // Env holds a complete testing environment for end-to-end tests.
 type Env struct {
 	*integration.Env
-	mapEnv     *maptest.MapEnv
+	mapEnv     *ttest.MapEnv
+	logEnv     *ttest.LogEnv
 	grpcServer *grpc.Server
 	grpcCC     *grpc.ClientConn
 	db         *sql.DB
@@ -91,19 +90,25 @@ func NewEnv() (*Env, error) {
 	}
 
 	// Map server
-	mapEnv, err := maptest.NewMapEnv(ctx)
+	mapEnv, err := ttest.NewMapEnv(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("env: failed to create trillian map server: %v", err)
 	}
 
-	tlog := fake.NewTrillianLogClient()
+	// Log server
+	numSequencers := 1
+	unused := ""
+	logEnv, err := ttest.NewLogEnv(ctx, numSequencers, unused)
+	if err != nil {
+		return nil, fmt.Errorf("env: failed to create trillian log server: %v", err)
+	}
 
 	// Configure domain, which creates new map and log trees.
 	domainStorage, err := domain.NewStorage(db)
 	if err != nil {
 		return nil, fmt.Errorf("env: failed to create domain storage: %v", err)
 	}
-	adminSvr := adminserver.New(tlog, mapEnv.Map, mapEnv.Admin, mapEnv.Admin, domainStorage, vrfKeyGen)
+	adminSvr := adminserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin, domainStorage, vrfKeyGen)
 	domainPB, err := adminSvr.CreateDomain(ctx, &pb.CreateDomainRequest{
 		DomainId:    domainID,
 		MinInterval: ptypes.DurationProto(1 * time.Second),
@@ -113,8 +118,6 @@ func NewEnv() (*Env, error) {
 		return nil, fmt.Errorf("env: CreateDomain(): %v", err)
 	}
 
-	mapID := domainPB.Map.TreeId
-	logID := domainPB.Log.TreeId
 	vrfPub, err := p256.NewVRFVerifierFromRawKey(domainPB.Vrf.GetDer())
 	if err != nil {
 		return nil, fmt.Errorf("env: Failed to load vrf pubkey: %v", err)
@@ -129,18 +132,18 @@ func NewEnv() (*Env, error) {
 	authz := authorization.New()
 
 	queue := mutator.MutationQueue(mutations)
-	server := keyserver.New(tlog, mapEnv.Map, mapEnv.Admin, mapEnv.Admin,
+	server := keyserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin,
 		entry.New(), auth, authz, domainStorage, queue, mutations)
 	gsvr := grpc.NewServer()
 	pb.RegisterKeyTransparencyServer(gsvr, server)
 
 	// Sequencer
-	seq := sequencer.New(tlog, mapEnv.Map, entry.New(), domainStorage, mutations, queue)
+	seq := sequencer.New(logEnv.Log, mapEnv.Map, entry.New(), domainStorage, mutations, queue)
 	// Only sequence when explicitly asked with receiver.Flush()
 	d := &domaindef.Domain{
-		DomainID: domainID,
-		LogID:    logID,
-		MapID:    mapID,
+		DomainID: domainPB.DomainId,
+		LogID:    domainPB.Log.TreeId,
+		MapID:    domainPB.Map.TreeId,
 	}
 	receiver := seq.NewReceiver(ctx, d, 60*time.Hour, 60*time.Hour)
 	receiver.Flush(ctx)
@@ -172,6 +175,7 @@ func NewEnv() (*Env, error) {
 			Receiver: receiver,
 		},
 		mapEnv:     mapEnv,
+		logEnv:     logEnv,
 		grpcServer: gsvr,
 		grpcCC:     cc,
 		db:         db,
@@ -183,5 +187,6 @@ func (env *Env) Close() {
 	env.grpcCC.Close()
 	env.grpcServer.Stop()
 	env.mapEnv.Close()
+	env.logEnv.Close()
 	env.db.Close()
 }


### PR DESCRIPTION
Diffbase #917 

The current strategy of using a fake.TrillianLogClient was being a bit _too_ predictable.
By using a real Trillian Log, we uncovered a number of timing and correctness issues.
This is the last of the fixes to use the real `LogEnv`. woohoo! 