### PR TITLE
Place MapRoots into Log by index

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -45,7 +45,7 @@ var (
 		Tree: &tpb.Tree{
 			DisplayName: "KT SMH Log",
 			TreeState:   tpb.TreeState_ACTIVE,
-			TreeType:    tpb.TreeType_LOG,
+			TreeType:    tpb.TreeType_PREORDERED_LOG,
 			// Clients that verify output from the log need to import
 			// _ "github.com/google/trillian/merkle/rfc6962"
 			HashStrategy:       tpb.HashStrategy_RFC6962_SHA256,
@@ -310,9 +310,8 @@ func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) err
 
 	glog.Infof("Initializing Trillian Log %v with empty map root", logID)
 
-	// Non-blocking add leaf
-	if err := logClient.AddLeaf(ctx, resp.GetMapRoot().GetMapRoot()); err != nil {
-		return fmt.Errorf("adminserver: log.AddLeaf(): %v", err)
+	if err := logClient.AddSequencedLeafAndWait(ctx, resp.GetMapRoot().GetMapRoot(), int64(mapRoot.Revision)); err != nil {
+		return fmt.Errorf("adminserver: log.AddSequencedLeaf(%v): %v", mapRoot.Revision, err)
 	}
 	return nil
 }

--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -103,7 +103,7 @@ func TestCreateDomain(t *testing.T) {
 			domainID: "mapinitfails",
 			wantCode: codes.Internal,
 			expect: func(e *miniEnv) {
-				e.ms.Admin.EXPECT().CreateTree(gomock.Any(), gomock.Any()).Return(&tpb.Tree{TreeType: tpb.TreeType_LOG}, nil)
+				e.ms.Admin.EXPECT().CreateTree(gomock.Any(), gomock.Any()).Return(&tpb.Tree{TreeType: tpb.TreeType_PREORDERED_LOG}, nil)
 				e.ms.Log.EXPECT().InitLog(gomock.Any(), gomock.Any()).Return(&tpb.InitLogResponse{}, nil)
 				e.ms.Log.EXPECT().GetLatestSignedLogRoot(gomock.Any(), gomock.Any()).Return(&tpb.GetLatestSignedLogRootResponse{}, nil)
 				e.ms.Admin.EXPECT().CreateTree(gomock.Any(), gomock.Any()).Return(&tpb.Tree{TreeType: tpb.TreeType_MAP}, nil)
@@ -117,7 +117,7 @@ func TestCreateDomain(t *testing.T) {
 			domainID: "initfails",
 			wantCode: codes.Internal,
 			expect: func(e *miniEnv) {
-				e.ms.Admin.EXPECT().CreateTree(gomock.Any(), gomock.Any()).Return(&tpb.Tree{TreeType: tpb.TreeType_LOG}, nil)
+				e.ms.Admin.EXPECT().CreateTree(gomock.Any(), gomock.Any()).Return(&tpb.Tree{TreeType: tpb.TreeType_PREORDERED_LOG}, nil)
 				e.ms.Log.EXPECT().InitLog(gomock.Any(), gomock.Any()).Return(&tpb.InitLogResponse{}, nil)
 				e.ms.Log.EXPECT().GetLatestSignedLogRoot(gomock.Any(), gomock.Any()).Return(&tpb.GetLatestSignedLogRootResponse{}, nil)
 				e.ms.Admin.EXPECT().CreateTree(gomock.Any(), gomock.Any()).Return(&tpb.Tree{TreeType: tpb.TreeType_MAP}, nil)
@@ -195,7 +195,7 @@ func TestCreateRead(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetDomain(): %v", err)
 		}
-		if got, want := domain.Log.TreeType, tpb.TreeType_LOG; got != want {
+		if got, want := domain.Log.TreeType, tpb.TreeType_PREORDERED_LOG; got != want {
 			t.Errorf("Log.TreeType: %v, want %v", got, want)
 		}
 		if got, want := domain.Map.TreeType, tpb.TreeType_MAP; got != want {

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -316,8 +316,8 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 	}
 
 	// Put SignedMapHead in an append only log.
-	if err := queueLogLeaf(ctx, logClient, setResp.GetMapRoot()); err != nil {
-		glog.Fatalf("queueLogLeaf(logID: %v, rev: %v): %v", d.LogID, mapRoot.Revision, err)
+	if err := logClient.AddSequencedLeafAndWait(ctx, setResp.GetMapRoot().GetMapRoot(), int64(mapRoot.Revision)); err != nil {
+		glog.Fatalf("AddSequencedLeaf(logID: %v, rev: %v): %v", d.LogID, mapRoot.Revision, err)
 		// TODO(gdbelvin): If the log doesn't do this, we need to generate an emergency alert.
 		return err
 	}
@@ -328,10 +328,4 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 	createEpochHist.Observe(time.Since(start).Seconds())
 	glog.Infof("CreatedEpoch: rev: %v, root: %x", mapRoot.Revision, mapRoot.RootHash)
 	return nil
-}
-
-// TODO(gdbelvin): Add leaf at a specific index. trillian#423
-func queueLogLeaf(ctx context.Context, logClient *tclient.LogClient, smr *tpb.SignedMapRoot) error {
-	// Queue the leaf and then wait until it has been sequenced and verified.
-	return logClient.AddLeaf(ctx, smr.MapRoot)
 }

--- a/core/testdata/domain.json
+++ b/core/testdata/domain.json
@@ -3,7 +3,7 @@
 	"log": {
 		"treeId": "1732270362285615536",
 		"treeState": "ACTIVE",
-		"treeType": "LOG",
+		"treeType": "PREORDERED_LOG",
 		"hashStrategy": "RFC6962_SHA256",
 		"hashAlgorithm": "SHA256",
 		"signatureAlgorithm": "ECDSA",


### PR DESCRIPTION
Now that PREORDERED_LOGs are a thing, we can insert map roots into the
log in a deterministic way, and remove the sword of Damocles that was
previously there due to non-deterministic log sequencing

