### PR TITLE
Use apt-get for google-cloud-sdk in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ addons:
     packages:
     - python3-pip
     - google-cloud-sdk
-    - kubectl
 
 before_install:
   - gcloud --quiet version
-  - kubectl version
   - docker --version
 
 install:
+  - gcloud components update kubectl
+  - kubectl version
   - go get -u github.com/alecthomas/gometalinter
   - gometalinter --install 
   - go get -t ./...


### PR DESCRIPTION
gcloud compoenents install kubeclt was erroring with
ERROR: (gcloud.components.install) You cannot perform this action because this Cloud SDK installation is managed by an external package manager.
Please consider using a separate installation of the Cloud SDK created through the default mechanism described at: https://cloud.google.com/sdk/

Migrate to apt-get based install to be compatible with Ubuntu docker image.