### PR TITLE
Add batch-size flag and metric

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -42,9 +42,10 @@ var (
 	serverDBPath = flag.String("db", "db", "Database connection string")
 
 	// Info to connect to the trillian map and log.
-	mapURL  = flag.String("map-url", "", "URL of Trillian Map Server")
-	logURL  = flag.String("log-url", "", "URL of Trillian Log Server for Signed Map Heads")
-	refresh = flag.Duration("domain-refresh", 5*time.Second, "Time to detect new domain")
+	mapURL    = flag.String("map-url", "", "URL of Trillian Map Server")
+	logURL    = flag.String("log-url", "", "URL of Trillian Log Server for Signed Map Heads")
+	refresh   = flag.Duration("domain-refresh", 5*time.Second, "Time to detect new domain")
+	batchSize = flag.Int("batch-size", 100, "Maximum number of mutations to process per map revision")
 )
 
 func openDB() *sql.DB {
@@ -90,7 +91,7 @@ func main() {
 	queue := mutator.MutationQueue(mutations)
 
 	// Create servers
-	signer := sequencer.New(tlog, logAdmin, tmap, mapAdmin, entry.New(), domainStorage, mutations, queue, prometheus.MetricFactory{})
+	signer := sequencer.New(tlog, logAdmin, tmap, mapAdmin, entry.New(), domainStorage, mutations, queue, prometheus.MetricFactory{}, *batchSize)
 	keygen := func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 		return der.NewProtoFromSpec(spec)
 	}

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -263,7 +263,7 @@ func (s *Sequencer) applyMutations(mutations []*mutator.QueueMessage, leaves []*
 func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient *tclient.LogClient, mapVerifier *tclient.MapVerifier, msgs []*mutator.QueueMessage) error {
 	glog.Infof("CreateEpoch: starting sequencing run with %d mutations", len(msgs))
 	start := time.Now()
-	batchSize.Set(float64(len(msgs)))
+	batchSize.Set(float64(len(msgs)), d.DomainID)
 	sequencingRuns.Inc(d.DomainID)
 	// Get the current root.
 	rootResp, err := s.tmap.GetSignedMapRoot(ctx, &tpb.GetSignedMapRootRequest{MapId: d.MapID})

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -182,7 +182,8 @@ func NewEnv() (*Env, error) {
 	pb.RegisterKeyTransparencyServer(gsvr, server)
 
 	// Sequencer
-	seq := sequencer.New(logEnv.Log, logEnv.Admin, mapEnv.Map, mapEnv.Admin, entry.New(), domainStorage, mutations, queue, monitoring.InertMetricFactory{})
+	batchSize := 100
+	seq := sequencer.New(logEnv.Log, logEnv.Admin, mapEnv.Map, mapEnv.Admin, entry.New(), domainStorage, mutations, queue, monitoring.InertMetricFactory{}, batchSize)
 	d := &domaindef.Domain{
 		DomainID:    domainPB.DomainId,
 		LogID:       domainPB.Log.TreeId,


### PR DESCRIPTION
Control the maximum number of mutations the Key Transparency sequencer processes per map revision.

Also adds visibility into the number of mutations the sequencer is attempting to process during each map revision. 