### PR TITLE
Fix commitment scheme comment

### DIFF
--- a/core/crypto/commitments/commitments.go
+++ b/core/crypto/commitments/commitments.go
@@ -16,7 +16,7 @@
 //
 // Commitment scheme is as follows:
 // T = HMAC(fixedKey, "Key Transparency Commitment" || 16 byte nonce || message)
-// message is defined as: len(userID) || userID || data
+// message is defined as: len(userID) || userID || len(appID) || appID || data
 package commitments
 
 import (


### PR DESCRIPTION
The commitment also includes appID as a namespace, updating the comment to reflect that.