### PR TITLE
Remove DeleteMessages API

### DIFF
--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -34,9 +34,6 @@ const (
   	SELECT Sequence, Mutation FROM Mutations
   	WHERE DomainID = ? AND Revision = ? AND Sequence >= ?
   	ORDER BY Sequence ASC LIMIT ?;`
-	deleteQueueExpr = `
-	DELETE FROM Queue
-	WHERE DomainID = ? AND Time = ?;`
 )
 
 var (

--- a/impl/sql/mutationstorage/queue.go
+++ b/impl/sql/mutationstorage/queue.go
@@ -186,22 +186,3 @@ func readQueueMessages(rows *sql.Rows) ([]*mutator.QueueMessage, error) {
 	}
 	return results, nil
 }
-
-// DeleteMessages removes messages from the queue.
-func (m *Mutations) DeleteMessages(ctx context.Context, domainID string, mutations []*mutator.QueueMessage) error {
-	glog.V(4).Infof("mutationstorage: DeleteMessages(%v, <mutation>)", domainID)
-	delStmt, err := m.db.Prepare(deleteQueueExpr)
-	if err != nil {
-		return err
-	}
-	defer delStmt.Close()
-	var retErr error
-	for _, mutation := range mutations {
-		if _, err = delStmt.ExecContext(ctx, domainID, mutation.ID); err != nil {
-			// If an error occurs, take note, but continue deleting
-			// the other referenced mutations.
-			retErr = err
-		}
-	}
-	return retErr
-}


### PR DESCRIPTION
Since we are no longer using a queue, but a log of messages, we
shouldn't be deleting messages.