### PR TITLE
Add integration test to code coverage metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ genfiles/*
 travis_secrets.tar.gz
 service_key.json
 client_secret*.json
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ addons:
     - python3-pip
 
 install:
-  - go get github.com/wadey/gocovmerge
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter --install 
   - go get -t ./...
@@ -27,11 +26,10 @@ install:
 script:
   - make
   - gometalinter --config=gometalinter.json ./...
-  - go test ./... -coverprofile=out1.txt
-  - TRILLIAN_SQL_DRIVER=mysql go test ./impl/integration/ -coverprofile=out2.txt -coverpkg=./...
+  - go test ./... -coverprofile=coverage1.txt
+  - TRILLIAN_SQL_DRIVER=mysql go test ./impl/integration/ -coverprofile=coverage2.txt -coverpkg=./...
 
 after_success:
-  - gocovmerge out1.txt out2.txt > coverage.txt
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
     - python3-pip
 
 install:
+  - go get github.com/wadey/gocovmerge
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter --install 
   - go get -t ./...
@@ -26,9 +27,11 @@ install:
 script:
   - make
   - gometalinter --config=gometalinter.json ./...
-  - TRILLIAN_SQL_DRIVER=mysql go test ./... -coverprofile=coverage.txt
+  - go test ./... -coverprofile=out1.txt
+  - TRILLIAN_SQL_DRIVER=mysql go test ./impl/integration/ -coverprofile=out2.txt -coverpkg=./...
 
 after_success:
+  - gocovmerge out1.txt out2.txt > coverage.txt
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ addons:
   apt:
     packages:
     - python3-pip
-    - parallel
 
 install:
   - go get -u github.com/alecthomas/gometalinter
@@ -25,10 +24,9 @@ install:
   - go get -t ./...
 
 script:
-  - export TRILLIAN_SQL_DRIVER=mysql
   - make
   - gometalinter --config=gometalinter.json ./...
-  - ./coverage.sh
+  - TRILLIAN_SQL_DRIVER=mysql go test ./... -coverprofile=coverage.txt
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test: main
 	TRILLIAN_SQL_DRIVER=mysql go test ./...
 
 coverage: main
-	TRILLIAN_SQL_DRIVER=mysql go test ./... -cover 
+	TRILLIAN_SQL_DRIVER=mysql go test ./... -cover
 
 check:
 	gometalinter --config=gometalinter.json ./...

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-mkdir -p out
-go list ./... | parallel -k go test -coverprofile=out/{#} {}
-cat out/* > coverage.txt


### PR DESCRIPTION
Go 1.10 removes the need to run each test separately with the `-coverprofile` flag.

This also makes it easier to set environment variables for tests.