### PR TITLE
Move get authentication function to `/impl`

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -242,7 +242,7 @@ func (c *Client) Update(ctx context.Context, u *tpb.User, signers []*tink.Keyset
 	}
 
 	// 2. Queue Mutation.
-	if err := c.QueueMutation(ctx, m, signers); err != nil {
+	if err := c.QueueMutation(ctx, m, signers, opts...); err != nil {
 		return nil, err
 	}
 

--- a/core/integration/alltests.go
+++ b/core/integration/alltests.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/keytransparency/core/client"
 	"github.com/google/keytransparency/core/mutator"
+	"google.golang.org/grpc"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
@@ -34,7 +35,11 @@ type Env struct {
 	Domain   *pb.Domain
 	Receiver mutator.Receiver
 	Timeout  time.Duration
+	CallOpts CallOptions
 }
+
+// CallOptions returns grpc.CallOptions for the requested user.
+type CallOptions func(userID string) []grpc.CallOption
 
 // NamedTestFn is a binding between a readable test name (used for a Go subtest)
 // and a function that performs the test, given a test environment.
@@ -49,7 +54,6 @@ type NamedTestFn struct {
 var AllTests = []NamedTestFn{
 	// Client Tests
 	{"TestEmptyGetAndUpdate", TestEmptyGetAndUpdate},
-	{"TestUpdateValidation", TestUpdateValidation},
 	{"TestListHistory", TestListHistory},
 	// Monitor Tests
 	{"TestMonitor", TestMonitor},

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/keytransparency/core/monitor"
 	"github.com/google/keytransparency/core/testutil"
-	"github.com/google/keytransparency/impl/authentication"
 	"github.com/google/tink/go/tink"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -100,10 +99,10 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 		},
 	} {
 		for _, u := range e.userUpdates {
-			actx := authentication.WithOutgoingFakeAuth(ctx, u.UserId)
-			cctx, cancel := context.WithTimeout(actx, 500*time.Millisecond)
+			opts := env.CallOpts(u.UserId)
+			cctx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
 			defer cancel()
-			if _, err = env.Client.Update(cctx, u, e.signers); err != context.DeadlineExceeded {
+			if _, err = env.Client.Update(cctx, u, e.signers, opts...); err != context.DeadlineExceeded {
 				t.Fatalf("Could not send update request: %v", err)
 			}
 		}

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -11,7 +11,7 @@
 	      }
              },
   "Severity": {"license": "error"},
-  "Enable": ["license", "imports-impl"],
+  "Enable": ["license", "imports-impl", "gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert", "megacheck", "gas"],
   "Vendor": true,
   "VendoredLinters": true,
   "Exclude": [

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,10 +1,17 @@
 {
   "Linters": {
 	      "errcheck": "errcheck -abspath -ignore 'Close|Write|Serve' {path}:PATH:LINE:COL:MESSAGE",
-	      "license": "grep -rL 'Apache License' {path}:^(?P<path>.[^.]+\\.(go|proto))$"
+	      "license": {
+		      "Command": "grep -rL 'Apache License'",
+		      "Pattern": "^(?P<path>.[^.]+\\.(go|proto))$"
+	      },
+	      "imports-impl": {
+		      "Command": "grep -rl 'keytransparency/impl'",
+		      "Pattern": "^(?P<path>\\./core.*(go|proto))$"
+	      }
              },
   "Severity": {"license": "error"},
-  "Enable": ["license", "gofmt", "golint", "vet", "ineffassign", "misspell", "gocyclo", "deadcode", "varcheck", "unconvert", "megacheck", "gas"],
+  "Enable": ["license", "imports-impl"],
   "Vendor": true,
   "VendoredLinters": true,
   "Exclude": [

--- a/impl/authentication/fake.go
+++ b/impl/authentication/fake.go
@@ -56,7 +56,7 @@ func (c fakeCredential) GetRequestMetadata(ctx context.Context, uri ...string) (
 }
 
 func (c fakeCredential) RequireTransportSecurity() bool {
-	return true
+	return false
 }
 
 // WithOutgoingFakeAuth returns a ctx with FakeAuth information for userID.

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -215,6 +215,9 @@ func NewEnv() (*Env, error) {
 			Domain:   domainPB,
 			Receiver: receiver,
 			Timeout:  500 * time.Millisecond,
+			CallOpts: func(userID string) []grpc.CallOption {
+				return []grpc.CallOption{grpc.PerRPCCredentials(authentication.GetFakeCredential(userID))}
+			},
 		},
 		mapEnv:     mapEnv,
 		logEnv:     logEnv,


### PR DESCRIPTION
Move the `WithFakeAuth` function from `core/integration` to `GetOpts` in `impl/integration/env`. All credential information is now deployment specific since #974. 

This PR also
-  introduces a new linter to make sure that nothing in `core` imports things from `impl`. 
- Removes the `TestUpdateValidation` integration test because it was only testing whether the authentication code was working. This is now checked in the authentication packages themselves. 