### PR TITLE
Use FailedPrecondition in mock Trillian server.

### DIFF
--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -109,7 +109,7 @@ func TestCreateDirectory(t *testing.T) {
 				e.ms.Admin.EXPECT().CreateTree(gomock.Any(), gomock.Any()).Return(&tpb.Tree{TreeType: tpb.TreeType_MAP}, nil)
 				e.ms.Map.EXPECT().InitMap(gomock.Any(), gomock.Any()).Return(&tpb.InitMapResponse{}, nil)
 				e.ms.Map.EXPECT().GetSignedMapRootByRevision(gomock.Any(), gomock.Any()).
-					Return(&tpb.GetSignedMapRootResponse{}, fmt.Errorf("not found")).MinTimes(1)
+					Return(&tpb.GetSignedMapRootResponse{}, status.Errorf(codes.FailedPrecondition, "tree needs init")).MinTimes(1)
 			},
 		},
 		{


### PR DESCRIPTION
Use the same error code as the Trilian code base does for uninitalized
trees while waiting for the tree to be initialized.

This follows change google/trillian#1333