### PR TITLE
Add loadtest hammer operation to the client

### DIFF
--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -43,9 +43,11 @@ var (
 )
 
 func init() {
-	log.SetOutput(memLog)
-
+	// Silence "logging before flag.Parse"
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	flag.CommandLine.Parse([]string{})
+
+	log.SetOutput(memLog)
 
 	RootCmd.AddCommand(hammerCmd)
 
@@ -168,18 +170,19 @@ func draw(latencies []float64, data *tm.DataTable, qps int64) {
 	chart := tm.NewLineChart(100, 20)
 	tm.Println(chart.Draw(data))
 
-	// Latency Hist
-	tm.Printf("Latency Histogram:\n")
-	width := 50
-	height := 10
-
-	hist := histogram.Hist(height, latencies)
-	histogram.Fprint(tm.Output, hist, histogram.Linear(width))
-
 	// Console output
+	tm.Printf("Debug Output:\n")
 	box := tm.NewBox(180, 10, 0)
 	box.Write(memLog.Bytes())
 	tm.Println(box)
+
+	// Latency Hist
+	width := 50
+	height := 10
+
+	tm.Printf("Latency Histogram:\n")
+	hist := histogram.Hist(height, latencies)
+	histogram.Fprint(tm.Output, hist, histogram.Linear(width))
 
 	tm.Flush()
 }

--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -1,0 +1,217 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/aybabtme/uniplot/histogram"
+	"github.com/paulbellamy/ratecounter"
+	"github.com/spf13/cobra"
+
+	tm "github.com/buger/goterm"
+)
+
+var (
+	maxWorkers int
+	workers    int
+	memLog     = new(bytes.Buffer)
+	ramp       time.Duration
+)
+
+func init() {
+	log.SetOutput(memLog)
+
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+
+	RootCmd.AddCommand(hammerCmd)
+
+	hammerCmd.Flags().IntVar(&maxWorkers, "workers", 1, "Number of parallel workers")
+}
+
+// hammerCmd represents the post command
+var hammerCmd = &cobra.Command{
+	Use:   "hammer",
+	Short: "Loadtest the server",
+	Long:  ``,
+
+	PreRun: func(cmd *cobra.Command, args []string) {
+		if err := readKeyStoreFile(); err != nil {
+			log.Fatal(err)
+		}
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		parallel(ctx, maxWorkers)
+		return nil
+	},
+}
+
+var (
+	qps = make([][2]float64, 0, 1000)
+)
+
+func parallel(ctx context.Context, maxWorkers int) {
+	times := make(chan time.Duration)
+	jobs := make(chan job)
+	var wg sync.WaitGroup
+	go recordLatencies(ctx, times)
+	go generateJobs(ctx, jobs)
+
+	// Slowly add workers up to maxWorkers
+	ramp := time.NewTicker(time.Duration(ramp.Nanoseconds() / int64(maxWorkers)))
+	for ; workers < maxWorkers && ctx.Err() == nil; <-ramp.C {
+		workers++
+		wg.Add(1)
+		go runJobsInThread(ctx, workers, jobs, times, &wg)
+	}
+	ramp.Stop()
+	wg.Wait()
+}
+
+type job func() error
+
+func generateJobs(ctx context.Context, jobs chan<- job) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case jobs <- bindJob(ctx, i):
+			i++
+		}
+	}
+}
+
+func bindJob(ctx context.Context, i int) func() error {
+	userID := fmt.Sprintf("user_%v", i)
+	return func() error {
+		return writeOp(ctx, "app1", userID)
+	}
+}
+
+func runJobsInThread(ctx context.Context, id int, jobs <-chan job, times chan<- time.Duration, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case f := <-jobs:
+			start := time.Now()
+			if err := f(); err != nil {
+				log.Printf("f(): %v", err)
+				continue
+			}
+			times <- time.Since(start)
+		}
+	}
+}
+
+func recordLatencies(ctx context.Context, times <-chan time.Duration) {
+	//start := time.Now()
+	latencies := make([]float64, 0, 1000)
+	refresh := time.NewTicker(250 * time.Millisecond)
+	newworker := time.NewTicker(time.Duration(ramp.Nanoseconds() / int64(maxWorkers)))
+	qps := ratecounter.NewRateCounter(5 * time.Second)
+
+	qpsData := new(tm.DataTable)
+	qpsData.AddColumn("Workers")
+	qpsData.AddColumn("QPS")
+	qpsData.AddRow(0, 0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-times:
+			latencies = append(latencies, t.Seconds())
+			qps.Incr(1)
+		case <-refresh.C:
+			draw(latencies, qpsData, qps.Rate())
+		case <-newworker.C:
+			qpsData.AddRow(float64(workers), float64(qps.Rate()))
+		}
+	}
+}
+
+func draw(latencies []float64, data *tm.DataTable, qps int64) {
+	tm.Clear()
+	tm.MoveCursor(0, 0)
+
+	// Global stats
+	tm.Printf("Workers: %v\n", workers)
+	tm.Printf("Total Requests: %v\n", len(latencies))
+	tm.Printf("Recent QPS:    %v\n", qps)
+
+	// QPS Chart
+	tm.Printf("QPS Chart:\n")
+	chart := tm.NewLineChart(100, 20)
+	tm.Println(chart.Draw(data))
+
+	// Latency Hist
+	tm.Printf("Latency Histogram:\n")
+	width := 50
+	height := 10
+
+	hist := histogram.Hist(height, latencies)
+	histogram.Fprint(tm.Output, hist, histogram.Linear(width))
+
+	// Console output
+	box := tm.NewBox(180, 10, 0)
+	box.Write(memLog.Bytes())
+	tm.Println(box)
+
+	// Threads per QPS graph
+	tm.Flush()
+}
+
+// writeOp performs one write command and returns the time it took to complete.
+func writeOp(ctx context.Context, appID, userID string) error {
+	timeout := viper.GetDuration("timeout")
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	userCreds := authentication.GetFakeCredential(userID)
+	c, err := GetClient(ctx, userCreds)
+	if err != nil {
+		return fmt.Errorf("error connecting: %v", err)
+	}
+
+	// Update.
+	signers := store.Signers()
+	authorizedKeys, err := store.PublicKeys()
+	if err != nil {
+		return fmt.Errorf("store.PublicKeys() failed: %v", err)
+	}
+	if err != nil {
+		return fmt.Errorf("updateKeys() failed: %v", err)
+	}
+	u := &tpb.User{
+		DomainId:       viper.GetString("domain"),
+		AppId:          appID,
+		UserId:         userID,
+		PublicKeyData:  []byte("publickey"),
+		AuthorizedKeys: authorizedKeys,
+	}
+	if _, err := c.Update(ctx, u, signers); err != nil {
+		return fmt.Errorf("update failed: %v", err)
+	}
+	return nil
+}

