### PR TITLE
Use MapVerifier in monitor

### DIFF
--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -43,11 +43,10 @@ type Monitor struct {
 }
 
 // NewFromConfig produces a new monitor from a Domain object.
-func NewFromConfig(mclient pb.KeyTransparencyClient,
+func NewFromConfig(mClient pb.KeyTransparencyClient,
 	config *pb.Domain,
 	signer *tcrypto.Signer,
 	store monitorstorage.Interface) (*Monitor, error) {
-
 	logVerifier, err := client.NewLogVerifierFromTree(config.GetLog())
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize log verifier: %v", err)
@@ -56,17 +55,17 @@ func NewFromConfig(mclient pb.KeyTransparencyClient,
 	if err != nil {
 		return nil, fmt.Errorf("could not initialize map verifier: %v", err)
 	}
-	return New(mclient, logVerifier, mapVerifier, signer, store)
+	return New(mClient, logVerifier, mapVerifier, signer, store)
 }
 
 // New creates a new instance of the monitor.
-func New(mclient pb.KeyTransparencyClient,
+func New(mClient pb.KeyTransparencyClient,
 	logVerifier client.LogVerifier,
 	mapVerifier *client.MapVerifier,
 	signer *tcrypto.Signer,
 	store monitorstorage.Interface) (*Monitor, error) {
 	return &Monitor{
-		mClient:     mclient,
+		mClient:     mClient,
 		logVerifier: logVerifier,
 		mapVerifier: mapVerifier,
 		signer:      signer,

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -24,6 +24,7 @@ import (
 	"math/big"
 
 	"github.com/google/keytransparency/core/mutator/entry"
+	"github.com/google/trillian"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -32,7 +33,6 @@ import (
 	"github.com/google/trillian/storage"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
-	tcrypto "github.com/google/trillian/crypto"
 	statuspb "google.golang.org/genproto/googleapis/rpc/status"
 )
 
@@ -112,26 +112,21 @@ func (m *Monitor) VerifyEpoch(epoch *pb.Epoch) []error {
 	}
 	leafIndex := epoch.GetSmr().GetMapRevision()
 	treeSize := epoch.GetLogRoot().GetTreeSize()
-	err = m.logVerifier.VerifyInclusionAtIndex(epoch.GetLogRoot(), b, leafIndex, epoch.GetLogInclusion())
-	if err != nil {
+	if err := m.logVerifier.VerifyInclusionAtIndex(epoch.GetLogRoot(), b, leafIndex, epoch.GetLogInclusion()); err != nil {
 		glog.Errorf("m.logVerifier.VerifyInclusionAtIndex((%v, %v, _): %v", leafIndex, treeSize, err)
 		errs.AppendStatus(status.Newf(codes.DataLoss, "invalid log inclusion: %v", err).WithDetails(epoch))
 	}
 
-	// copy of signed map root
-	smr := *epoch.GetSmr()
-	// reset to the state before it was signed:
-	smr.Signature = nil
-	// verify signature on map root:
-	if err := tcrypto.VerifyObject(m.mapPubKey, smr, epoch.GetSmr().GetSignature()); err != nil {
+	if err := m.mapVerifier.VerifySignedMapRoot(epoch.GetSmr()); err != nil {
 		glog.Infof("couldn't verify signature on map root: %v", err)
-		errs.AppendStatus(status.Newf(codes.DataLoss, "invalid map signature: %v", err).WithDetails(&smr, epoch.GetSmr().GetSignature()))
+		errs.AppendStatus(status.Newf(codes.DataLoss, "invalid map signature: %v", err).WithDetails(epoch.GetSmr()))
 	}
 
 	return errs
 }
 
-func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNewRoot []byte, mapID int64) []error {
+func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNewRoot *trillian.SignedMapRoot) []error {
+	mapID := oldRoot.GetMapId()
 	errs := ErrList{}
 	mutator := entry.New()
 	oldProofNodes := make(map[string][]byte)
@@ -146,9 +141,7 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNew
 
 		// verify that the provided leaf’s inclusion proof goes to epoch e-1:
 		index := mut.GetLeafProof().GetLeaf().GetIndex()
-		leaf := mut.GetLeafProof().GetLeaf().GetLeafValue()
-		if err := merkle.VerifyMapInclusionProof(mapID, index,
-			leaf, oldRoot, mut.GetLeafProof().GetInclusion(), m.mapHasher); err != nil {
+		if err := m.mapVerifier.VerifyMapLeafInclusion(oldRoot, mut.GetLeafProof()); err != nil {
 			glog.Infof("VerifyMapInclusionProof(%x): %v", index, err)
 			errs.AppendStatus(status.Newf(codes.DataLoss, "invalid  map inclusion proof: %v", err).WithDetails(mut.GetLeafProof()))
 		}
@@ -159,7 +152,7 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNew
 			glog.Infof("Mutation did not verify: %v", err)
 			errs.AppendStatus(status.Newf(codes.DataLoss, "invalid mutation: %v", err).WithDetails(mut.GetMutation()))
 		}
-		newLeafnID := storage.NewNodeIDFromPrefixSuffix(index, storage.Suffix{}, m.mapHasher.BitLen())
+		newLeafnID := storage.NewNodeIDFromPrefixSuffix(index, storage.Suffix{}, m.mapVerifier.Hasher.BitLen())
 		newLeaf, err := entry.ToLeafValue(newValue)
 		if err != nil {
 			glog.Infof("Failed to serialize: %v", err)
@@ -169,7 +162,7 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNew
 		// BUG(gdbelvin): Proto serializations are not idempotent.
 		// - Upgrade the hasher to use ObjectHash.
 		// - Use deep compare between the tree and the computed value.
-		newLeafHash, err := m.mapHasher.HashLeaf(mapID, index, newLeaf)
+		newLeafHash, err := m.mapVerifier.Hasher.HashLeaf(mapID, index, newLeaf)
 		if err != nil {
 			errs.appendErr(err)
 		}
@@ -198,20 +191,20 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNew
 		}
 	}
 
-	if err := m.validateMapRoot(expectedNewRoot, mapID, newLeaves, oldProofNodes); err != nil {
+	if err := m.validateMapRoot(expectedNewRoot, newLeaves, oldProofNodes); err != nil {
 		errs.appendErr(err)
 	}
 
 	return errs
 }
 
-func (m *Monitor) validateMapRoot(expectedRoot []byte, mapID int64, mutatedLeaves []merkle.HStar2LeafHash, oldProofNodes map[string][]byte) error {
+func (m *Monitor) validateMapRoot(expectedRoot *trillian.SignedMapRoot, mutatedLeaves []merkle.HStar2LeafHash, oldProofNodes map[string][]byte) error {
 	// compute the new root using local intermediate hashes from epoch e
 	// (above proof hashes):
-	hs2 := merkle.NewHStar2(mapID, m.mapHasher)
-	newRoot, err := hs2.HStar2Nodes([]byte{}, m.mapHasher.BitLen(), mutatedLeaves,
+	hs2 := merkle.NewHStar2(expectedRoot.GetMapId(), m.mapVerifier.Hasher)
+	newRoot, err := hs2.HStar2Nodes([]byte{}, m.mapVerifier.Hasher.BitLen(), mutatedLeaves,
 		func(depth int, index *big.Int) ([]byte, error) {
-			nID := storage.NewNodeIDFromBigInt(depth, index, m.mapHasher.BitLen())
+			nID := storage.NewNodeIDFromBigInt(depth, index, m.mapVerifier.Hasher.BitLen())
 			if p, ok := oldProofNodes[nID.String()]; ok {
 				return p, nil
 			}
@@ -224,7 +217,7 @@ func (m *Monitor) validateMapRoot(expectedRoot []byte, mapID int64, mutatedLeave
 	}
 
 	// verify rootHash
-	if !bytes.Equal(newRoot, expectedRoot) {
+	if !bytes.Equal(newRoot, expectedRoot.GetRootHash()) {
 		return ErrNotMatchingMapRoot
 	}
 


### PR DESCRIPTION
This PR cleans up a little bit of the monitor. Many of the more complex functions that used to be manually performed have been moved to the trillian `MapVerifier`. 