### PR TITLE
Fix format string bug

### DIFF
--- a/impl/authorization/authorization.go
+++ b/impl/authorization/authorization.go
@@ -78,7 +78,7 @@ func (a *AuthzPolicy) checkPermission(sctx *authentication.SecurityContext, doma
 			return nil
 		}
 	}
-	return status.Errorf(codes.PermissionDenied, "%v is not authorized to perform %v on %v", sctx.Email, rLabel)
+	return status.Errorf(codes.PermissionDenied, "%v is not authorized to act on %v", sctx.Email, rLabel)
 }
 
 func resourceLabel(domainID, appID string) (string, error) {


### PR DESCRIPTION
A prior pull request simplified the authentication library by removing
action labels and only performing group inclusion checks. This PR removes 
the old action label from the format string.