### PR TITLE
Cleanup domains after integration test

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -346,21 +346,5 @@ func (s *Server) DeleteDomain(ctx context.Context, in *pb.DeleteDomainRequest) (
 
 // UndeleteDomain reactivates a deleted domain - provided that UndeleteDomain is called sufficiently soon after DeleteDomain.
 func (s *Server) UndeleteDomain(ctx context.Context, in *pb.UndeleteDomainRequest) (*google_protobuf.Empty, error) {
-	d, err := s.GetDomain(ctx, &pb.GetDomainRequest{DomainId: in.GetDomainId(), ShowDeleted: true})
-	if err != nil {
-		return nil, err
-	}
-
-	if err := s.domains.SetDelete(ctx, in.GetDomainId(), false); err != nil {
-		return nil, err
-	}
-
-	_, delLogErr := s.logAdmin.UndeleteTree(ctx, &tpb.UndeleteTreeRequest{TreeId: d.Log.TreeId})
-	_, delMapErr := s.mapAdmin.UndeleteTree(ctx, &tpb.UndeleteTreeRequest{TreeId: d.Map.TreeId})
-	if delLogErr != nil || delMapErr != nil {
-		return nil, status.Errorf(codes.Internal, "adminserver: undelete log %v: %v, undelete map %v: %v",
-			err, d.Log.TreeId, delLogErr, d.Map.TreeId, delMapErr)
-	}
-
-	return &google_protobuf.Empty{}, nil
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
 }

--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -255,19 +255,6 @@ func TestDelete(t *testing.T) {
 		if got, want := domain.Map.Deleted, true; got != want {
 			t.Errorf("Map.TreeState: %v, want %v", got, want)
 		}
-		if _, err := svr.UndeleteDomain(ctx, &pb.UndeleteDomainRequest{DomainId: tc.domainID}); err != nil {
-			t.Fatalf("UndeleteDomain(): %v", err)
-		}
-		domain, err = svr.GetDomain(ctx, &pb.GetDomainRequest{DomainId: tc.domainID})
-		if err != nil {
-			t.Fatalf("GetDomain(): %v", err)
-		}
-		if got, want := domain.Log.Deleted, false; got != want {
-			t.Errorf("Log.TreeState: %v, want %v", got, want)
-		}
-		if got, want := domain.Map.Deleted, false; got != want {
-			t.Errorf("Map.TreeState: %v, want %v", got, want)
-		}
 	}
 }
 

--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -235,12 +235,11 @@ func TestDelete(t *testing.T) {
 			maxInterval: 5 * time.Second,
 		},
 	} {
-		_, err := svr.CreateDomain(ctx, &pb.CreateDomainRequest{
+		if _, err := svr.CreateDomain(ctx, &pb.CreateDomainRequest{
 			DomainId:    tc.domainID,
 			MinInterval: ptypes.DurationProto(tc.minInterval),
 			MaxInterval: ptypes.DurationProto(tc.maxInterval),
-		})
-		if err != nil {
+		}); err != nil {
 			t.Fatalf("CreateDomain(): %v", err)
 		}
 		if _, err := svr.DeleteDomain(ctx, &pb.DeleteDomainRequest{DomainId: tc.domainID}); err != nil {
@@ -270,5 +269,59 @@ func TestDelete(t *testing.T) {
 			t.Errorf("Map.TreeState: %v, want %v", got, want)
 		}
 	}
+}
 
+func TestListDomains(t *testing.T) {
+	testdb.SkipIfNoMySQL(t)
+	ctx := context.Background()
+	storage := fake.NewDomainStorage()
+
+	// Map server
+	mapEnv, err := integration.NewMapEnv(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create trillian map server: %v", err)
+	}
+
+	// Log server
+	numSequencers := 1
+	unused := ""
+	logEnv, err := integration.NewLogEnv(ctx, numSequencers, unused)
+	if err != nil {
+		t.Fatalf("Failed to create trillian log server: %v", err)
+	}
+
+	svr := New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin, storage, vrfKeyGen)
+
+	for _, tc := range []struct {
+		domainIDs []string
+	}{
+		{
+			domainIDs: []string{"A", "B"},
+		},
+	} {
+		for _, domain := range tc.domainIDs {
+			if _, err := svr.CreateDomain(ctx, &pb.CreateDomainRequest{
+				DomainId:    domain,
+				MinInterval: ptypes.DurationProto(60 * time.Hour),
+				MaxInterval: ptypes.DurationProto(60 * time.Hour),
+			}); err != nil {
+				t.Fatalf("CreateDomain(%v): %v", domain, err)
+			}
+		}
+		resp, err := svr.ListDomains(ctx, &pb.ListDomainsRequest{})
+		if err != nil {
+			t.Fatalf("ListDomains(): %v", err)
+		}
+		// Make sure we got all the same domains back.
+		want := make(map[string]bool)
+		for _, d := range tc.domainIDs {
+			want[d] = true
+		}
+		for _, d := range resp.GetDomains() {
+			domainID := d.GetDomainId()
+			if ok := want[domainID]; !ok {
+				t.Errorf("Did not find domain %v in list response", domainID)
+			}
+		}
+	}
 }


### PR DESCRIPTION
At the end of an integration test, soft-delete the domain and the corresponding Trillian trees. 

TODO: 
- Run doman and tree garbage collection. 
