### PR TITLE
Keep PeriodicallyRun running until ctx is canceled

### DIFF
--- a/cmd/gen-test-vectors/main.go
+++ b/cmd/gen-test-vectors/main.go
@@ -82,17 +82,15 @@ func GenerateTestVectors(ctx context.Context, env *integration.Env) error {
 	go func() {
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
-		if err := sequencer.PeriodicallyRun(ctx, ticker.C,
-			func(ctx context.Context) error {
-				_, err := env.Sequencer.RunBatch(ctx, &spb.RunBatchRequest{
-					DirectoryId: env.Directory.DirectoryId,
-					MinBatch:    1,
-					MaxBatch:    100,
-				})
-				return err
+		sequencer.PeriodicallyRun(ctx, ticker.C, func(ctx context.Context) {
+			if _, err := env.Sequencer.RunBatch(ctx, &spb.RunBatchRequest{
+				DirectoryId: env.Directory.DirectoryId,
+				MinBatch:    1,
+				MaxBatch:    100,
 			}); err != nil {
-			log.Errorf("PeriodicallyRun(): %v", err)
-		}
+				log.Errorf("RunBatch(): %v", err)
+			}
+		})
 	}()
 	// Create lists of signers.
 	signers1 := testutil.SignKeysetsFromPEMs(testPrivKey1)

--- a/cmd/gen-test-vectors/main.go
+++ b/cmd/gen-test-vectors/main.go
@@ -83,11 +83,12 @@ func GenerateTestVectors(ctx context.Context, env *integration.Env) error {
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 		sequencer.PeriodicallyRun(ctx, ticker.C, func(ctx context.Context) {
-			if _, err := env.Sequencer.RunBatch(ctx, &spb.RunBatchRequest{
+			req := &spb.RunBatchRequest{
 				DirectoryId: env.Directory.DirectoryId,
 				MinBatch:    1,
 				MaxBatch:    100,
-			}); err != nil {
+			}
+			if _, err := env.Sequencer.RunBatch(ctx, req); err != nil {
 				log.Errorf("RunBatch(): %v", err)
 			}
 		})

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -120,10 +120,11 @@ func main() {
 
 	cctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	if err := sequencer.PeriodicallyRun(ctx, time.Tick(*refresh),
-		signer.RunBatchForAllDirectories); err != nil {
-		glog.Errorf("PeriodicallyRun(RunBatchForAllDirectories): %v", err)
-	}
+	sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
+		if err := signer.RunBatchForAllDirectories(ctx); err != nil {
+			glog.Errorf("PeriodicallyRun(RunBatchForAllDirectories): %v", err)
+		}
+	})
 	httpServer.Shutdown(cctx)
 	glog.Errorf("Signer exiting")
 }

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -120,11 +120,12 @@ func (s *Sequencer) RunBatchForAllDirectories(ctx context.Context) error {
 	}
 	for _, d := range directories {
 		knownDirectories.Set(1, d.DirectoryID)
-		if _, err := s.sequencerClient.RunBatch(ctx, &spb.RunBatchRequest{
+		req := &spb.RunBatchRequest{
 			DirectoryId: d.DirectoryID,
 			MinBatch:    1,
 			MaxBatch:    s.batchSize,
-		}); err != nil {
+		}
+		if _, err := s.sequencerClient.RunBatch(ctx, req); err != nil {
 			return err
 		}
 	}

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/google/keytransparency/core/directory"
 
@@ -94,27 +92,23 @@ func RunAndConnect(ctx context.Context, impl spb.KeyTransparencySequencerServer)
 
 // PeriodicallyRun executes f once per tick until ctx is closed.
 // Closing ctx will also stop any in-flight operation mid-way through.
-func PeriodicallyRun(ctx context.Context, tickch <-chan time.Time, f func(ctx context.Context) error) error {
+func PeriodicallyRun(ctx context.Context, tickch <-chan time.Time, f func(ctx context.Context)) {
+	if f == nil {
+		glog.Errorf("cannot schedule nil function")
+		return
+	}
 	for range tickch {
 		select {
 		case <-ctx.Done():
-			return nil
+			return
 		default:
 		}
-		if err := func() error {
-			// Give each invocation of f a separate context.
-			// Prevent f from creating detached go routines using ctx.
-			ctx, cancel := context.WithCancel(ctx)
-			defer cancel()
-			return f(ctx)
-		}(); err == context.Canceled || status.Code(err) == codes.Canceled {
-			// Ignore canceled errors. These are expected on shutdown.
-			return nil
-		} else if err != nil {
-			return err
-		}
+		// Give each invocation of f a separate context.
+		// Prevent f from creating detached go routines using ctx.
+		cctx, cancel := context.WithCancel(ctx)
+		f(cctx)
+		cancel()
 	}
-	return nil
 }
 
 // RunBatchForAllDirectories scans the directories table for new directories and creates new receivers for


### PR DESCRIPTION
Removes the previous behavior of stopping the recurring call if the
called function returned an error. This behavior was causing the server
to stop processing while appearing to be healthy.

Require the internal function to handle it's errors or shutdown.