### PR TITLE
Restrict integration.Env to only grpc clients

### DIFF
--- a/core/integration/alltests.go
+++ b/core/integration/alltests.go
@@ -26,16 +26,18 @@ import (
 	"google.golang.org/grpc"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 )
 
 // Env holds a complete testing environment for end-to-end tests.
 type Env struct {
-	Client   *client.Client
-	Cli      pb.KeyTransparencyClient
-	Domain   *pb.Domain
-	Receiver mutator.Receiver
-	Timeout  time.Duration
-	CallOpts CallOptions
+	Client    *client.Client
+	Cli       pb.KeyTransparencyClient
+	Sequencer spb.KeyTransparencySequencerClient
+	Domain    *pb.Domain
+	Receiver  mutator.Receiver
+	Timeout   time.Duration
+	CallOpts  CallOptions
 }
 
 // CallOptions returns grpc.CallOptions for the requested user.

--- a/core/integration/alltests.go
+++ b/core/integration/alltests.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/google/keytransparency/core/client"
-	"github.com/google/keytransparency/core/mutator"
 	"google.golang.org/grpc"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
@@ -35,7 +34,6 @@ type Env struct {
 	Cli       pb.KeyTransparencyClient
 	Sequencer spb.KeyTransparencySequencerClient
 	Domain    *pb.Domain
-	Receiver  mutator.Receiver
 	Timeout   time.Duration
 	CallOpts  CallOptions
 }

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -287,7 +287,7 @@ func (env *Env) setupHistory(ctx context.Context, domain *pb.Domain, userID stri
 				DomainId: domain.DomainId,
 				Messages: []*pb.EntryUpdate{msg.EntryUpdate},
 			}); err != nil {
-				return fmt.Errorf("create empty epoch: %v", err)
+				return fmt.Errorf("create epoch: %v", err)
 			}
 		} else {
 			// Create an empty epoch.

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -31,6 +31,7 @@ import (
 
 	tpb "github.com/google/keytransparency/core/api/type/type_go_proto"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
@@ -287,8 +288,10 @@ func (env *Env) setupHistory(ctx context.Context, domain *pb.Domain, userID stri
 			}
 		} else {
 			// Create an empty epoch.
-			if err := env.Receiver.FlushN(ctx, 0); err != nil {
-				return fmt.Errorf("FlushN(0): %v", err)
+			if _, err := env.Sequencer.CreateEpoch(ctx, &spb.CreateEpochRequest{
+				DomainId: domain.DomainId,
+			}); err != nil {
+				return fmt.Errorf("create empty epoch: %v", err)
 			}
 		}
 	}

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -180,10 +180,6 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 					t.Fatalf("QueueMutation(%v): %v", tc.userID, err)
 				}
 
-				if err := env.Receiver.FlushN(ctx, 1); err != nil {
-					t.Fatalf("FlushN(1): %v", err)
-				}
-
 				if _, err := env.Client.WaitForUserUpdate(cctx, m); err != nil {
 					t.Errorf("WaitForUserUpdate(%v): %v, want nil", m, err)
 				}
@@ -277,10 +273,6 @@ func (env *Env) setupHistory(ctx context.Context, domain *pb.Domain, userID stri
 			}
 			if err := env.Client.QueueMutation(cctx, m, signers, opts...); err != nil {
 				return fmt.Errorf("QueueMutation(%v): %v", userID, err)
-			}
-
-			if err := env.Receiver.FlushN(ctx, 1); err != nil {
-				return fmt.Errorf("FlushN(1): %v", err)
 			}
 
 			if _, err := env.Client.WaitForUserUpdate(cctx, m); err != nil {

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -110,9 +110,6 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 			}
 		}
 
-		if err := env.Receiver.FlushN(ctx, len(e.userUpdates)); err != nil {
-			t.Fatalf("FlushN(%v): %v", len(e.userUpdates), err)
-		}
 		if err := env.Client.WaitForRevision(ctx, e.epoch); err != nil {
 			t.Fatalf("WaitForRevision(): %v", err)
 		}

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -239,11 +239,12 @@ func NewEnv() (*Env, error) {
 
 	return &Env{
 		Env: &integration.Env{
-			Client:   client,
-			Cli:      ktClient,
-			Domain:   domainPB,
-			Receiver: receiver,
-			Timeout:  timeout,
+			Client:    client,
+			Cli:       ktClient,
+			Sequencer: sequencerClient,
+			Domain:    domainPB,
+			Receiver:  receiver,
+			Timeout:   timeout,
 			CallOpts: func(userID string) []grpc.CallOption {
 				return []grpc.CallOption{grpc.PerRPCCredentials(authentication.GetFakeCredential(userID))}
 			},

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -115,7 +115,7 @@ func keyFromPEM(p string) *any.Any {
 // NewEnv sets up common resources for tests.
 func NewEnv() (*Env, error) {
 	ctx := context.Background()
-	timeout := 60 * time.Second
+	timeout := 6 * time.Second
 	domainID := fmt.Sprintf("domain_%d", rand.Int()) // nolint: gas
 
 	db, err := testdb.NewTrillianDB(ctx)

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -230,12 +230,6 @@ func NewEnv() (*Env, error) {
 	}
 	// Integration tests manually create epochs immediately, so retry fairly quickly.
 	client.RetryDelay = 10 * time.Millisecond
-	/*
-		if err := client.WaitForRevision(ctx, 1); err != nil {
-			return nil, fmt.Errorf("WaitForRevision(1): %v", err)
-		}
-	*/
-
 	return &Env{
 		Env: &integration.Env{
 			Client:    client,

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -92,6 +92,7 @@ type Env struct {
 	*integration.Env
 	mapEnv        *ttest.MapEnv
 	logEnv        *ttest.LogEnv
+	Receiver      mutator.Receiver
 	grpcServer    *grpc.Server
 	grpcCC        *grpc.ClientConn
 	db            *sql.DB
@@ -146,9 +147,8 @@ func NewEnv() (*Env, error) {
 	cctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	domainPB, err := adminSvr.CreateDomain(cctx, &pb.CreateDomainRequest{
-		DomainId: domainID,
-		// Only sequence when explicitly asked with receiver.Flush()
-		MinInterval:   ptypes.DurationProto(60 * time.Hour),
+		DomainId:      domainID,
+		MinInterval:   ptypes.DurationProto(100 * time.Millisecond),
 		MaxInterval:   ptypes.DurationProto(60 * time.Hour),
 		VrfPrivateKey: keyFromPEM(vrfPriv),
 		LogPrivateKey: keyFromPEM(logPriv),
@@ -243,12 +243,12 @@ func NewEnv() (*Env, error) {
 			Cli:       ktClient,
 			Sequencer: sequencerClient,
 			Domain:    domainPB,
-			Receiver:  receiver,
 			Timeout:   timeout,
 			CallOpts: func(userID string) []grpc.CallOption {
 				return []grpc.CallOption{grpc.PerRPCCredentials(authentication.GetFakeCredential(userID))}
 			},
 		},
+		Receiver:      receiver,
 		mapEnv:        mapEnv,
 		logEnv:        logEnv,
 		grpcServer:    gsvr,


### PR DESCRIPTION
This PR removes `Env.Receiver` which was previously being used for fine-grained control over what mutations were part of a batch. The presence of `Receiver` in `Env` prevented integration tests from being run against live servers.

This PR replace `Receiver` with 
a) Real sequencing behavior when the exact batch composition is not being tested.
b) Calls to the new`sequencer.Server.CreateEpcoh` API to create new epochs directly when exact batching is needed. 