### PR TITLE
Make Timeout a test env variable.

### DIFF
--- a/core/integration/alltests.go
+++ b/core/integration/alltests.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/keytransparency/core/client"
 	"github.com/google/keytransparency/core/mutator"
@@ -32,6 +33,7 @@ type Env struct {
 	Cli      pb.KeyTransparencyClient
 	Domain   *pb.Domain
 	Receiver mutator.Receiver
+	Timeout  time.Duration
 }
 
 // NamedTestFn is a binding between a readable test name (used for a Go subtest)

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -204,6 +204,7 @@ func NewEnv() (*Env, error) {
 			Cli:      ktClient,
 			Domain:   domainPB,
 			Receiver: receiver,
+			Timeout:  500 * time.Millisecond,
 		},
 		mapEnv:     mapEnv,
 		logEnv:     logEnv,


### PR DESCRIPTION
Different test environments will run at different speeds.
Therefore it makes sense to make timeout a part of Env.

This PR also expands the use of timeouts to several more
functions which could timeout.