### PR TITLE
Use real Trillian verifier in integration tests

### DIFF
--- a/core/client/verify.go
+++ b/core/client/verify.go
@@ -126,7 +126,7 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, domainID, appID, 
 		return fmt.Errorf("json.Marshal(): %v", err)
 	}
 	logLeafIndex := in.GetSmr().GetMapRevision()
-	if err := v.logVerifier.VerifyInclusionAtIndex(&trusted, b, logLeafIndex,
+	if err := v.logVerifier.VerifyInclusionAtIndex(in.GetLogRoot(), b, logLeafIndex,
 		in.GetLogInclusion()); err != nil {
 		return fmt.Errorf("VerifyInclusionAtIndex(%s, %v, _): %v",
 			b, in.GetSmr().GetMapRevision(), err)

--- a/core/client/verify.go
+++ b/core/client/verify.go
@@ -117,7 +117,7 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, domainID, appID, 
 	// Verify consistency proof between root and newroot.
 	// TODO(gdbelvin): Gossip root.
 	if err := v.logVerifier.VerifyRoot(&trusted, in.GetLogRoot(), in.GetLogConsistency()); err != nil {
-		return fmt.Errorf("VerifyRoot(%v, %v): %v", in.GetLogRoot(), in.GetLogConsistency(), err)
+		return fmt.Errorf("logVerifier: VerifyRoot(%v, %v): %v", in.GetLogRoot(), in.GetLogConsistency(), err)
 	}
 
 	// Verify inclusion proof.
@@ -128,7 +128,7 @@ func (v *Verifier) VerifyGetEntryResponse(ctx context.Context, domainID, appID, 
 	logLeafIndex := in.GetSmr().GetMapRevision()
 	if err := v.logVerifier.VerifyInclusionAtIndex(in.GetLogRoot(), b, logLeafIndex,
 		in.GetLogInclusion()); err != nil {
-		return fmt.Errorf("VerifyInclusionAtIndex(%s, %v, _): %v",
+		return fmt.Errorf("logVerifier: VerifyInclusionAtIndex(%s, %v, _): %v",
 			b, in.GetSmr().GetMapRevision(), err)
 	}
 	Vlog.Printf("✓ Log inclusion proof verified.")

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -114,16 +114,16 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 		authorizedKeys []*keyspb.PublicKey
 	}{
 		{
-			desc:           "Empty",
+			desc:           "empty_alice",
 			wantProfile:    nil,
 			setProfile:     nil,
 			ctx:            context.Background(),
-			userID:         "noalice",
+			userID:         "alice",
 			signers:        signers1,
 			authorizedKeys: authorizedKeys1,
 		},
 		{
-			desc:           "Insert",
+			desc:           "bob0_set",
 			wantProfile:    nil,
 			setProfile:     []byte("bob-key1"),
 			ctx:            WithOutgoingFakeAuth(ctx, "bob"),
@@ -132,16 +132,16 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 			authorizedKeys: authorizedKeys1,
 		},
 		{
-			desc:           "Empty2",
+			desc:           "empty_carol",
 			wantProfile:    nil,
 			setProfile:     nil,
 			ctx:            context.Background(),
-			userID:         "nocarol",
+			userID:         "carol",
 			signers:        signers1,
 			authorizedKeys: authorizedKeys1,
 		},
 		{
-			desc:           "Not Empty",
+			desc:           "bob1_get",
 			wantProfile:    []byte("bob-key1"),
 			setProfile:     nil,
 			ctx:            context.Background(),
@@ -150,7 +150,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 			authorizedKeys: authorizedKeys1,
 		},
 		{
-			desc:           "Update",
+			desc:           "bob1_set",
 			wantProfile:    []byte("bob-key1"),
 			setProfile:     []byte("bob-key2"),
 			ctx:            WithOutgoingFakeAuth(ctx, "bob"),
@@ -159,7 +159,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 			authorizedKeys: authorizedKeys1,
 		},
 		{
-			desc:           "Update, changing keys",
+			desc:           "bob2_setkeys",
 			wantProfile:    []byte("bob-key2"),
 			setProfile:     []byte("bob-key3"),
 			ctx:            WithOutgoingFakeAuth(ctx, "bob"),
@@ -168,7 +168,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 			authorizedKeys: authorizedKeys2,
 		},
 		{
-			desc:           "Update, using new keys",
+			desc:           "bob3_setnewkeys",
 			wantProfile:    []byte("bob-key3"),
 			setProfile:     []byte("bob-key4"),
 			ctx:            WithOutgoingFakeAuth(ctx, "bob"),
@@ -179,12 +179,12 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			// Check profile.
-			profile, _, err := env.Client.GetEntry(ctx, tc.userID, appID)
+			e, err := env.Client.VerifiedGetEntry(ctx, appID, tc.userID)
 			if err != nil {
-				t.Errorf("GetEntry(%v): %v, want nil", tc.userID, err)
+				t.Errorf("VerifiedGetEntry(%v): %v, want nil", tc.userID, err)
 			}
-			if got, want := profile, tc.wantProfile; !bytes.Equal(got, want) {
-				t.Errorf("GetEntry(%v): %v, want %v", tc.userID, got, want)
+			if got, want := e.GetCommitted().GetData(), tc.wantProfile; !bytes.Equal(got, want) {
+				t.Errorf("VerifiedGetEntry(%v): %s, want %s", tc.userID, got, want)
 			}
 
 			// Update profile.


### PR DESCRIPTION
This change catches a bug in the client which was not using the correct root for inclusion proof verification.  

This PR 
 - Uses a full KT client configured directly from the domain proto.
 - Sets and checks unique values for the public keys in user accounts. 