### PR TITLE
Merge Tink API changes

### DIFF
--- a/cmd/gen-test-vectors/main.go
+++ b/cmd/gen-test-vectors/main.go
@@ -74,7 +74,7 @@ func main() {
 
 // GenerateTestVectors verifies set/get semantics.
 func GenerateTestVectors(ctx context.Context, env *integration.Env) error {
-	if _, err := signature.RegisterStandardKeyTypes(); err != nil {
+	if err := signature.Register(); err != nil {
 		return err
 	}
 	// Create lists of signers.

--- a/cmd/keytransparency-client/cmd/keys.go
+++ b/cmd/keytransparency-client/cmd/keys.go
@@ -24,6 +24,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/insecure"
 	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/subtle/aead"
 	"github.com/google/tink/go/tink"
@@ -56,8 +57,7 @@ var keysCmd = &cobra.Command{
 	Long: `Manage the authorized-keys list with tinkey
 	https://github.com/google/tink/blob/master/doc/TINKEY.md`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		_, err := signature.RegisterStandardKeyTypes()
-		return err
+		return signature.Register()
 	},
 }
 
@@ -75,7 +75,7 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		keyset, err = tink.CleartextKeysetHandle().GenerateNew(template)
+		keyset, err = tink.NewKeysetHandle(template)
 		if err != nil {
 			return err
 		}
@@ -87,11 +87,11 @@ var createCmd = &cobra.Command{
 func keyTemplate(keyType string) (*tinkpb.KeyTemplate, error) {
 	switch keyType {
 	case "P256":
-		return signature.EcdsaP256KeyTemplate(), nil
+		return signature.ECDSAP256KeyTemplate(), nil
 	case "P384":
-		return signature.EcdsaP384KeyTemplate(), nil
+		return signature.ECDSAP384KeyTemplate(), nil
 	case "P521":
-		return signature.EcdsaP521KeyTemplate(), nil
+		return signature.ECDSAP521KeyTemplate(), nil
 	default:
 		return nil, fmt.Errorf("unknown key-type: %s", keyType)
 	}
@@ -115,7 +115,7 @@ The actual keys are not listed, only their corresponding metadata.
 		keyset = handle
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		keysetInfo, err := keyset.KeysetInfo()
+		keysetInfo, err := tink.GetKeysetInfo(keyset.Keyset())
 		if err != nil {
 			return err
 		}
@@ -140,13 +140,34 @@ The actual keys are not listed, only their corresponding metadata.
 }
 
 // masterPBKDF converts the master password into the master key.
-func masterPBKDF(masterPassword string) (tink.Aead, error) {
+func masterPBKDF(masterPassword string) (tink.AEAD, error) {
 	if masterPassword == "" {
 		return nil, fmt.Errorf("please provide a master password")
 	}
 	dk := pbkdf2.Key([]byte(masterPassword), salt,
 		masterKeyIterations, masterKeyLen, masterKeyHashFunc)
-	return aead.NewAesGcm(dk)
+	return aead.NewAESGCM(dk)
+}
+
+func encryptKeyset(keyset *tinkpb.Keyset, masterKey tink.AEAD) (*tinkpb.EncryptedKeyset, error) {
+	serializedKeyset, err := proto.Marshal(keyset)
+	if err != nil {
+		return nil, fmt.Errorf("invalid keyset")
+	}
+	encrypted, err := masterKey.Encrypt(serializedKeyset, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("encrypted failed: %s", err)
+	}
+	// get keyset info
+	info, err := tink.GetKeysetInfo(keyset)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get keyset info: %s", err)
+	}
+	encryptedKeyset := &tinkpb.EncryptedKeyset{
+		EncryptedKeyset: encrypted,
+		KeysetInfo:      info,
+	}
+	return encryptedKeyset, nil
 }
 
 func readKeysetFile(file, password string) (*tink.KeysetHandle, error) {
@@ -164,12 +185,24 @@ func readKeysetFile(file, password string) (*tink.KeysetHandle, error) {
 		return nil, fmt.Errorf("could not parse encrypted keyset: %v", err)
 	}
 
-	keyset, err := tink.DecryptKeyset(encryptedKeyset, masterKey)
+	keyset, err := decryptKeyset(encryptedKeyset, masterKey)
 	if err != nil {
 		return nil, err
 	}
 
-	return tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	return insecure.KeysetHandle(keyset)
+}
+
+func decryptKeyset(encryptedKeyset *tinkpb.EncryptedKeyset, masterKey tink.AEAD) (*tinkpb.Keyset, error) {
+	decrypted, err := masterKey.Decrypt(encryptedKeyset.EncryptedKeyset, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("decryption failed: %s", err)
+	}
+	keyset := new(tinkpb.Keyset)
+	if err := proto.Unmarshal(decrypted, keyset); err != nil {
+		return nil, fmt.Errorf("invalid encrypted keyset")
+	}
+	return keyset, nil
 }
 
 func writeKeysetFile(keyset *tink.KeysetHandle, file, password string) error {
@@ -177,7 +210,7 @@ func writeKeysetFile(keyset *tink.KeysetHandle, file, password string) error {
 	if err != nil {
 		return err
 	}
-	encryptedKeyset, err := tink.EncryptKeyset(keyset.Keyset(), masterKey)
+	encryptedKeyset, err := encryptKeyset(keyset.Keyset(), masterKey)
 	if err != nil {
 		return err
 	}

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -36,7 +36,7 @@ var (
 var postCmd = &cobra.Command{
 	Use:   "post [user email] [app] -d {base64 key data}",
 	Short: "Update the account with the given profile",
-	Long: `Post replaces the current key-set with the provided key-set, 
+	Long: `Post replaces the current key-set with the provided key-set,
 and verifies that both the previous and current key-sets are accurate. eg:
 
 ./keytransparency-client post foobar@example.com app1 -d "dGVzdA=="
@@ -83,7 +83,7 @@ User email MUST match the OAuth account used to authorize the update.
 		}
 
 		// Update.
-		authorizedKeys, err := keyset.GetPublicKeysetHandle()
+		authorizedKeys, err := keyset.Public()
 		if err != nil {
 			return fmt.Errorf("store.PublicKeys() failed: %v", err)
 		}

--- a/core/client/hammer/hammer.go
+++ b/core/client/hammer/hammer.go
@@ -86,9 +86,9 @@ func New(ctx context.Context, dial DialFunc, callOptions CallOptions,
 		return nil, err
 	}
 
-	authorizedKeys, err := keyset.GetPublicKeysetHandle()
+	authorizedKeys, err := keyset.Public()
 	if err != nil {
-		return nil, fmt.Errorf("keyset.GetPublicKeysetHandle() failed: %v", err)
+		return nil, fmt.Errorf("keyset.Public() failed: %v", err)
 	}
 
 	return &Hammer{

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -66,8 +66,8 @@ var (
 
 // TestEmptyGetAndUpdate verifies set/get semantics.
 func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
-	if _, err := signature.RegisterStandardKeyTypes(); err != nil {
-		t.Fatalf("RegisterStandardKeyTypes(): %v", err)
+	if err := signature.Register(); err != nil {
+		t.Fatalf("signature.Register(): %v", err)
 	}
 
 	// Create lists of signers.

--- a/core/managementserver/server.go
+++ b/core/managementserver/server.go
@@ -58,7 +58,7 @@ func (s *Server) GetKeySet(ctx context.Context, in *pb.GetKeySetRequest) (*tinkp
 	if err != nil {
 		return nil, err
 	}
-	pub, err := ks.GetPublicKeysetHandle()
+	pub, err := ks.Public()
 	if err != nil {
 		return nil, err
 	}

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -102,7 +102,7 @@ func (m *Mutation) SetCommitment(data []byte) error {
 // pubkeys must contain at least one key.
 func (m *Mutation) ReplaceAuthorizedKeys(pubkeys *tinkpb.Keyset) error {
 	// Make sure that pubkeys is a valid keyset.
-	if _, err := tink.CleartextKeysetHandle().ParseKeyset(pubkeys); err != nil {
+	if _, err := tink.KeysetHandleWithNoSecret(pubkeys); err != nil {
 		return err
 	}
 
@@ -155,7 +155,7 @@ func (m *Mutation) sign(signers []*tink.KeysetHandle) (*pb.Entry, error) {
 	m.entry.Signatures = nil
 	sigs := make([][]byte, 0, len(signers))
 	for _, handle := range signers {
-		signer, err := signature.GetPublicKeySignPrimitive(handle)
+		signer, err := signature.NewSigner(handle)
 		if err != nil {
 			return nil, err
 		}

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -33,8 +33,8 @@ import (
 )
 
 func init() {
-	if _, err := signature.RegisterStandardKeyTypes(); err != nil {
-		glog.Errorf("RegisterStandardKeyTypes(): %v", err)
+	if err := signature.Register(); err != nil {
+		glog.Errorf("signature.Register(): %v", err)
 	}
 }
 
@@ -116,7 +116,7 @@ func verifyKeys(prevAuthz, authz *tinkpb.Keyset, data interface{}, sigs [][]byte
 		keyset = authz
 	}
 
-	verifier, err := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	verifier, err := tink.KeysetHandleWithNoSecret(keyset)
 	if err != nil {
 		return fmt.Errorf("ParseKeyset(new): %v", err)
 	}
@@ -127,7 +127,7 @@ func verifyKeys(prevAuthz, authz *tinkpb.Keyset, data interface{}, sigs [][]byte
 // verifyAuthorizedKeys requires AT LEAST one verifier to have a valid
 // corresponding signature.
 func verifyAuthorizedKeys(data interface{}, handle *tink.KeysetHandle, sigs [][]byte) error {
-	verifier, err := signature.GetPublicKeyVerifyPrimitive(handle)
+	verifier, err := signature.NewVerifier(handle)
 	if err != nil {
 		return err
 	}

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -31,9 +31,9 @@ func queueMsg(t *testing.T, id int64, signer *tink.KeysetHandle) *ktpb.EntryUpda
 	userID := string(id)
 	m := entry.NewMutation(index, "domain", "app", userID)
 	signers := []*tink.KeysetHandle{signer}
-	pubkey, err := signer.GetPublicKeysetHandle()
+	pubkey, err := signer.Public()
 	if err != nil {
-		t.Fatalf("GetPublicKeysetHandle(): %v", err)
+		t.Fatalf("Public(): %v", err)
 	}
 	if err := m.ReplaceAuthorizedKeys(pubkey.Keyset()); err != nil {
 		t.Fatalf("ReplaceAuthorizedKeys(): %v", err)
@@ -53,11 +53,11 @@ func queueMsg(t *testing.T, id int64, signer *tink.KeysetHandle) *ktpb.EntryUpda
 // each mapleaf.Index at most ONCE.
 func TestDuplicateMutations(t *testing.T) {
 
-	keyset1, err := tink.CleartextKeysetHandle().GenerateNew(signature.EcdsaP256KeyTemplate())
+	keyset1, err := tink.NewKeysetHandle(signature.ECDSAP256KeyTemplate())
 	if err != nil {
 		t.Fatalf("tink.GenerateNew(): %v", err)
 	}
-	keyset2, err := tink.CleartextKeysetHandle().GenerateNew(signature.EcdsaP256KeyTemplate())
+	keyset2, err := tink.NewKeysetHandle(signature.ECDSAP256KeyTemplate())
 	if err != nil {
 		t.Fatalf("tink.GenerateNew(): %v", err)
 	}

--- a/core/testutil/tink.go
+++ b/core/testutil/tink.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/google/tink/go/insecure"
 	"github.com/google/tink/go/signature"
+	"github.com/google/tink/go/testkeysethandle"
 	"github.com/google/tink/go/tink"
 	"github.com/google/trillian/crypto/keys/pem"
 
@@ -118,7 +118,7 @@ func SignKeysetsFromPEMs(privPEMs ...string) []*tink.KeysetHandle {
 		}
 		keysetKey := PrivateKeyFromPEM(pem, uint32(i+1))
 		keyset := tink.CreateKeyset(uint32(i+1), []*tinkpb.Keyset_Key{keysetKey})
-		parsedHandle, err := insecure.KeysetHandle(keyset)
+		parsedHandle, err := testkeysethandle.KeysetHandle(keyset)
 		if err != nil {
 			panic(fmt.Sprintf("KeysetHandleWithNoSecret(): %v", err))
 		}

--- a/core/testutil/tink.go
+++ b/core/testutil/tink.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/tink/go/insecure"
 	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/tink"
 	"github.com/google/trillian/crypto/keys/pem"
@@ -41,22 +42,22 @@ func PrivateKeyFromPEM(privPEM string, keyID uint32) *tinkpb.Keyset_Key {
 		panic(fmt.Sprintf("not ecdsa private key: %T", signer))
 	}
 
-	params := signature.NewEcdsaParams(
+	params := signature.NewECDSAParams(
 		commonpb.HashType_SHA256,
 		commonpb.EllipticCurveType_NIST_P256,
 		ecdsapb.EcdsaSignatureEncoding_DER)
 
-	publicKey := signature.NewEcdsaPublicKey(
-		signature.EcdsaVerifyKeyVersion,
+	publicKey := signature.NewECDSAPublicKey(
+		signature.ECDSAVerifierKeyVersion,
 		params, priv.X.Bytes(), priv.Y.Bytes())
-	privKey := signature.NewEcdsaPrivateKey(
-		signature.EcdsaSignKeyVersion,
+	privKey := signature.NewECDSAPrivateKey(
+		signature.ECDSASignerKeyVersion,
 		publicKey, priv.D.Bytes())
 	serializedKey, err := proto.Marshal(privKey)
 	if err != nil {
 		panic(fmt.Sprintf("proto.Marshal(): %v", err))
 	}
-	keyData := tink.CreateKeyData(signature.EcdsaSignTypeURL,
+	keyData := tink.CreateKeyData(signature.ECDSASignerTypeURL,
 		serializedKey,
 		tinkpb.KeyData_ASYMMETRIC_PRIVATE)
 	return tink.CreateKey(keyData, tinkpb.KeyStatusType_ENABLED, keyID, tinkpb.OutputPrefixType_TINK)
@@ -73,18 +74,18 @@ func PublicKeyFromPEM(pubPEM string, keyID uint32) *tinkpb.Keyset_Key {
 		panic(fmt.Sprintf("not ecdsa public key: %T", pubKey))
 	}
 
-	params := signature.NewEcdsaParams(
+	params := signature.NewECDSAParams(
 		commonpb.HashType_SHA256,
 		commonpb.EllipticCurveType_NIST_P256,
 		ecdsapb.EcdsaSignatureEncoding_DER)
-	publicKey := signature.NewEcdsaPublicKey(
-		signature.EcdsaVerifyKeyVersion,
+	publicKey := signature.NewECDSAPublicKey(
+		signature.ECDSAVerifierKeyVersion,
 		params, pub.X.Bytes(), pub.Y.Bytes())
 	serializedKey, err := proto.Marshal(publicKey)
 	if err != nil {
 		panic(fmt.Sprintf("proto.Marshal(): %v", err))
 	}
-	keyData := tink.CreateKeyData(signature.EcdsaVerifyTypeURL,
+	keyData := tink.CreateKeyData(signature.ECDSAVerifierTypeURL,
 		serializedKey,
 		tinkpb.KeyData_ASYMMETRIC_PUBLIC)
 	return tink.CreateKey(keyData, tinkpb.KeyStatusType_ENABLED, keyID, tinkpb.OutputPrefixType_TINK)
@@ -101,9 +102,9 @@ func VerifyKeysetFromPEMs(pubPEMs ...string) *tink.KeysetHandle {
 		keys = append(keys, keysetKey)
 	}
 	keyset := tink.CreateKeyset(1, keys)
-	parsedHandle, err := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+	parsedHandle, err := tink.KeysetHandleWithNoSecret(keyset)
 	if err != nil {
-		panic(fmt.Sprintf("ParseKeyset(): %v", err))
+		panic(fmt.Sprintf("KeysetHandleWithNoSecret(): %v", err))
 	}
 	return parsedHandle
 }
@@ -117,9 +118,9 @@ func SignKeysetsFromPEMs(privPEMs ...string) []*tink.KeysetHandle {
 		}
 		keysetKey := PrivateKeyFromPEM(pem, uint32(i+1))
 		keyset := tink.CreateKeyset(uint32(i+1), []*tinkpb.Keyset_Key{keysetKey})
-		parsedHandle, err := tink.CleartextKeysetHandle().ParseKeyset(keyset)
+		parsedHandle, err := insecure.KeysetHandle(keyset)
 		if err != nil {
-			panic(fmt.Sprintf("ParseKeyset(): %v", err))
+			panic(fmt.Sprintf("KeysetHandleWithNoSecret(): %v", err))
 		}
 		handles = append(handles, parsedHandle)
 	}

--- a/impl/sql/keysets/keysets.go
+++ b/impl/sql/keysets/keysets.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
+	"github.com/google/tink/go/insecure"
 	"github.com/google/tink/go/tink"
 )
 
@@ -67,7 +68,7 @@ func newKeyset(instance int64, domainID, appID string, k *tink.KeysetHandle) (*k
 
 // Proto converts a keyset to a tpb.KeySet proto.
 func (k *keyset) Proto() (*tink.KeysetHandle, error) {
-	return tink.CleartextKeysetHandle().ParseSerializedKeyset(k.KeySet)
+	return insecure.KeysetHandleFromSerializedProto(k.KeySet)
 }
 
 // New returns a storage.KeySets client backed by an SQL table.

--- a/impl/sql/keysets/keysets_test.go
+++ b/impl/sql/keysets/keysets_test.go
@@ -39,10 +39,10 @@ func TestWriteRead(t *testing.T) {
 		t.Fatalf("Failed to create keysets.Storage")
 	}
 
-	if _, err := signature.RegisterStandardKeyTypes(); err != nil {
-		t.Fatalf("RegisterStandardKeyTypes(): %v", err)
+	if err := signature.Register(); err != nil {
+		t.Fatalf("Register(): %v", err)
 	}
-	ks, err := tink.CleartextKeysetHandle().GenerateNew(signature.EcdsaP256KeyTemplate())
+	ks, err := tink.NewKeysetHandle(signature.ECDSAP256KeyTemplate())
 	if err != nil {
 		t.Fatalf("tink.GenerateNew(): %v", err)
 	}


### PR DESCRIPTION
Follows API cleanup in Tink per google/tink#93.

It seems like Tink removed the capability to read/write encrypted keysets, so I've had to use insecure.KeysetHandle in a few places.