### PR TITLE
Clarify root of trust in monitor

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -86,7 +86,7 @@ func main() {
 	store := fake.NewMonitorStorage()
 
 	// Create monitoring background process.
-	mon, err := monitor.NewFromConfig(ktClient, config, signer, store)
+	mon, err := monitor.NewFromDomain(ktClient, config, signer, store)
 	if err != nil {
 		glog.Exitf("Failed to initialize monitor: %v", err)
 	}

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
 	"github.com/google/keytransparency/core/monitorserver"
+	"github.com/google/trillian"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/google/trillian/crypto"
@@ -89,7 +90,10 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to initialize monitor: %v", err)
 	}
-	go mon.ProcessLoop(ctx, *domainID, store.LatestEpoch(), *pollPeriod)
+
+	// TODO(gbelvin): persist trusted roots
+	trusted := trillian.SignedLogRoot{}
+	go mon.ProcessLoop(ctx, *domainID, trusted, *pollPeriod)
 
 	// Monitor Server.
 	srv := monitorserver.New(store)

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -77,6 +77,14 @@ func createSigner(t *testing.T, privKey string) signatures.Signer {
 	return signer
 }
 
+func getAuthorizedKeys(pubKeys ...string) []*keyspb.PublicKey {
+	ret := make([]*keyspb.PublicKey, 0, len(pubKeys))
+	for _, pubKey := range pubKeys {
+		ret = append(ret, getAuthorizedKey(pubKey))
+	}
+	return ret
+}
+
 func getAuthorizedKey(pubKey string) *keyspb.PublicKey {
 	pk, _ := pem.Decode([]byte(pubKey))
 	return &keyspb.PublicKey{Der: pk.Bytes}

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -22,10 +22,10 @@ import (
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
+	"github.com/google/trillian"
 
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
-	"github.com/google/trillian/crypto/keyspb"
 
 	tpb "github.com/google/keytransparency/core/api/type/type_proto"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
@@ -59,87 +59,74 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 
 	// Setup a bunch of epochs with data to verify.
 	for _, e := range []struct {
-		userUpdates []*tpb.User
 		epoch       int64
+		signers     []signatures.Signer
+		userUpdates []*tpb.User
 	}{
 		{
 			epoch: 1,
+		},
+		{
+			epoch:   2,
+			signers: []signatures.Signer{createSigner(t, testPrivKey1)},
 			userUpdates: []*tpb.User{
 				{
 					DomainId:       env.Domain.DomainId,
 					AppId:          "app1",
 					UserId:         "alice@test.com",
 					PublicKeyData:  []byte("alice-key1"),
-					AuthorizedKeys: tc.authorizedKeys,
+					AuthorizedKeys: getAuthorizedKeys(testPubKey1),
+				},
+			},
+		},
+		{
+			epoch:   3,
+			signers: []signatures.Signer{createSigner(t, testPrivKey1)},
+			userUpdates: []*tpb.User{
+				{
+					DomainId:       env.Domain.DomainId,
+					AppId:          "app1",
+					UserId:         "bob@test.com",
+					PublicKeyData:  []byte("bob-key1"),
+					AuthorizedKeys: getAuthorizedKeys(testPubKey1),
+				},
+				{
+					DomainId:       env.Domain.DomainId,
+					AppId:          "app1",
+					UserId:         "carol@test.com",
+					PublicKeyData:  []byte("carol-key1"),
+					AuthorizedKeys: getAuthorizedKeys(testPubKey1),
 				},
 			},
 		},
 	} {
-		for _, userID := range tc.userIDs {
-			u := &tpb.User{
-				DomainId:       env.Domain.DomainId,
-				AppId:          appID,
-				UserId:         userID,
-				PublicKeyData:  tc.updateData,
-				AuthorizedKeys: tc.authorizedKeys,
-			}
-			actx := WithOutgoingFakeAuth(ctx, userID)
+		for _, u := range e.userUpdates {
+			actx := WithOutgoingFakeAuth(ctx, u.UserId)
 			cctx, cancel := context.WithTimeout(actx, 500*time.Millisecond)
 			defer cancel()
-			if _, err = env.Client.Update(cctx, u, tc.signers); err != context.DeadlineExceeded {
+			if _, err = env.Client.Update(cctx, u, e.signers); err != context.DeadlineExceeded {
 				t.Fatalf("Could not send update request: %v", err)
 			}
 		}
 
 		env.Receiver.Flush(ctx)
-		if err := env.Client.WaitForRevision(ctx, tc.queryEpoch); err != nil {
+		if err := env.Client.WaitForRevision(ctx, e.epoch); err != nil {
 			t.Fatalf("WaitForRevision(): %v", err)
 		}
 	}
 
-	for _, tc := range []struct {
-		desc string
-		// the userIDs to update, if no userIDs are provided, no update request
-		// will be sent before querying
-		userIDs        []string
-		updateData     []byte
-		signers        []signatures.Signer
-		authorizedKeys []*keyspb.PublicKey
-		// the epoch to query after sending potential updates
-		queryEpoch int64
-	}{
-		{
-			desc:       "Query first epoch",
-			queryEpoch: 1,
-		},
-		{
-			desc:           "create one mutation and new epoch (not forced like in sequencer)",
-			userIDs:        []string{"test@test.com"},
-			updateData:     []byte("testData"),
-			signers:        []signatures.Signer{createSigner(t, testPrivKey1)},
-			authorizedKeys: []*keyspb.PublicKey{getAuthorizedKey(testPubKey1)},
-			queryEpoch:     3,
-		},
-		{
-			desc:           "create several mutations and new epoch",
-			userIDs:        []string{"test@test.com", "test2@test2.com"},
-			updateData:     []byte("more update data"),
-			signers:        []signatures.Signer{createSigner(t, testPrivKey1)},
-			authorizedKeys: []*keyspb.PublicKey{getAuthorizedKey(testPubKey1)},
-			queryEpoch:     4,
-		},
-	} {
+	trusted := trillian.SignedLogRoot{}
+	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	pollPeriod := 100 * time.Millisecond
+	if err := mon.ProcessLoop(cctx, env.Domain.DomainId, trusted, pollPeriod); err != context.DeadlineExceeded {
+		t.Errorf("Monitor could not process mutations: %v", err)
+	}
+	cancel()
 
-		domainID := env.Domain.DomainId
-		cctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
-		if err := mon.ProcessLoop(cctx, domainID, tc.queryEpoch-1, 40*time.Millisecond); err != context.DeadlineExceeded {
-			t.Errorf("Monitor could not process mutations: %v", err)
-		}
-		cancel()
-
-		mresp, err := store.Get(tc.queryEpoch)
+	for i := int64(1); i < 4; i++ {
+		mresp, err := store.Get(i)
 		if err != nil {
-			t.Errorf("Could not read monitoring response: %v", err)
+			t.Errorf("Could not read monitoring response for epoch %v: %v", i, err)
 			continue
 		}
 		for _, err := range mresp.Errors {

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -52,7 +52,7 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 		t.Fatalf("Couldn't retrieve domain info: %v", err)
 	}
 	store := fake.NewMonitorStorage()
-	mon, err := monitor.NewFromConfig(env.Cli, config, signer, store)
+	mon, err := monitor.NewFromDomain(env.Cli, config, signer, store)
 	if err != nil {
 		t.Fatalf("Couldn't create monitor: %v", err)
 	}

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -23,6 +23,8 @@ import (
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
 	"github.com/google/trillian"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
@@ -118,7 +120,7 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 	trusted := trillian.SignedLogRoot{}
 	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	pollPeriod := 100 * time.Millisecond
-	if err := mon.ProcessLoop(cctx, env.Domain.DomainId, trusted, pollPeriod); err != context.DeadlineExceeded {
+	if err := mon.ProcessLoop(cctx, env.Domain.DomainId, trusted, pollPeriod); err != context.DeadlineExceeded && status.Code(err) != codes.DeadlineExceeded {
 		t.Errorf("Monitor could not process mutations: %v", err)
 	}
 	cancel()

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -46,11 +46,11 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't create signer: %v", err)
 	}
-	signer := crypto.NewSHA256Signer(privKey)
 	config, err := env.Cli.GetDomain(ctx, &pb.GetDomainRequest{DomainId: env.Domain.DomainId})
 	if err != nil {
 		t.Fatalf("Couldn't retrieve domain info: %v", err)
 	}
+	signer := crypto.NewSHA256Signer(privKey)
 	store := fake.NewMonitorStorage()
 	mon, err := monitor.NewFromDomain(env.Cli, config, signer, store)
 	if err != nil {

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -42,8 +42,8 @@ type Monitor struct {
 	store       monitorstorage.Interface
 }
 
-// NewFromConfig produces a new monitor from a Domain object.
-func NewFromConfig(mClient pb.KeyTransparencyClient,
+// NewFromDomain produces a new monitor from a Domain object.
+func NewFromDomain(mClient pb.KeyTransparencyClient,
 	config *pb.Domain,
 	signer *tcrypto.Signer,
 	store monitorstorage.Interface) (*Monitor, error) {

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -36,7 +36,7 @@ import (
 type Monitor struct {
 	mClient     pb.KeyTransparencyClient
 	signer      *tcrypto.Signer
-	trusted     *trillian.SignedLogRoot
+	trusted     trillian.SignedLogRoot
 	logVerifier client.LogVerifier
 	mapVerifier *client.MapVerifier
 	store       monitorstorage.Interface
@@ -102,7 +102,7 @@ func EpochPairs(ctx context.Context, epochs <-chan *pb.Epoch, pairs chan<- Epoch
 }
 
 // ProcessLoop continuously fetches mutations and processes them.
-func (m *Monitor) ProcessLoop(ctx context.Context, domainID string, startEpoch int64, period time.Duration) error {
+func (m *Monitor) ProcessLoop(ctx context.Context, domainID string, trusted trillian.SignedLogRoot, period time.Duration) error {
 	mutCli := mutationclient.New(m.mClient, period)
 	cctx, cancel := context.WithCancel(ctx)
 	errc := make(chan error)
@@ -110,7 +110,7 @@ func (m *Monitor) ProcessLoop(ctx context.Context, domainID string, startEpoch i
 	pairs := make(chan EpochPair)
 
 	go func(ctx context.Context) {
-		errc <- mutCli.StreamEpochs(ctx, domainID, startEpoch, epochs)
+		errc <- mutCli.StreamEpochs(ctx, domainID, trusted.TreeSize, epochs)
 	}(cctx)
 	go func(ctx context.Context) {
 		errc <- EpochPairs(ctx, epochs, pairs)
@@ -126,7 +126,7 @@ func (m *Monitor) ProcessLoop(ctx context.Context, domainID string, startEpoch i
 
 		var smr *trillian.SignedMapRoot
 		var errList []error
-		if errs := m.VerifyEpochMutations(pair.A, pair.B, mutations); len(errs) > 0 {
+		if errs := m.VerifyEpochMutations(pair.A, pair.B, &trusted, mutations); len(errs) > 0 {
 			glog.Infof("Epoch %v did not verify: %v", revision, errs)
 			errList = errs
 		} else {
@@ -155,17 +155,15 @@ func (m *Monitor) ProcessLoop(ctx context.Context, domainID string, startEpoch i
 }
 
 // VerifyEpochMutations validates that epochA + mutations = epochB.
-func (m *Monitor) VerifyEpochMutations(epochA, epochB *pb.Epoch, mutations []*pb.MutationProof) []error {
+func (m *Monitor) VerifyEpochMutations(epochA, epochB *pb.Epoch, trusted *trillian.SignedLogRoot, mutations []*pb.MutationProof) []error {
 	revision := epochB.GetSmr().GetMapRevision()
-	if errs := m.VerifyEpoch(epochB); len(errs) > 0 {
+	if errs := m.VerifyEpoch(epochB, trusted); len(errs) > 0 {
 		glog.Errorf("Invalid Epoch %v: %v", revision, errs)
 		return errs
 	}
 
 	// Fetch Previous root.
-	smrA := epochA.GetSmr()
-	smrB := epochB.GetSmr()
-	if errs := m.verifyMutations(mutations, smrA, smrB); len(errs) > 0 {
+	if errs := m.verifyMutations(mutations, epochA.GetSmr(), epochB.GetSmr()); len(errs) > 0 {
 		glog.Errorf("Invalid Epoch %v Mutations: %v", revision, errs)
 		return errs
 	}

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -91,12 +91,13 @@ func (e *ErrList) Proto() []*statuspb.Status {
 }
 
 // VerifyEpoch verifies that epoch is correctly signed and included in the append only log.
+// VerifyEpoch also verifies that epoch.LogRoot is consistent with the last trusted SignedLogRoot.
 func (m *Monitor) VerifyEpoch(epoch *pb.Epoch, trusted *trillian.SignedLogRoot) []error {
 	errs := ErrList{}
 
 	if err := m.logVerifier.VerifyRoot(trusted, epoch.GetLogRoot(), epoch.GetLogConsistency()); err != nil {
 		// this could be one of ErrInvalidLogSignature, ErrInvalidLogConsistencyProof
-		errs.AppendStatus(status.Newf(codes.DataLoss, "VerifyRoot: %v", err).WithDetails(epoch, trusted))
+		errs.AppendStatus(status.Newf(codes.DataLoss, "VerifyRoot: %v", err).WithDetails(trusted, epoch))
 	}
 	// updated trusted log root
 	m.updateTrusted(epoch.GetLogRoot())


### PR DESCRIPTION
This PR slightly reworks the monitor to clarify what the currently trusted log root is. 

It also reworks the integration test to be easier to follow. 