### PR TITLE
Assert number of items in queue during tests

### DIFF
--- a/cmd/gen-test-vectors/main.go
+++ b/cmd/gen-test-vectors/main.go
@@ -175,9 +175,11 @@ func GenerateTestVectors(ctx context.Context, env *integration.Env) error {
 			if got, want := err, context.DeadlineExceeded; got != want {
 				return fmt.Errorf("Update(%v): %v, want %v", tc.userID, got, want)
 			}
-			cctx, cancel = context.WithTimeout(tc.ctx, env.Timeout)
-			defer cancel()
-			env.Receiver.Flush(cctx)
+
+			if err := env.Receiver.FlushN(ctx, 1); err != nil {
+				return fmt.Errorf("FlushN(1): %v", err)
+			}
+
 			cctx, cancel = context.WithTimeout(tc.ctx, env.Timeout)
 			defer cancel()
 			if _, err := env.Client.WaitForUserUpdate(cctx, m); err != nil {

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -210,20 +210,20 @@ func TestListHistory(ctx context.Context, env *Env, t *testing.T) {
 		wantErr     bool
 	}{
 		{-1, 1, [][]byte{}, true},                                                        // start epoch < 0: expect error
-		{0, 1, [][]byte{}, false},                                                        // no profile yet
-		{1, 2, [][]byte{cp(1)}, false},                                                   // single profile (first entry at 3)
-		{2, 2, [][]byte{cp(1)}, false},                                                   // single profile (first entry at 3)
-		{3, 3, [][]byte{cp(2)}, false},                                                   // single (changed) profile
-		{4, 4, [][]byte{cp(2)}, false},                                                   // single (unchanged) profile
+		{1, 2, [][]byte{}, false},                                                        // no profile yet
+		{2, 3, [][]byte{cp(1)}, false},                                                   // single profile (first entry at 3)
+		{3, 3, [][]byte{cp(1)}, false},                                                   // single profile (first entry at 3)
+		{4, 4, [][]byte{cp(2)}, false},                                                   // single (changed) profile
 		{5, 5, [][]byte{cp(2)}, false},                                                   // single (unchanged) profile
-		{6, 6, [][]byte{cp(3)}, false},                                                   // single (changed) profile
-		{2, 3, [][]byte{cp(1), cp(2)}, false},                                            // multiple profiles
-		{0, 3, [][]byte{cp(1), cp(2)}, false},                                            // test 'nil' first profile(s)
-		{2, 9, [][]byte{cp(1), cp(2), cp(3), cp(4), cp(5)}, false},                       // filtering
-		{8, 15, [][]byte{cp(4), cp(5), cp(6)}, false},                                    // filtering consecutive resubmitted profiles
-		{8, 18, [][]byte{cp(4), cp(5), cp(6), cp(5), cp(7)}, false},                      // no filtering of resubmitted profiles
-		{0, 18, [][]byte{cp(1), cp(2), cp(3), cp(4), cp(5), cp(6), cp(5), cp(7)}, false}, // multiple pages
-		{0, 1000, [][]byte{}, true},                                                      // Invalid end epoch, beyond current epoch
+		{6, 6, [][]byte{cp(2)}, false},                                                   // single (unchanged) profile
+		{7, 7, [][]byte{cp(3)}, false},                                                   // single (changed) profile
+		{3, 4, [][]byte{cp(1), cp(2)}, false},                                            // multiple profiles
+		{1, 4, [][]byte{cp(1), cp(2)}, false},                                            // test 'nil' first profile(s)
+		{3, 10, [][]byte{cp(1), cp(2), cp(3), cp(4), cp(5)}, false},                      // filtering
+		{9, 16, [][]byte{cp(4), cp(5), cp(6)}, false},                                    // filtering consecutive resubmitted profiles
+		{9, 19, [][]byte{cp(4), cp(5), cp(6), cp(5), cp(7)}, false},                      // no filtering of resubmitted profiles
+		{1, 19, [][]byte{cp(1), cp(2), cp(3), cp(4), cp(5), cp(6), cp(5), cp(7)}, false}, // multiple pages
+		{1, 1001, [][]byte{}, true},                                                      // Invalid end epoch, beyond current epoch
 	} {
 		_, resp, err := env.Client.PaginateHistory(ctx, appID, userID, tc.start, tc.end)
 		if got := err != nil; got != tc.wantErr {

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -179,7 +179,9 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 					t.Fatalf("QueueMutation(%v): %v", tc.userID, err)
 				}
 
-				env.Receiver.Flush(ctx)
+				if err := env.Receiver.FlushN(ctx, 1); err != nil {
+					t.Fatalf("FlushN(1): %v", err)
+				}
 
 				if _, err := env.Client.WaitForUserUpdate(cctx, m); err != nil {
 					t.Errorf("WaitForUserUpdate(%v): %v, want nil", m, err)
@@ -276,14 +278,18 @@ func (env *Env) setupHistory(ctx context.Context, domain *pb.Domain, userID stri
 				return fmt.Errorf("QueueMutation(%v): %v", userID, err)
 			}
 
-			env.Receiver.Flush(ctx)
+			if err := env.Receiver.FlushN(ctx, 1); err != nil {
+				return fmt.Errorf("FlushN(1): %v", err)
+			}
 
 			if _, err := env.Client.WaitForUserUpdate(cctx, m); err != nil {
 				return fmt.Errorf("WaitForUserUpdate(%v): %v, want nil", m, err)
 			}
 		} else {
 			// Create an empty epoch.
-			env.Receiver.Flush(ctx)
+			if err := env.Receiver.FlushN(ctx, 0); err != nil {
+				return fmt.Errorf("FlushN(0): %v", err)
+			}
 		}
 	}
 	return nil

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -111,7 +111,9 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 			}
 		}
 
