### PR TITLE
Rename *Queue* with *Logs*

### DIFF
--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -120,7 +120,7 @@ func main() {
 	mapAdmin := trillian.NewTrillianAdminClient(mconn)
 
 	// Create gRPC server.
-	queue := mutator.MutationQueue(mutations)
+	queue := mutator.MutationLogs(mutations)
 	ksvr := keyserver.New(tlog, tmap, logAdmin, mapAdmin,
 		entry.New(), domains, queue, mutations)
 	grpcServer := grpc.NewServer(

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/keytransparency/cmd/serverutil"
 	"github.com/google/keytransparency/core/keyserver"
-	"github.com/google/keytransparency/core/mutator"
 	"github.com/google/keytransparency/core/mutator/entry"
 	"github.com/google/keytransparency/impl/authentication"
 	"github.com/google/keytransparency/impl/authorization"
@@ -100,9 +99,9 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed to create domain storage: %v", err)
 	}
-	mutations, err := mutationstorage.New(sqldb)
+	logs, err := mutationstorage.New(sqldb)
 	if err != nil {
-		glog.Exitf("Failed to create mutations object: %v", err)
+		glog.Exitf("Failed to create logs object: %v", err)
 	}
 
 	// Connect to log and map server.
@@ -120,9 +119,8 @@ func main() {
 	mapAdmin := trillian.NewTrillianAdminClient(mconn)
 
 	// Create gRPC server.
-	queue := mutator.MutationLogs(mutations)
 	ksvr := keyserver.New(tlog, tmap, logAdmin, mapAdmin,
-		entry.New(), domains, queue, mutations)
+		entry.New(), domains, logs, logs)
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(

--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -75,9 +75,9 @@ var (
 	}
 )
 
-// LogsAdmin controls the lifecycle and scaling of mutation queues.
+// LogsAdmin controls the lifecycle and scaling of mutation logs.
 type LogsAdmin interface {
-	// AddLogs creates and adds new shards for queue writing to a domain.
+	// AddLogs creates and adds new shards for writing to a domain.
 	AddLogs(ctx context.Context, domainID string, logIDs ...int64) error
 }
 
@@ -271,8 +271,8 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 		return nil, fmt.Errorf("adminserver: domains.Write(): %v", err)
 	}
 
-	// Create initial shards for queue.
-	// TODO(#1063): Additional shards can be added at a later point to support increased server load.
+	// Create initial logs for writing.
+	// TODO(#1063): Additional logs can be added at a later point to support increased server load.
 	shardIDs := []int64{1, 2}
 	if err := s.logsAdmin.AddLogs(ctx, in.GetDomainId(), shardIDs...); err != nil {
 		return nil, fmt.Errorf("adminserver: AddShards(%v): %v", shardIDs, err)

--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -75,21 +75,21 @@ var (
 	}
 )
 