--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/keytransparency/core/authentication"
 
 	"github.com/aybabtme/uniplot/histogram"
-	"github.com/golang/glog"
 	"github.com/paulbellamy/ratecounter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -100,15 +99,6 @@ func generateJobs(ctx context.Context, jobs chan<- job) {
 			return
 		case jobs <- bindJob(ctx, i):
 			i++
-		}
-	}
-}
-
-func bindJob(ctx context.Context, i int) func() {
-	userID := fmt.Sprintf("user_%v", i)
-	return func() {
-		if err := writeOp(ctx, "app1", userID); err != nil {
-			glog.Errorf("write(%v): %v", userID, err)
 		}
 	}
 }

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -77,7 +77,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.keytransparency.yaml)")
 
 	RootCmd.PersistentFlags().String("domain", "default", "Domain within the KT server")
-	RootCmd.PersistentFlags().String("kt-url", "35.225.194.168:8080", "URL of Key Transparency server")
+	RootCmd.PersistentFlags().String("kt-url", "35.224.99.110:8080", "URL of Key Transparency server")
 	RootCmd.PersistentFlags().String("kt-cert", "genfiles/server.crt", "Path to public key for Key Transparency")
 	RootCmd.PersistentFlags().Bool("autoconfig", true, "Fetch config info from the server's /v1/domain/info")
 	RootCmd.PersistentFlags().Bool("insecure", true, "Skip TLS checks")

--- a/deploy/kubernetes/server-deployment.yaml
+++ b/deploy/kubernetes/server-deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - --map-url=map-server:8090
         - --tls-key=/kt/server.key
         - --tls-cert=/kt/server.crt
+        - --auth-type=insecure-fake
         - --alsologtostderr
         - --v=5
         image: us.gcr.io/key-transparency/keytransparency-server:latest


### PR DESCRIPTION
Load test the open source continuous integration server. 
Each operation takes ~2s to complete end to end.
QPS peaked at ~80 and revealed a leaking transaction in the Trillian Map: #944 

<img width="745" alt="screen shot 2018-03-03 at 13 26 27" src="https://user-images.githubusercontent.com/198478/36935147-b4f9efea-1eeb-11e8-806a-944704294517.png">
