### PR TITLE
Exit sequencer when sequencing fails.

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -100,14 +100,13 @@ func main() {
 	glog.Infof("Signer starting")
 
 	// Run servers
-	cctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		if err := signer.ListenForNewDomains(cctx, *refresh); err != nil {
-			glog.Errorf("StartSequencingAll(): %v", err)
-		}
-	}()
-	run(adminServer)
-	cancel()
+	httpServer := startHTTPServer(adminServer)
 
+	cctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := signer.ListenForNewDomains(cctx, *refresh); err != nil {
+		glog.Errorf("StartSequencingAll(): %v", err)
+	}
+	httpServer.Shutdown(cctx)
 	glog.Errorf("Signer exiting")
 }


### PR DESCRIPTION
This PR allows the main thread to call `http.Shutdown`
when the sequencing thread exits.