### PR TITLE
 Invert dependency of userCreds 

### DIFF
--- a/cmd/keytransparency-client/cmd/get.go
+++ b/cmd/keytransparency-client/cmd/get.go
@@ -42,7 +42,7 @@ results are consistent.`,
 		if err != nil {
 			return err
 		}
-		c, err := GetClient(userCreds)
+		c, err := GetClient(ctx, userCreds)
 		if err != nil {
 			return fmt.Errorf("error connecting: %v", err)
 		}

--- a/cmd/keytransparency-client/cmd/get.go
+++ b/cmd/keytransparency-client/cmd/get.go
@@ -35,13 +35,17 @@ results are consistent.`,
 		userID := args[0]
 		appID := args[1]
 		timeout := viper.GetDuration("timeout")
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
 
-		c, err := GetClient(false)
+		userCreds, err := userCreds(ctx, false)
+		if err != nil {
+			return err
+		}
+		c, err := GetClient(userCreds)
 		if err != nil {
 			return fmt.Errorf("error connecting: %v", err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
 		profile, _, err := c.GetEntry(ctx, userID, appID)
 		if err != nil {
 			return fmt.Errorf("GetEntry failed: %v", err)

--- a/cmd/keytransparency-client/cmd/history.go
+++ b/cmd/keytransparency-client/cmd/history.go
@@ -52,7 +52,7 @@ and verify that the results are consistent.`,
 		if err != nil {
 			return err
 		}
-		c, err := GetClient(userCreds)
+		c, err := GetClient(ctx, userCreds)
 		if err != nil {
 			return fmt.Errorf("Error connecting: %v", err)
 		}

--- a/cmd/keytransparency-client/cmd/history.go
+++ b/cmd/keytransparency-client/cmd/history.go
@@ -45,13 +45,17 @@ and verify that the results are consistent.`,
 		userID := args[0]
 		appID := args[1]
 		timeout := viper.GetDuration("timeout")
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
 
-		c, err := GetClient(false)
+		userCreds, err := userCreds(ctx, false)
+		if err != nil {
+			return err
+		}
+		c, err := GetClient(userCreds)
 		if err != nil {
 			return fmt.Errorf("Error connecting: %v", err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
 		if end == 0 {
 			// Get the current epoch.
 			_, smh, err := c.GetEntry(ctx, userID, appID)

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -66,14 +66,18 @@ User email MUST match the OAuth account used to authorize the update.
 		userID := args[0]
 		appID := args[1]
 		timeout := viper.GetDuration("timeout")
+		cctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
 
 		// Create client.
-		c, err := GetClient(true)
+		userCreds, err := userCreds(ctx, false)
+		if err != nil {
+			return err
+		}
+		c, err := GetClient(userCreds)
 		if err != nil {
 			return fmt.Errorf("error connecting: %v", err)
 		}
-		cctx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
 
 		// Update.
 		signers := store.Signers()

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -48,7 +48,6 @@ User email MUST match the OAuth account used to authorize the update.
 		}
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx := context.Background()
 		// Validate input.
 		if len(args) < 2 {
 			return fmt.Errorf("user email and app-id need to be provided")
@@ -66,7 +65,7 @@ User email MUST match the OAuth account used to authorize the update.
 		userID := args[0]
 		appID := args[1]
 		timeout := viper.GetDuration("timeout")
-		cctx, cancel := context.WithTimeout(ctx, timeout)
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
 		// Create client.
@@ -74,7 +73,7 @@ User email MUST match the OAuth account used to authorize the update.
 		if err != nil {
 			return err
 		}
-		c, err := GetClient(userCreds)
+		c, err := GetClient(ctx, userCreds)
 		if err != nil {
 			return fmt.Errorf("error connecting: %v", err)
 		}
@@ -95,7 +94,7 @@ User email MUST match the OAuth account used to authorize the update.
 			PublicKeyData:  profileData,
 			AuthorizedKeys: authorizedKeys,
 		}
-		if _, err := c.Update(cctx, u, signers); err != nil {
+		if _, err := c.Update(ctx, u, signers); err != nil {
 			return fmt.Errorf("update failed: %v", err)
 		}
 		fmt.Printf("New key for %v: %x\n", userID, data)

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -45,9 +45,8 @@ import (
 )
 
 var (
-	cfgFile  string
-	verbose  bool
-	authType string
+	cfgFile string
+	verbose bool
 )
 
 // RootCmd represents the base command when called without any subcommands

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -45,8 +45,9 @@ import (
 )
 
 var (
-	cfgFile string
-	verbose bool
+	cfgFile  string
+	verbose  bool
+	authType string
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -210,7 +211,7 @@ func userCreds(ctx context.Context, useClientSecret bool) (credentials.PerRPCCre
 	}
 }
 
-func dial(ctx context.Context, ktURL string, useClientSecret bool) (*grpc.ClientConn, error) {
+func dial(ctx context.Context, ktURL string, userCreds credentials.PerRPCCredentials) (*grpc.ClientConn, error) {
 	var opts []grpc.DialOption
 
 	transportCreds, err := transportCreds(ktURL)
@@ -219,10 +220,6 @@ func dial(ctx context.Context, ktURL string, useClientSecret bool) (*grpc.Client
 	}
 	opts = append(opts, grpc.WithTransportCredentials(transportCreds))
 
-	userCreds, err := userCreds(ctx, useClientSecret)
-	if err != nil {
-		return nil, err
-	}
 	if userCreds != nil {
 		opts = append(opts, grpc.WithPerRPCCredentials(userCreds))
 	}
@@ -236,10 +233,11 @@ func dial(ctx context.Context, ktURL string, useClientSecret bool) (*grpc.Client
 
 // GetClient connects to the server and returns a key transparency verification
 // client.
-func GetClient(useClientSecret bool) (*client.Client, error) {
+func GetClient(userCreds credentials.PerRPCCredentials) (*client.Client, error) {
 	ctx := context.Background()
 	ktURL := viper.GetString("kt-url")
-	cc, err := dial(ctx, ktURL, useClientSecret)
+
+	cc, err := dial(ctx, ktURL, userCreds)
 	if err != nil {
 		return nil, fmt.Errorf("Error Dialing: %v", err)
 	}

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -233,8 +233,7 @@ func dial(ctx context.Context, ktURL string, userCreds credentials.PerRPCCredent
 
 // GetClient connects to the server and returns a key transparency verification
 // client.
-func GetClient(userCreds credentials.PerRPCCredentials) (*client.Client, error) {
-	ctx := context.Background()
+func GetClient(ctx context.Context, userCreds credentials.PerRPCCredentials) (*client.Client, error) {
 	ktURL := viper.GetString("kt-url")
 
 	cc, err := dial(ctx, ktURL, userCreds)


### PR DESCRIPTION
Pass user creds into GetClient so that callers can supply their own
creds during testing.