### PR TITLE
 Don't fail silently when uninitialized 

### DIFF
--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -167,11 +167,13 @@ func NewEnv() (*Env, error) {
 	seq := sequencer.New(logEnv.Log, mapEnv.Map, entry.New(), domainStorage, mutations, queue)
 	// Only sequence when explicitly asked with receiver.Flush()
 	d := &domaindef.Domain{
-		DomainID: domainPB.DomainId,
-		LogID:    domainPB.Log.TreeId,
-		MapID:    domainPB.Map.TreeId,
+		DomainID:    domainPB.DomainId,
+		LogID:       domainPB.Log.TreeId,
+		MapID:       domainPB.Map.TreeId,
+		MinInterval: 60 * time.Hour,
+		MaxInterval: 60 * time.Hour,
 	}
-	receiver, err := seq.NewReceiver(ctx, d, 60*time.Hour, 60*time.Hour)
+	receiver, err := seq.NewReceiver(ctx, d)
 	if err != nil {
 		return nil, err
 	}

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -171,7 +171,10 @@ func NewEnv() (*Env, error) {
 		LogID:    domainPB.Log.TreeId,
 		MapID:    domainPB.Map.TreeId,
 	}
-	receiver := seq.NewReceiver(ctx, d, 60*time.Hour, 60*time.Hour)
+	receiver, err := seq.NewReceiver(ctx, d, 60*time.Hour, 60*time.Hour)
+	if err != nil {
+		return nil, err
+	}
 	receiver.Flush(ctx)
 
 	addr, lis, err := Listen()


### PR DESCRIPTION
Now that log and map initializtion are part of the admin server, this
check and quick-fix are no longer needed. If by this point the map
really is not setup, a serious error has occurred.

This PR also contains a few formatting cleanups. 