### PR TITLE
Move userCreds func to cmd/client

### DIFF
--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc"
 )
 
 var (
@@ -68,7 +69,7 @@ var hammerCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		h, err := hammer.New(ctx, dial, authentication.GetFakeCredential,
+		h, err := hammer.New(ctx, dial, callOptions,
 			ktURL, domainID, timeout, keyset)
 		if err != nil {
 			return err
@@ -77,4 +78,10 @@ var hammerCmd = &cobra.Command{
 		h.Run(ctx, maxOperations, maxWorkers, ramp)
 		return nil
 	},
+}
+
+func callOptions(userID string) []grpc.CallOption {
+	return []grpc.CallOption{
+		grpc.PerRPCCredentials(authentication.GetFakeCredential(userID)),
+	}
 }

--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/keytransparency/core/client/hammer"
+	"github.com/google/keytransparency/impl/authentication"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -67,7 +68,8 @@ var hammerCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		h, err := hammer.New(ctx, dial, ktURL, domainID, timeout, keyset)
+		h, err := hammer.New(ctx, dial, authentication.GetFakeCredential,
+			ktURL, domainID, timeout, keyset)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The previous few PRs (#974  #973 ) migrated authentication and authorization from `/core` to implementation specific grpc interceptors. 

This PR refactors the `PerRPCCredentials` creation out of `/core/client` into implementation specific `/cmd/keytransparency-client`.   The `CallOptions` even has the flexibility to not return any options for situations where an implementation has chosen to not implement authorization controls. 