-// QueueAdmin controls the lifecycle and scaling of mutation queues.
-type QueueAdmin interface {
-	// AddShards creates and adds new shards for queue writing to a domain.
-	AddShards(ctx context.Context, domainID string, shardIDs ...int64) error
+// LogsAdmin controls the lifecycle and scaling of mutation queues.
+type LogsAdmin interface {
+	// AddLogs creates and adds new shards for queue writing to a domain.
+	AddLogs(ctx context.Context, domainID string, logIDs ...int64) error
 }
 
 // Server implements pb.KeyTransparencyAdminServer
 type Server struct {
-	tlog       tpb.TrillianLogClient
-	tmap       tpb.TrillianMapClient
-	logAdmin   tpb.TrillianAdminClient
-	mapAdmin   tpb.TrillianAdminClient
-	domains    domain.Storage
-	queueAdmin QueueAdmin
-	keygen     keys.ProtoGenerator
+	tlog      tpb.TrillianLogClient
+	tmap      tpb.TrillianMapClient
+	logAdmin  tpb.TrillianAdminClient
+	mapAdmin  tpb.TrillianAdminClient
+	domains   domain.Storage
+	logsAdmin LogsAdmin
+	keygen    keys.ProtoGenerator
 }
 
 // New returns a KeyTransparencyAdmin implementation.
@@ -98,17 +98,17 @@ func New(
 	tmap tpb.TrillianMapClient,
 	logAdmin, mapAdmin tpb.TrillianAdminClient,
 	domains domain.Storage,
-	queueAdmin QueueAdmin,
+	logsAdmin LogsAdmin,
 	keygen keys.ProtoGenerator,
 ) *Server {
 	return &Server{
-		tlog:       tlog,
-		tmap:       tmap,
-		logAdmin:   logAdmin,
-		mapAdmin:   mapAdmin,
-		domains:    domains,
-		queueAdmin: queueAdmin,
-		keygen:     keygen,
+		tlog:      tlog,
+		tmap:      tmap,
+		logAdmin:  logAdmin,
+		mapAdmin:  mapAdmin,
+		domains:   domains,
+		logsAdmin: logsAdmin,
+		keygen:    keygen,
 	}
 }
 
@@ -274,7 +274,7 @@ func (s *Server) CreateDomain(ctx context.Context, in *pb.CreateDomainRequest) (
 	// Create initial shards for queue.
 	// TODO(#1063): Additional shards can be added at a later point to support increased server load.
 	shardIDs := []int64{1, 2}
-	if err := s.queueAdmin.AddShards(ctx, in.GetDomainId(), shardIDs...); err != nil {
+	if err := s.logsAdmin.AddLogs(ctx, in.GetDomainId(), shardIDs...); err != nil {
 		return nil, fmt.Errorf("adminserver: AddShards(%v): %v", shardIDs, err)
 	}
 

--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -87,7 +87,7 @@ func (e *miniEnv) Close() {
 
 type fakeQueueAdmin struct{}
 
-func (fakeQueueAdmin) AddShards(ctx context.Context, domainID string, shardIDs ...int64) error {
+func (fakeQueueAdmin) AddLogs(ctx context.Context, domainID string, shardIDs ...int64) error {
 	return nil
 }
 

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -43,7 +43,7 @@ type Server struct {
 	mapAdmin  tpb.TrillianAdminClient
 	mutator   mutator.Func
 	domains   domain.Storage
-	queue     mutator.MutationQueue
+	queue     mutator.MutationLogs
 	mutations mutator.MutationStorage
 	indexFunc indexFunc
 }
@@ -55,7 +55,7 @@ func New(tlog tpb.TrillianLogClient,
 	mapAdmin tpb.TrillianAdminClient,
 	mutator mutator.Func,
 	domains domain.Storage,
-	queue mutator.MutationQueue,
+	queue mutator.MutationLogs,
 	mutations mutator.MutationStorage) *Server {
 	return &Server{
 		tlog:      tlog,

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -43,7 +43,7 @@ type Server struct {
 	mapAdmin  tpb.TrillianAdminClient
 	mutator   mutator.Func
 	domains   domain.Storage
-	queue     mutator.MutationLogs
+	logs      mutator.MutationLogs
 	mutations mutator.MutationStorage
 	indexFunc indexFunc
 }
@@ -55,7 +55,7 @@ func New(tlog tpb.TrillianLogClient,
 	mapAdmin tpb.TrillianAdminClient,
 	mutator mutator.Func,
 	domains domain.Storage,
-	queue mutator.MutationLogs,
+	logs mutator.MutationLogs,
 	mutations mutator.MutationStorage) *Server {
 	return &Server{
 		tlog:      tlog,
@@ -64,7 +64,7 @@ func New(tlog tpb.TrillianLogClient,
 		mapAdmin:  mapAdmin,
 		mutator:   mutator,
 		domains:   domains,
-		queue:     queue,
+		logs:      logs,
 		mutations: mutations,
 		indexFunc: indexFromVRF,
 	}
@@ -300,7 +300,7 @@ func (s *Server) QueueEntryUpdate(ctx context.Context, in *pb.UpdateEntryRequest
 	}
 
 	// Save mutation to the database.
-	if err := s.queue.Send(ctx, domain.DomainID, in.GetEntryUpdate()); err != nil {
+	if err := s.logs.Send(ctx, domain.DomainID, in.GetEntryUpdate()); err != nil {
 		glog.Errorf("mutations.Write failed: %v", err)
 		return nil, status.Errorf(codes.Internal, "Mutation write error")
 	}

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -54,8 +54,8 @@ type Func interface {
 	Mutate(value, mutation proto.Message) (proto.Message, error)
 }
 
-// QueueMessage represents a change to a user, and associated data.
-type QueueMessage struct {
+// LogMessage represents a change to a user, and associated data.
+type LogMessage struct {
 	ID        int64
 	Mutation  *pb.Entry
 	ExtraData *pb.Committed
@@ -68,7 +68,7 @@ type MutationLogs interface {
 }
 
 // ReceiveFunc receives updates from the queue.
-type ReceiveFunc func([]*QueueMessage) error
+type ReceiveFunc func([]*LogMessage) error
 
 // Receiver receives messages from a queue.
 type Receiver interface {

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -61,9 +61,9 @@ type LogMessage struct {
 	ExtraData *pb.Committed
 }
 
-// MutationLogs provides a time ordered log(s) of messages.
+// MutationLogs provides a time ordered logs of messages.
 type MutationLogs interface {
-	// Send submits an item to the queue
+	// Send submits an item to a random log.
 	Send(ctx context.Context, domainID string, mutation *pb.EntryUpdate) error
 }
 

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -61,10 +61,8 @@ type QueueMessage struct {
 	ExtraData *pb.Committed
 }
 
-// MutationQueue provides (at minimum) a roughly time ordered queue that can support
-// multiple writers.  Replays, drops, and duplicate delivery must be tolerated by
-// receivers.
-type MutationQueue interface {
+// MutationLogs provides a time ordered log(s) of messages.
+type MutationLogs interface {
 	// Send submits an item to the queue
 	Send(ctx context.Context, domainID string, mutation *pb.EntryUpdate) error
 }

--- a/core/sequencer/sequencer_api.proto
+++ b/core/sequencer/sequencer_api.proto
@@ -62,7 +62,7 @@ message RunBatchRequest{
    string domain_id = 1;
    // min_batch is the minimum number of items in a batch.
    // If less than min_batch items are available, nothing happens.
-   // TODO(#1047): Replace with timeout so items in the queue get processed eventually.
+   // TODO(#1047): Replace with timeout so items in the log get processed eventually.
    int32 min_batch = 2;
    // max_batch is the maximum number of items in a batch.
    int32 max_batch = 3;

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -74,7 +74,7 @@ type Queue interface {
 	HighWatermarks(ctx context.Context, domainID string) (map[int64]int64, error)
 	// ReadQueue returns the messages under shardID in the (low, high] range.
 	// ReadQueue does NOT delete messages.
-	ReadQueue(ctx context.Context, domainID string, shardID, low, high int64) ([]*mutator.QueueMessage, error)
+	ReadQueue(ctx context.Context, domainID string, shardID, low, high int64) ([]*mutator.LogMessage, error)
 }
 
 // Server implements KeyTransparencySequencerServer.

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -107,7 +107,7 @@ func NewServer(
 	}
 }
 
-// RunBatch reads mutations out of the queue and calls CreateEpoch.
+// RunBatch reads mutations out of the logs and calls CreateEpoch.
 func (s *Server) RunBatch(ctx context.Context, in *spb.RunBatchRequest) (*empty.Empty, error) {
 	// Get the previous and current high water marks.
 	domain, err := s.ktServer.GetDomain(ctx, &ktpb.GetDomainRequest{DomainId: in.DomainId})
@@ -132,7 +132,7 @@ func (s *Server) RunBatch(ctx context.Context, in *spb.RunBatchRequest) (*empty.
 	}
 
 	// TODO(#1057): If time since last map revision > max timeout, run batch.
-	// TODO(#1047): If time since oldest queue item > max latency has elapsed, run batch.
+	// TODO(#1047): If time since oldest log item > max latency has elapsed, run batch.
 	// TODO(#1056): If count items > max_batch, run batch.
 
 	// Count items to be processed.  Unfortunately, this means we will be

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -25,7 +25,7 @@ import (
 	tpb "github.com/google/trillian"
 )
 
-func queueMsg(t *testing.T, id int64, signer *tink.KeysetHandle) *ktpb.EntryUpdate {
+func logMsg(t *testing.T, id int64, signer *tink.KeysetHandle) *ktpb.EntryUpdate {
 	t.Helper()
 	index := []byte{byte(id)}
 	userID := string(id)
@@ -72,16 +72,16 @@ func TestDuplicateMutations(t *testing.T) {
 		{
 			desc: "duplicate index, same data",
 			msgs: []*ktpb.EntryUpdate{
-				queueMsg(t, 1, keyset1),
-				queueMsg(t, 1, keyset1),
+				logMsg(t, 1, keyset1),
+				logMsg(t, 1, keyset1),
 			},
 			wantLeaves: 1,
 		},
 		{
 			desc: "duplicate index, different data",
 			msgs: []*ktpb.EntryUpdate{
-				queueMsg(t, 1, keyset1),
-				queueMsg(t, 1, keyset2),
+				logMsg(t, 1, keyset1),
+				logMsg(t, 1, keyset2),
 			},
 			wantLeaves: 1,
 		},

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -165,7 +165,7 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	authFunc := authentication.FakeAuthFunc
 	authz := &authorization.AuthzPolicy{}
 
-	queue := mutator.MutationQueue(mutations)
+	queue := mutator.MutationLogs(mutations)
 	server := keyserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin,
 		entry.New(), domainStorage, queue, mutations)
 	gsvr := grpc.NewServer(

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -50,16 +50,16 @@ var (
 	);`,
 		`CREATE TABLE IF NOT EXISTS Queue (
 		DomainID VARCHAR(30)   NOT NULL,
-		ShardID  BIGINT        NOT NULL,
+		LogID    BIGINT        NOT NULL,
 		Time     BIGINT        NOT NULL,
 		Mutation BLOB          NOT NULL,
-		PRIMARY KEY(DomainID, ShardID, Time)
+		PRIMARY KEY(DomainID, LogID, Time)
 	);`,
-		`CREATE TABLE IF NOT EXISTS Shards (
+		`CREATE TABLE IF NOT EXISTS Logs (
 		DomainID VARCHAR(30)   NOT NULL,
-		ShardID  BIGINT        NOT NULL,
+		LogID    BIGINT        NOT NULL,
 		Enabled  INTEGER       NOT NULL,
-		PRIMARY KEY(DomainID, ShardID)
+		PRIMARY KEY(DomainID, LogID)
 	);`,
 	}
 )

--- a/impl/sql/mutationstorage/queue.go
+++ b/impl/sql/mutationstorage/queue.go
@@ -29,16 +29,16 @@ import (
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
-// AddShards creates and adds new shards for queue writing to a domain.
-func (m *Mutations) AddShards(ctx context.Context, domainID string, shardIDs ...int64) error {
-	glog.Infof("mutationstorage: AddShard(%v, %v)", domainID, shardIDs)
-	for _, shardID := range shardIDs {
+// AddLogs creates and adds new logs for writing to a domain.
+func (m *Mutations) AddLogs(ctx context.Context, domainID string, logIDs ...int64) error {
+	glog.Infof("mutationstorage: AddLog(%v, %v)", domainID, logIDs)
+	for _, logID := range logIDs {
 		// TODO(gdbelvin): Use INSERT IGNORE to allow this function to be retried.
 		// TODO(gdbelvin): Migrate to a MySQL Docker image for unit tests.
 		// MySQL and SQLite do not have the same syntax for INSERT IGNORE.
 		if _, err := m.db.ExecContext(ctx,
-			`INSERT INTO Shards (DomainID, ShardID, Enabled)  Values(?, ?, ?);`,
-			domainID, shardID, true); err != nil {
+			`INSERT INTO Logs (DomainID, LogID, Enabled)  Values(?, ?, ?);`,
+			domainID, logID, true); err != nil {
 			return err
 		}
 	}
@@ -48,7 +48,7 @@ func (m *Mutations) AddShards(ctx context.Context, domainID string, shardIDs ...
 // Send writes mutations to the leading edge (by sequence number) of the mutations table.
 func (m *Mutations) Send(ctx context.Context, domainID string, update *pb.EntryUpdate) error {
 	glog.Infof("mutationstorage: Send(%v, <mutation>)", domainID)
-	shardID, err := m.randShard(ctx, domainID)
+	logID, err := m.randLog(ctx, domainID)
 	if err != nil {
 		return err
 	}
@@ -58,40 +58,40 @@ func (m *Mutations) Send(ctx context.Context, domainID string, update *pb.EntryU
 	}
 	// TODO(gbelvin): Implement retry with backoff for retryable errors if
 	// we get timestamp contention.
-	return m.send(ctx, domainID, shardID, mData, time.Now())
+	return m.send(ctx, domainID, logID, mData, time.Now())
 }
 
-// randShard returns a random, enabled shard for domainID.
-func (m *Mutations) randShard(ctx context.Context, domainID string) (int64, error) {
+// randLog returns a random, enabled log for domainID.
+func (m *Mutations) randLog(ctx context.Context, domainID string) (int64, error) {
 	// TODO(gbelvin): Cache these results.
-	var shardIDs []int64
+	var logIDs []int64
 	rows, err := m.db.QueryContext(ctx,
-		`SELECT ShardID from Shards WHERE DomainID = ? AND Enabled = ?;`,
+		`SELECT LogID from Logs WHERE DomainID = ? AND Enabled = ?;`,
 		domainID, true)
 	if err != nil {
 		return 0, err
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var shardID int64
-		if err := rows.Scan(&shardID); err != nil {
+		var logID int64
+		if err := rows.Scan(&logID); err != nil {
 			return 0, err
 		}
-		shardIDs = append(shardIDs, shardID)
+		logIDs = append(logIDs, logID)
 	}
 	if err := rows.Err(); err != nil {
 		return 0, err
 	}
-	if len(shardIDs) == 0 {
-		return 0, status.Errorf(codes.NotFound, "No shard found for domain %v", domainID)
+	if len(logIDs) == 0 {
+		return 0, status.Errorf(codes.NotFound, "No log found for domain %v", domainID)
 	}
 
-	// Return a random shard.
-	return shardIDs[rand.Intn(len(shardIDs))], nil
+	// Return a random log.
+	return logIDs[rand.Intn(len(logIDs))], nil
 }
 
 // ts must be greater than all other timestamps currently recorded for domainID.
-func (m *Mutations) send(ctx context.Context, domainID string, shardID int64, mData []byte, ts time.Time) (ret error) {
+func (m *Mutations) send(ctx context.Context, domainID string, logID int64, mData []byte, ts time.Time) (ret error) {
 	tx, err := m.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return err
@@ -106,8 +106,8 @@ func (m *Mutations) send(ctx context.Context, domainID string, shardID int64, mD
 
 	var maxTime int64
 	if err := tx.QueryRowContext(ctx,
-		`SELECT COALESCE(MAX(Time), 0) FROM Queue WHERE DomainID = ? AND ShardID = ?;`,
-		domainID, shardID).Scan(&maxTime); err != nil {
+		`SELECT COALESCE(MAX(Time), 0) FROM Queue WHERE DomainID = ? AND LogID = ?;`,
+		domainID, logID).Scan(&maxTime); err != nil {
 		return status.Errorf(codes.Internal, "could not find max timestamp: %v", err)
 	}
 	tsTime := ts.UnixNano()
@@ -118,29 +118,29 @@ func (m *Mutations) send(ctx context.Context, domainID string, shardID int64, mD
 	}
 
 	if _, err = tx.ExecContext(ctx,
-		`INSERT INTO Queue (DomainID, ShardID, Time, Mutation) VALUES (?, ?, ?, ?);`,
-		domainID, shardID, tsTime, mData); err != nil {
+		`INSERT INTO Queue (DomainID, LogID, Time, Mutation) VALUES (?, ?, ?, ?);`,
+		domainID, logID, tsTime, mData); err != nil {
 		return status.Errorf(codes.Internal, "failed inserting into queue: %v", err)
 	}
 	return tx.Commit()
 }
 
-// HighWatermarks returns the highest timestamp for each shard in the mutations table.
+// HighWatermarks returns the highest timestamp for each log in the mutations table.
 func (m *Mutations) HighWatermarks(ctx context.Context, domainID string) (map[int64]int64, error) {
 	watermarks := make(map[int64]int64)
 	rows, err := m.db.QueryContext(ctx,
-		`SELECT ShardID, Max(Time) FROM Queue WHERE DomainID = ? GROUP BY ShardID;`,
+		`SELECT LogID, Max(Time) FROM Queue WHERE DomainID = ? GROUP BY LogID;`,
 		domainID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 	for rows.Next() {
-		var shardID, watermark int64
-		if err := rows.Scan(&shardID, &watermark); err != nil {
+		var logID, watermark int64
+		if err := rows.Scan(&logID, &watermark); err != nil {
 			return nil, err
 		}
-		watermarks[shardID] = watermark
+		watermarks[logID] = watermark
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -148,14 +148,14 @@ func (m *Mutations) HighWatermarks(ctx context.Context, domainID string) (map[in
 	return watermarks, nil
 }
 
-// ReadQueue reads all mutations in shardID between (low, high].
-func (m *Mutations) ReadQueue(ctx context.Context,
-	domainID string, shardID, low, high int64) ([]*mutator.LogMessage, error) {
+// ReadLog reads all mutations in logID between (low, high].
+func (m *Mutations) ReadLog(ctx context.Context,
+	domainID string, logID, low, high int64) ([]*mutator.LogMessage, error) {
 	rows, err := m.db.QueryContext(ctx,
 		`SELECT Time, Mutation FROM Queue
-		WHERE DomainID = ? AND ShardID = ? AND Time > ? AND Time <= ?
+		WHERE DomainID = ? AND LogID = ? AND Time > ? AND Time <= ?
 		ORDER BY Time ASC;`,
-		domainID, shardID, low, high)
+		domainID, logID, low, high)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +187,7 @@ func readQueueMessages(rows *sql.Rows) ([]*mutator.LogMessage, error) {
 	return results, nil
 }
 
-// DeleteMessages removes messages from the queue.
+// DeleteMessages removes messages from the log.
 func (m *Mutations) DeleteMessages(ctx context.Context, domainID string, mutations []*mutator.LogMessage) error {
 	glog.V(4).Infof("mutationstorage: DeleteMessages(%v, <mutation>)", domainID)
 	delStmt, err := m.db.Prepare(deleteQueueExpr)


### PR DESCRIPTION
The previous few PRs have been migrating Key Transparency away from a queue based model where things in the queue are deleted after they have been processed, to a log(s) based model, where once things go in the log, they stay there forever.  This change helps increase reliability by creating a journal that can be replayed into the map at any time if things go haywire for any reason. 

This PR clarifies variables and comments by switching the terminology from Queues and Shards to a group of logs and individual logIDs. 