### PR TITLE
Add missing argument to NewMapEnv

### DIFF
--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -158,7 +158,7 @@ func TestCreateRead(t *testing.T) {
 	storage := fake.NewDomainStorage()
 
 	// Map server
-	mapEnv, err := integration.NewMapEnv(ctx)
+	mapEnv, err := integration.NewMapEnv(ctx, false)
 	if err != nil {
 		t.Fatalf("Failed to create trillian map server: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestDelete(t *testing.T) {
 	storage := fake.NewDomainStorage()
 
 	// Map server
-	mapEnv, err := integration.NewMapEnv(ctx)
+	mapEnv, err := integration.NewMapEnv(ctx, false)
 	if err != nil {
 		t.Fatalf("Failed to create trillian map server: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestListDomains(t *testing.T) {
 	storage := fake.NewDomainStorage()
 
 	// Map server
-	mapEnv, err := integration.NewMapEnv(ctx)
+	mapEnv, err := integration.NewMapEnv(ctx, false)
 	if err != nil {
 		t.Fatalf("Failed to create trillian map server: %v", err)
 	}

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -124,7 +124,7 @@ func NewEnv() (*Env, error) {
 	}
 
 	// Map server
-	mapEnv, err := ttest.NewMapEnv(ctx)
+	mapEnv, err := ttest.NewMapEnv(ctx, false)
 	if err != nil {
 		return nil, fmt.Errorf("env: failed to create trillian map server: %v", err)
 	}


### PR DESCRIPTION
google/trillian#1272 added an experimental argument to NewMapEnv. Fixes adminserver and integration build errors.