-		env.Receiver.Flush(ctx)
+		if err := env.Receiver.FlushN(ctx, len(e.userUpdates)); err != nil {
+			t.Fatalf("FlushN(%v): %v", len(e.userUpdates), err)
+		}
 		if err := env.Client.WaitForRevision(ctx, e.epoch); err != nil {
 			t.Fatalf("WaitForRevision(): %v", err)
 		}

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -79,7 +79,8 @@ type ReceiveFunc func([]*QueueMessage) error
 type Receiver interface {
 	// Close stops the receiver and returns only when all callbacks are complete.
 	Close()
-	// Flush waits for n items and then sends them.
+	// FlushN waits for n items and then sends them.
+	// Deterministic implementations that can't wait will return an error.
 	FlushN(context.Context, int) error
 }
 

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -79,8 +79,8 @@ type ReceiveFunc func([]*QueueMessage) error
 type Receiver interface {
 	// Close stops the receiver and returns only when all callbacks are complete.
 	Close()
-	// Flush sends any waiting queue items.
-	Flush(context.Context)
+	// Flush waits for n items and then sends them.
+	FlushN(context.Context, int) error
 }
 
 // ReceiverOptions holds options for setting up a receiver.

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -326,7 +326,7 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 	indexCTR.Add(float64(len(indexes)))
 	mapUpdateHist.Observe(mapSetEnd.Sub(mapSetStart).Seconds())
 	createEpochHist.Observe(time.Since(start).Seconds())
-	glog.Infof("CreatedEpoch: rev: %v, root: %x", mapRoot.Revision, mapRoot.RootHash)
+	glog.Infof("CreatedEpoch: rev: %v with %v mutations, root: %x", mapRoot.Revision, len(msgs), mapRoot.RootHash)
 	return nil
 }
 

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -186,6 +186,7 @@ func NewEnv() (*Env, error) {
 		MinInterval: time.Duration(domainPB.MinInterval.Seconds) * time.Second,
 		MaxInterval: time.Duration(domainPB.MaxInterval.Seconds) * time.Second,
 	}
+	// NewReceiver will create a fist map revision right away.
 	receiver, err := seq.NewReceiver(ctx, d)
 	if err != nil {
 		return nil, fmt.Errorf("env: NewReceiver(): %v", err)
@@ -209,6 +210,9 @@ func NewEnv() (*Env, error) {
 	}
 	// Integration tests manually create epochs immediately, so retry fairly quickly.
 	client.RetryDelay = 10 * time.Millisecond
+	if err := client.WaitForRevision(ctx, 1); err != nil {
+		return nil, fmt.Errorf("WaitForRevision(1): %v", err)
+	}
 
 	return &Env{
 		Env: &integration.Env{


### PR DESCRIPTION
Some queue implementations are asynchronous.  Therefore tests need to wait for the expected number of items to arrive at the receiver before continuing. 

This PR also resolves another race condition: During env setup, `seq.NewReceiver` creates a map revision, so now we wait for this revision to complete before returning `env`.  As a result, we also need to add 1 to the list history test expectations. 