### PR TITLE
Explicitly trust the first observed log root

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/trillian/crypto/keys/der"
 	"github.com/google/trillian/crypto/keyspb"
 	"github.com/google/trillian/crypto/sigpb"
+	"github.com/google/trillian/types"
 
 	google_protobuf "github.com/golang/protobuf/ptypes/empty"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
@@ -277,8 +278,9 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) error {
 	logID := logTree.GetTreeId()
 	mapID := mapTree.GetTreeId()
+	trustedRoot := types.LogRootV1{} // Automatically trust the first observed log root.
 
-	logClient, err := client.NewFromTree(s.tlog, logTree)
+	logClient, err := client.NewFromTree(s.tlog, logTree, trustedRoot)
 	if err != nil {
 		return fmt.Errorf("adminserver: could not create log client: %v", err)
 	}

--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -278,6 +278,7 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 func (s *Server) initialize(ctx context.Context, logTree, mapTree *tpb.Tree) error {
 	logID := logTree.GetTreeId()
 	mapID := mapTree.GetTreeId()
+	// TODO(gbelvin): Store and track trusted root.
 	trustedRoot := types.LogRootV1{} // Automatically trust the first observed log root.
 
 	logClient, err := client.NewFromTree(s.tlog, logTree, trustedRoot)

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -190,6 +190,7 @@ func (s *Sequencer) NewReceiver(ctx context.Context, d *domain.Domain) (mutator.
 	if err != nil {
 		return nil, err
 	}
+	// TODO(gbelvin): Store and track trustedRoot.
 	trustedRoot := types.LogRootV1{} // Automatically trust the first observed log root.
 	logClient, err := tclient.NewFromTree(s.tlog, logTree, trustedRoot)
 	if err != nil {

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian/monitoring"
+	"github.com/google/trillian/types"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	tpb "github.com/google/trillian"
@@ -189,7 +190,8 @@ func (s *Sequencer) NewReceiver(ctx context.Context, d *domain.Domain) (mutator.
 	if err != nil {
 		return nil, err
 	}
-	logClient, err := tclient.NewFromTree(s.tlog, logTree)
+	trustedRoot := types.LogRootV1{} // Automatically trust the first observed log root.
+	logClient, err := tclient.NewFromTree(s.tlog, logTree, trustedRoot)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
google/trillian#1224 requires clients to explicity state what trusted
root to initially use when verifying responses from the trillian log.

This PR uses an empty root, effectively trusting the first observed
log root.