### PR TITLE
Add ';' to separate if statements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ addons:
 
 before_install:
   - if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then
-        mkdir -p $HOME/gcloud
-        wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=$HOME/gcloud
-        cd $HOME/gcloud
-        tar xzf google-cloud-sdk.tar.gz
-        ./google-cloud-sdk/install.sh -q
+        mkdir -p $HOME/gcloud; 
+        wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=$HOME/gcloud; 
+        cd $HOME/gcloud; 
+        tar xzf google-cloud-sdk.tar.gz; 
+        ./google-cloud-sdk/install.sh -q; 
         cd $TRAVIS_BUILD_DIR;
     fi
   - source "$HOME/gcloud/google-cloud-sdk/path.bash.inc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,14 @@ addons:
     - python3-pip
 
 before_install:
-  - if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then
-        mkdir -p $HOME/gcloud; 
-        wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=$HOME/gcloud; 
-        cd $HOME/gcloud; 
-        tar xzf google-cloud-sdk.tar.gz; 
-        ./google-cloud-sdk/install.sh -q; 
-        cd $TRAVIS_BUILD_DIR;
+  - |
+    if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then
+        mkdir -p $HOME/gcloud 
+        wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz --directory-prefix=$HOME/gcloud
+        cd $HOME/gcloud
+        tar xzf google-cloud-sdk.tar.gz;
+        ./google-cloud-sdk/install.sh -q;
+        cd $TRAVIS_BUILD_DIR
     fi
   - source "$HOME/gcloud/google-cloud-sdk/path.bash.inc"
   - gcloud -q components update


### PR DESCRIPTION
The multiple statements inside the bash if block are being treated as one continuous command.
This PR separates them properly with semicolons.

Fixes #1060 