### PR TITLE
Write glog.Errorf for errors

### DIFF
--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -268,7 +268,7 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 	mapRoot, err := mapVerifier.VerifySignedMapRoot(rootResp.GetMapRoot())
 	if err != nil {
 		sequencingFailures.Inc(d.DomainID)
-		return err
+		return fmt.Errorf("VerifySignedMapRoot(): %v", err)
 	}
 	glog.V(3).Infof("CreateEpoch: Previous SignedMapRoot: {Revision: %v}", mapRoot.Revision)
 
@@ -284,7 +284,7 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 	})
 	if err != nil {
 		sequencingFailures.Inc(d.DomainID)
-		return err
+		return fmt.Errorf("tmap.GetLeaves(): %v", err)
 	}
 	glog.V(3).Infof("CreateEpoch: len(GetLeaves.MapLeafInclusions): %v",
 		len(getResp.MapLeafInclusion))
@@ -312,12 +312,12 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 	})
 	if err != nil {
 		sequencingFailures.Inc(d.DomainID)
-		return err
+		return fmt.Errorf("tmap.SetLeaves(): %v", err)
 	}
 	mapRoot, err = mapVerifier.VerifySignedMapRoot(setResp.GetMapRoot())
 	if err != nil {
 		sequencingFailures.Inc(d.DomainID)
-		return err
+		return fmt.Errorf("VerifySignedMapRoot(): %v", err)
 	}
 	glog.V(2).Infof("CreateEpoch: SetLeaves:{Revision: %v}", mapRoot.Revision)
 
@@ -329,7 +329,7 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 	if err := s.mutations.WriteBatch(ctx, d.DomainID, int64(mapRoot.Revision), mutations); err != nil {
 		glog.Fatalf("Could not write mutations for revision %v: %v", mapRoot.Revision, err)
 		sequencingFailures.Inc(d.DomainID)
-		return err
+		return fmt.Errorf("mutations.WriteBatch(): %v", err)
 	}
 
 	// Put SignedMapHead in an append only log.
@@ -337,7 +337,7 @@ func (s *Sequencer) createEpoch(ctx context.Context, d *domain.Domain, logClient
 		sequencingFailures.Inc(d.DomainID)
 		glog.Fatalf("AddSequencedLeaf(logID: %v, rev: %v): %v", d.LogID, mapRoot.Revision, err)
 		// TODO(gdbelvin): If the log doesn't do this, we need to generate an emergency alert.
-		return err
+		return fmt.Errorf("tlog.AddSequencedLeafAndWait(): %v", err)
 	}
 
 	mutationCount.Add(float64(len(msgs)), d.DomainID)

--- a/impl/sql/mutationstorage/queue.go
+++ b/impl/sql/mutationstorage/queue.go
@@ -139,7 +139,7 @@ func (r *Receiver) sendBatch(ctx context.Context, minBatch, maxBatch int32) int3
 	}
 
 	if err := r.recieveFunc(ms); err != nil {
-		glog.Infof("queue.SendBatch failed: %v", err)
+		glog.Errorf("queue.SendBatch(): %v", err)
 		return 0
 	}
 	// TODO(gbelvin): Do we need finer grained errors?


### PR DESCRIPTION
Sequencing errors were being info logged rather than err logged.

Also wraps errors during sequencing to better identify them