### PR TITLE
Add commit tags to docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ infra*.etcd
 genfiles/*
 .keytransparency-scts.dat
 .keystore
+.keyset
 travis_secrets.tar.gz
 service_key.json
 client_secret*.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
   - DOCKER_COMPOSE_VERSION="1.13.0"
   - PATH=$PATH:${HOME}/google-cloud-sdk/bin
   - CLOUDSDK_CORE_DISABLE_PROMPTS=1
-  - PROJECT_NAME=key-transparency
 
 addons:
   apt:
@@ -51,13 +50,9 @@ before_deploy:
   - rm -f service_key.json
   - gcloud --quiet components update kubectl
   - gcloud --quiet version
-  - gcloud config set project key-transparency
-  - gcloud config set compute/zone us-central1-a
-  - gcloud container clusters get-credentials ci-cluster
   - go get github.com/google/trillian/server/trillian_log_server
   - go get github.com/google/trillian/server/trillian_log_signer
   - go get github.com/google/trillian/server/trillian_map_server
-  - gcloud docker --authorize-only 
 
 deploy:
   skip_cleanup: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     depends_on:
       - server
       - sequencer
-    image: us.gcr.io/key-transparency/prometheus:latest
+    image: us.gcr.io/key-transparency/prometheus:${TRAVIS_COMMIT}
     build:
       context: .
       dockerfile: deploy/prometheus/Dockerfile
@@ -29,7 +29,7 @@ services:
   log-server:
     depends_on:
       - db
-    image: us.gcr.io/key-transparency/log-server
+    image: us.gcr.io/key-transparency/log-server:${TRAVIS_COMMIT}
     build: 
       context: ../trillian
       dockerfile: server/trillian_log_server/Dockerfile
@@ -52,7 +52,7 @@ services:
   log-signer:
     depends_on:
       - db
-    image: us.gcr.io/key-transparency/log-signer
+    image: us.gcr.io/key-transparency/log-signer:${TRAVIS_COMMIT}
     build:
       context: ../trillian
       dockerfile: server/trillian_log_signer/Dockerfile
@@ -78,7 +78,7 @@ services:
   map-server:
     depends_on:
       - db
-    image: us.gcr.io/key-transparency/map-server:latest
+    image: us.gcr.io/key-transparency/map-server:${TRAVIS_COMMIT}
     build: 
       context: ../trillian
       dockerfile: server/trillian_map_server/Dockerfile
@@ -103,7 +103,7 @@ services:
       - db
       - log-server
       - map-server
-    image: us.gcr.io/key-transparency/keytransparency-server:latest
+    image: us.gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
     build:
       context: ..
       dockerfile: ./keytransparency/cmd/keytransparency-server/Dockerfile
@@ -134,7 +134,7 @@ services:
       - db
       - log-server
       - map-server
-    image: us.gcr.io/key-transparency/keytransparency-sequencer:latest
+    image: us.gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}
     build:
       context: ..
       dockerfile: ./keytransparency/cmd/keytransparency-sequencer/Dockerfile
@@ -167,7 +167,7 @@ services:
     depends_on:
       - server
       - sequencer
-    image: us.gcr.io/key-transparency/keytransparency-monitor:latest
+    image: us.gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
     build:
       context: ..
       dockerfile: ./keytransparency/cmd/keytransparency-monitor/Dockerfile


### PR DESCRIPTION
The current docker configuration doesn't cause kubernetes to actually update. 
The reason is that docker only updates when the job configuration changes, not when the `:latest` label points to something else. 

This PR gives each deployment a unique label based on the travis commit, and then it explicitly updates Kubernetes to that tag. 