### PR TITLE
Remove unused poll-period flag

### DIFF
--- a/cmd/keytransparency-monitor/Dockerfile
+++ b/cmd/keytransparency-monitor/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1
 
 ADD keytransparency/genfiles/* /kt/
 ADD ./keytransparency /go/src/github.com/google/keytransparency

--- a/cmd/keytransparency-sequencer/Dockerfile
+++ b/cmd/keytransparency-sequencer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1
 
 ADD ./keytransparency /go/src/github.com/google/keytransparency
 ADD ./trillian /go/src/github.com/google/trillian

--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1
 
 ADD keytransparency/genfiles/* /kt/
 ADD ./keytransparency /go/src/github.com/google/keytransparency

--- a/deploy/kubernetes/monitor-deployment.yaml
+++ b/deploy/kubernetes/monitor-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         - --addr=0.0.0.0:8099
         - --kt-url=server:8080
         - --insecure
-        - --poll-period=5s
         - --domainid=default
         - --tls-key=/kt/server.key
         - --tls-cert=/kt/server.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,6 @@ services:
       - --addr=0.0.0.0:8099
       - --kt-url=server:8080
       - --insecure
-      - --poll-period=5s
       - --domainid=default
       - --tls-key=/kt/server.key
       - --tls-cert=/kt/server.crt


### PR DESCRIPTION
Having an unused flag in the deploy scripts causes the binary to immediately crash.