### PR TITLE
Fix hammer off-by-one

### DIFF
--- a/core/client/hammer/hammer.go
+++ b/core/client/hammer/hammer.go
@@ -103,7 +103,8 @@ func (h *Hammer) launchWorkers(ctx context.Context, jobs <-chan int, workers int
 	go func() {
 		rampTicker := time.NewTicker(ramp / time.Duration(workers))
 		var wg sync.WaitGroup
-		for ; h.workers < workers; h.workers++ {
+		for h.workers < workers {
+			h.workers++
 			wg.Add(1)
 			go func() {
 				defer wg.Done()


### PR DESCRIPTION
Move the increment variable before the wait at the end of the function.

The loop was creating the correct number of jobs, but because the wait is at the end of the loop, real-time statistics were one less than they should be. 