### PR TITLE
Use separate log and map admin connections in the keyserver

### DIFF
--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -115,11 +115,12 @@ func main() {
 	}
 	tlog := trillian.NewTrillianLogClient(tconn)
 	tmap := trillian.NewTrillianMapClient(mconn)
-	tadmin := trillian.NewTrillianAdminClient(mconn)
+	logAdmin := trillian.NewTrillianAdminClient(tconn)
+	mapAdmin := trillian.NewTrillianAdminClient(mconn)
 
 	// Create gRPC server.
 	queue := mutator.MutationQueue(mutations)
-	ksvr := keyserver.New(tlog, tmap, tadmin,
+	ksvr := keyserver.New(tlog, tmap, logAdmin, mapAdmin,
 		entry.New(), auth, authz, domains, queue, mutations)
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -132,7 +132,7 @@ func NewEnv() (*Env, error) {
 	tlog := fake.NewTrillianLogClient()
 
 	queue := mutator.MutationQueue(mutations)
-	server := keyserver.New(tlog, mapEnv.Map, mapEnv.Admin,
+	server := keyserver.New(tlog, mapEnv.Map, mapEnv.Admin, mapEnv.Admin,
 		entry.New(), auth, authz, domainStorage, queue, mutations)
 	gsvr := grpc.NewServer()
 	pb.RegisterKeyTransparencyServer(gsvr, server)


### PR DESCRIPTION
Trilian Logs and Trilian Maps have different Admin interfaces. 
This repipes the KT server to use the appropriate Admin interface for logs and maps.

The integration tests, however, at this time don't have a logEnv (coming soon), so we use mapEnv.Admin for both logs and maps temporarily. 