### PR TITLE
Use types.LogRootV1

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -26,11 +26,11 @@ import (
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
 	"github.com/google/keytransparency/core/monitorserver"
-	"github.com/google/trillian"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
+	"github.com/google/trillian/types"
 
 	"github.com/golang/glog"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -92,7 +92,7 @@ func main() {
 	}
 
 	// TODO(gbelvin): persist trusted roots
-	trusted := trillian.SignedLogRoot{}
+	trusted := types.LogRootV1{}
 	go mon.ProcessLoop(ctx, *domainID, trusted, *pollPeriod)
 
 	// Monitor Server.

--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -277,7 +277,7 @@ func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) err
 
 	// If the tree is empty and the map is empty,
 	// add the empty map root to the log.
-	if logRoot.GetTreeSize() != 0 ||
+	if logRoot.TreeSize != 0 ||
 		mapRoot.GetMapRoot().GetMapRevision() != 0 {
 		return nil // Init not needed.
 	}

--- a/core/client/get_and_verify.go
+++ b/core/client/get_and_verify.go
@@ -27,7 +27,7 @@ func (c *Client) VerifiedGetEntry(ctx context.Context, appID, userID string) (*p
 		DomainId:      c.domainID,
 		UserId:        userID,
 		AppId:         appID,
-		FirstTreeSize: c.trusted.TreeSize,
+		FirstTreeSize: int64(c.trusted.TreeSize),
 	})
 	if err != nil {
 		return nil, err
@@ -36,7 +36,9 @@ func (c *Client) VerifiedGetEntry(ctx context.Context, appID, userID string) (*p
 	if err := c.VerifyGetEntryResponse(ctx, c.domainID, appID, userID, c.trusted, e); err != nil {
 		return nil, err
 	}
-	c.trusted = *e.GetLogRoot()
+	if err := c.updateTrusted(e.GetLogRoot()); err != nil {
+		return nil, err
+	}
 	glog.Infof("VerifiedGetEntry: Trusted root updated to TreeSize %v", c.trusted.TreeSize)
 	Vlog.Printf("✓ Log root updated.")
 

--- a/core/client/vectors_test.go
+++ b/core/client/vectors_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/types"
 
 	"github.com/google/keytransparency/core/api/v1/keytransparency_proto"
 	"github.com/google/trillian"
@@ -29,7 +30,7 @@ import (
 type GetEntryResponseVector struct {
 	desc          string
 	appID, userID string
-	trusted       trillian.SignedLogRoot
+	trusted       types.LogRootV1
 	resp          *keytransparency_proto.GetEntryResponse
 }
 

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -22,12 +22,12 @@ import (
 	"github.com/google/keytransparency/core/crypto/signatures"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
-	"github.com/google/trillian"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
+	"github.com/google/trillian/types"
 
 	tpb "github.com/google/keytransparency/core/api/type/type_proto"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_proto"
@@ -117,7 +117,7 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 		}
 	}
 
-	trusted := trillian.SignedLogRoot{}
+	trusted := types.LogRootV1{}
 	cctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	pollPeriod := 100 * time.Millisecond
 	if err := mon.ProcessLoop(cctx, env.Domain.DomainId, trusted, pollPeriod); err != context.DeadlineExceeded && status.Code(err) != codes.DeadlineExceeded {


### PR DESCRIPTION
Following google/trillian#1048, use types.LogRootV1 as the local
reference of what the most up-to-date log root is.