### PR TITLE
Strengthen CreateDomain

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -285,9 +285,12 @@ func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) err
 	}
 
 	// TODO(gbelvin): does this need to be in a retry loop?
-	resp, err := s.tmap.GetSignedMapRoot(ctx, &tpb.GetSignedMapRootRequest{MapId: mapID})
+	resp, err := s.tmap.GetSignedMapRootByRevision(ctx, &tpb.GetSignedMapRootByRevisionRequest{
+		MapId:    mapID,
+		Revision: 0,
+	})
 	if err != nil {
-		return fmt.Errorf("adminserver: GetSignedMapRoot(%v): %v", mapID, err)
+		return fmt.Errorf("adminserver: GetSignedMapRootByRevision(%v,0): %v", mapID, err)
 	}
 	mapVerifier, err := client.NewMapVerifierFromTree(mapTree)
 	if err != nil {

--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -238,14 +238,10 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 	// Initialize log with first map root.
 	if err := s.initialize(ctx, logTree, mapTree); err != nil {
 		// Delete log and map if initialization fails.
-		if _, delErr := s.logAdmin.DeleteTree(ctx, &tpb.DeleteTreeRequest{TreeId: logTree.TreeId}); delErr != nil {
-			return nil, status.Errorf(codes.Internal, "adminserver: CreateAndInitTree(map): %v, DeleteTree(%v): %v ", err, logTree.TreeId, delErr)
-		}
-		if _, delErr := s.mapAdmin.DeleteTree(ctx, &tpb.DeleteTreeRequest{TreeId: mapTree.TreeId}); delErr != nil {
-			return nil, status.Errorf(codes.Internal, "adminserver: CreateAndInitTree(map): %v, DeleteTree(%v): %v ", err, mapTree.TreeId, delErr)
-		}
-		return nil, status.Errorf(codes.Internal, "adminserver: initialize of log %v and map %v failed: %v",
-			logTree.TreeId, mapTree.TreeId, err)
+		_, delLogErr := s.logAdmin.DeleteTree(ctx, &tpb.DeleteTreeRequest{TreeId: logTree.TreeId})
+		_, delMapErr := s.mapAdmin.DeleteTree(ctx, &tpb.DeleteTreeRequest{TreeId: mapTree.TreeId})
+		return nil, status.Errorf(codes.Internal, "adminserver: init of log with first map root failed: %v. Cleanup: delete log %v: %v, delete map %v: %v",
+			err, logTree.TreeId, delLogErr, mapTree.TreeId, delMapErr)
 	}
 
 	if err := s.domains.Write(ctx, &domain.Domain{

--- a/core/fake/domain_storage.go
+++ b/core/fake/domain_storage.go
@@ -16,9 +16,10 @@ package fake
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/keytransparency/core/domain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // DomainStorage implements domain.Storage
@@ -52,7 +53,7 @@ func (a *DomainStorage) Write(ctx context.Context, d *domain.Domain) error {
 func (a *DomainStorage) Read(ctx context.Context, ID string, showDeleted bool) (*domain.Domain, error) {
 	d, ok := a.domains[ID]
 	if !ok {
-		return nil, fmt.Errorf("Domain %v not found", ID)
+		return nil, status.Errorf(codes.NotFound, "Domain %v not found", ID)
 	}
 	return d, nil
 }
@@ -61,7 +62,7 @@ func (a *DomainStorage) Read(ctx context.Context, ID string, showDeleted bool) (
 func (a *DomainStorage) SetDelete(ctx context.Context, ID string, isDeleted bool) error {
 	_, ok := a.domains[ID]
 	if !ok {
-		return fmt.Errorf("Domain %v not found", ID)
+		return status.Errorf(codes.NotFound, "Domain %v not found", ID)
 	}
 	a.domains[ID].Deleted = isDeleted
 	return nil

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -115,10 +115,14 @@ func (m *Monitor) ProcessLoop(ctx context.Context, domainID string, trusted type
 	pairs := make(chan EpochPair)
 
 	go func(ctx context.Context) {
-		errc <- m.cli.StreamEpochs(ctx, domainID, int64(trusted.TreeSize), epochs)
+		err := <-m.cli.StreamEpochs(ctx, domainID, int64(trusted.TreeSize), epochs)
+		glog.Errorf("StreamEpochs(%v): %v", domainID, err)
+		errc <- err
 	}(cctx)
 	go func(ctx context.Context) {
-		errc <- EpochPairs(ctx, epochs, pairs)
+		err := EpochPairs(ctx, epochs, pairs)
+		glog.Errorf("EpochPairs(): %v", err)
+		errc <- err
 	}(cctx)
 	defer cancel()
 

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -115,7 +115,7 @@ func (m *Monitor) ProcessLoop(ctx context.Context, domainID string, trusted type
 	pairs := make(chan EpochPair)
 
 	go func(ctx context.Context) {
-		err := <-m.cli.StreamEpochs(ctx, domainID, int64(trusted.TreeSize), epochs)
+		err := m.cli.StreamEpochs(ctx, domainID, int64(trusted.TreeSize), epochs)
 		glog.Errorf("StreamEpochs(%v): %v", domainID, err)
 		errc <- err
 	}(cctx)

--- a/impl/sql/domain/storage.go
+++ b/impl/sql/domain/storage.go
@@ -26,6 +26,8 @@ import (
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/keytransparency/core/domain"
 	"github.com/google/trillian/crypto/keyspb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -170,7 +172,9 @@ func (s *storage) Read(ctx context.Context, domainID string, showDeleted bool) (
 		&d.MapID, &d.LogID,
 		&pubkey, &anyData,
 		&d.MinInterval, &d.MaxInterval,
-		&d.Deleted); err != nil {
+		&d.Deleted); err == sql.ErrNoRows {
+		return nil, status.Errorf(codes.NotFound, "%v", err)
+	} else if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR addresses some mid-CreateDomain issues that were cropping up in production and seeks to increase test cases coverage. 

* Handle the AlreadyExists Case
* Handle a mid-tree creation failure by deleting other tree.
* Add unit testing with mocks.