### PR TITLE
Fix queue deadlock

### DIFF
--- a/impl/sql/mutationstorage/queue.go
+++ b/impl/sql/mutationstorage/queue.go
@@ -111,6 +111,7 @@ func (r *Receiver) run(ctx context.Context, last time.Time) {
 	for {
 		select {
 		case <-r.ticker.C:
+			// We will be overdue for an epoch soon.
 			if _, err := r.sendMultiBatch(ctx, 1, int(r.opts.MaxBatchSize)); err != nil {
 				glog.Errorf("minTick: sendMultiBatch(): %v", err)
 			}
@@ -132,6 +133,9 @@ func (r *Receiver) run(ctx context.Context, last time.Time) {
 func (r *Receiver) sendMultiBatch(ctx context.Context, minMsgs, maxMsgs int) (int, error) {
 	var total int
 	var err error
+	if minMsgs > maxMsgs {
+		minMsgs = maxMsgs
+	}
 	for sent := maxMsgs; sent >= maxMsgs; {
 		sent, err = r.sendBatch(ctx, minMsgs, maxMsgs)
 		if err != nil {

--- a/impl/sql/mutationstorage/queue_test.go
+++ b/impl/sql/mutationstorage/queue_test.go
@@ -155,10 +155,10 @@ func TestQueueSendBatch(t *testing.T) {
 			batchSize:   10,
 		},
 	} {
-		var wg sync.WaitGroup
-		wg.Add(len(tc.updates))
-		var i int
 		t.Run(tc.description, func(t *testing.T) {
+			var wg sync.WaitGroup
+			wg.Add(len(tc.updates))
+			var i int
 			r, ok := m.NewReceiver(ctx, time.Now(), domainID, func(msgs []*mutator.QueueMessage) error {
 				if got, want := len(msgs), len(tc.updates[i]); got != want {
 					t.Errorf("len(msgs): %v, want %v", got, want)


### PR DESCRIPTION
Use a slightly simpler loop for sending multiple batches.

The previous implementation used a more chanel with a small buffer.
This worked as long as the select loop never chooses min.C when it
could have selected the more channel.