### PR TITLE
Fix/seq wait

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -90,7 +90,7 @@ func main() {
 	queue := mutator.MutationQueue(mutations)
 
 	// Create servers
-	signer := sequencer.New(tlog, tmap, entry.New(), domainStorage, mutations, queue)
+	signer := sequencer.New(tlog, logAdmin, tmap, entry.New(), domainStorage, mutations, queue)
 	keygen := func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 		return der.NewProtoFromSpec(spec)
 	}

--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -241,10 +241,12 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 	}
 	glog.Infof("Created domain %v", in.GetDomainId())
 	return &pb.Domain{
-		DomainId: in.GetDomainId(),
-		Log:      logTree,
-		Map:      mapTree,
-		Vrf:      vrfPublicPB,
+		DomainId:    in.GetDomainId(),
+		Log:         logTree,
+		Map:         mapTree,
+		Vrf:         vrfPublicPB,
+		MinInterval: in.MinInterval,
+		MaxInterval: in.MaxInterval,
 	}, nil
 }
 

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -316,5 +316,6 @@ func queueLogLeaf(ctx context.Context, logClient *tclient.LogClient, smr *tpb.Si
 		return err
 	}
 
+	// Queue the leaf and then wait until it has been sequenced and verified.
 	return logClient.AddLeaf(ctx, smrJSON)
 }

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -138,9 +138,10 @@ func NewEnv() (*Env, error) {
 	}
 	adminSvr := adminserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin, domainStorage, vrfKeyGen)
 	domainPB, err := adminSvr.CreateDomain(ctx, &pb.CreateDomainRequest{
-		DomainId:      domainID,
-		MinInterval:   ptypes.DurationProto(1 * time.Second),
-		MaxInterval:   ptypes.DurationProto(5 * time.Second),
+		DomainId: domainID,
+		// Only sequence when explicitly asked with receiver.Flush()
+		MinInterval:   ptypes.DurationProto(60 * time.Hour),
+		MaxInterval:   ptypes.DurationProto(60 * time.Hour),
 		VrfPrivateKey: keyFromPEM(vrfPriv),
 		LogPrivateKey: keyFromPEM(logPriv),
 		MapPrivateKey: keyFromPEM(mapPriv),
@@ -165,13 +166,12 @@ func NewEnv() (*Env, error) {
 
 	// Sequencer
 	seq := sequencer.New(logEnv.Log, logEnv.Admin, mapEnv.Map, entry.New(), domainStorage, mutations, queue)
-	// Only sequence when explicitly asked with receiver.Flush()
 	d := &domaindef.Domain{
 		DomainID:    domainPB.DomainId,
 		LogID:       domainPB.Log.TreeId,
 		MapID:       domainPB.Map.TreeId,
-		MinInterval: 60 * time.Hour,
-		MaxInterval: 60 * time.Hour,
+		MinInterval: time.Duration(domainPB.MinInterval.Seconds) * time.Second,
+		MaxInterval: time.Duration(domainPB.MaxInterval.Seconds) * time.Second,
 	}
 	receiver, err := seq.NewReceiver(ctx, d)
 	if err != nil {

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -164,7 +164,7 @@ func NewEnv() (*Env, error) {
 	pb.RegisterKeyTransparencyServer(gsvr, server)
 
 	// Sequencer
-	seq := sequencer.New(logEnv.Log, mapEnv.Map, entry.New(), domainStorage, mutations, queue)
+	seq := sequencer.New(logEnv.Log, logEnv.Admin, mapEnv.Map, entry.New(), domainStorage, mutations, queue)
 	// Only sequence when explicitly asked with receiver.Flush()
 	d := &domaindef.Domain{
 		DomainID:    domainPB.DomainId,


### PR DESCRIPTION
Diffbase: #930 

The Trillian Log API contract does NOT guarantee that items will be sequenced in the same order they are submitted. 

Eventually we will usethe AddSequencedLeavesAPI, but until that is available, we can refuse to send any more leaves to the log until it as sequenced the one we just sent it.