### PR TITLE
Removed Spanner callback interfaces

### DIFF
--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -69,18 +69,6 @@ type MutationQueue interface {
 	Send(ctx context.Context, domainID string, mutation *pb.EntryUpdate) error
 }
 
-// ReceiveFunc receives updates from the queue.
-type ReceiveFunc func([]*QueueMessage) error
-
-// Receiver receives messages from a queue.
-type Receiver interface {
-	// Close stops the receiver and returns only when all callbacks are complete.
-	Close()
-	// FlushN waits for n items and then sends them.
-	// Deterministic implementations that can't wait will return an error.
-	FlushN(context.Context, int) error
-}
-
 // MutationStorage reads and writes mutations to the database.
 type MutationStorage interface {
 	// ReadPage returns mutations in the interval (start, end] for mapID.


### PR DESCRIPTION
We are no longer using Spanner style callbacks and can remove this interface now. 