### PR TITLE
Register standard tink types

### DIFF
--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/keytransparency/core/client/hammer"
-	"github.com/google/tink/go/signature"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -53,8 +52,6 @@ var hammerCmd = &cobra.Command{
 	Long:  `Sends update requests for user_1 through user_n using a select number of workers in parallel.`,
 
 	PreRun: func(cmd *cobra.Command, args []string) {
-		signature.PublicKeySignConfig().RegisterStandardKeyTypes()
-		signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
 		handle, err := readKeysetFile(keysetFile, masterPassword)
 		if err != nil {
 			log.Fatal(err)

--- a/core/mutator/entry/entry_test.go
+++ b/core/mutator/entry/entry_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/google/tink/go/signature"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
@@ -49,7 +48,6 @@ LOA+tLe/MbwZ69SRdG6Rx92f9tbC6dz7UVsyI7vIjS+961sELA6FeR91lA==
 )
 
 func TestFromLeafValue(t *testing.T) {
-	signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
 	entry := &pb.Entry{Commitment: []byte{1, 2}}
 	entryB, err := proto.Marshal(entry)
 	if err != nil {

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -18,15 +18,12 @@ import (
 	"testing"
 
 	"github.com/google/keytransparency/core/testutil"
-	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/tink"
 )
 
 const domainID = "default"
 
 func TestCreateAndVerify(t *testing.T) {
-	signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
-	signature.PublicKeySignConfig().RegisterStandardKeyTypes()
 	for _, tc := range []struct {
 		old     []byte
 		pubKeys *tink.KeysetHandle

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -32,6 +32,11 @@ import (
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
+func init() {
+	signature.PublicKeySignConfig().RegisterStandardKeyTypes()
+	signature.PublicKeyVerifyConfig().RegisterStandardKeyTypes()
+}
+
 // Mutator defines mutations to simply replace the current map value with the
 // contents of the mutation.
 type Mutator struct{}


### PR DESCRIPTION
Previously, tink types were being registered in tests, but this lead to the unfortunate result that they were missing when run from the binary. 

This PR registers the standard Tink types in the same modules in which they are used. 