### PR TITLE
 Simplify the Reduce function interface

### DIFF
--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	// Create gRPC server.
 	ksvr := keyserver.New(tlog, tmap, logAdmin, mapAdmin,
-		entry.Mutate, directories, logs, logs)
+		entry.MutateFn, directories, logs, logs)
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -120,7 +120,7 @@ func main() {
 
 	// Create gRPC server.
 	ksvr := keyserver.New(tlog, tmap, logAdmin, mapAdmin,
-		entry.New(), directories, logs, logs)
+		entry.Mutate, directories, logs, logs)
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -128,7 +128,7 @@ func New(ktClient pb.KeyTransparencyClient,
 		Verifier:    ktVerifier,
 		cli:         ktClient,
 		directoryID: directoryID,
-		mutate:      entry.Mutate,
+		mutate:      entry.MutateFn,
 		RetryDelay:  retryDelay,
 	}
 }

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -99,7 +99,7 @@ type Client struct {
 	Verifier
 	cli         pb.KeyTransparencyClient
 	directoryID string
-	mutator     mutator.Func
+	mutate      mutator.ReduceMutationFn
 	RetryDelay  time.Duration
 	trusted     types.LogRootV1
 	trustedLock sync.Mutex
@@ -128,7 +128,7 @@ func New(ktClient pb.KeyTransparencyClient,
 		Verifier:    ktVerifier,
 		cli:         ktClient,
 		directoryID: directoryID,
-		mutator:     entry.New(),
+		mutate:      entry.Mutate,
 		RetryDelay:  retryDelay,
 	}
 }

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -91,7 +91,6 @@ func (e *ErrList) Proto() []*statuspb.Status {
 
 func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot *trillian.SignedMapRoot, expectedNewRoot *types.MapRootV1) []error {
 	errs := ErrList{}
-	mutator := entry.New()
 	oldProofNodes := make(map[string][]byte)
 	newLeaves := make([]merkle.HStar2LeafHash, 0, len(muts))
 	glog.Infof("verifyMutations() called with %v mutations.", len(muts))
@@ -110,7 +109,7 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot *trillian.Si
 		}
 
 		// compute the new leaf
-		newValue, err := mutator.Mutate(oldLeaf, mut.GetMutation())
+		newValue, err := entry.Mutate(oldLeaf, mut.GetMutation())
 		if err != nil {
 			glog.Infof("Mutation did not verify: %v", err)
 			errs.AppendStatus(status.Newf(codes.DataLoss, "invalid mutation: %v", err).WithDetails(mut.GetMutation()))

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -109,7 +109,7 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot *trillian.Si
 		}
 
 		// compute the new leaf
-		newValue, err := entry.Mutate(oldLeaf, mut.GetMutation())
+		newValue, err := entry.MutateFn(oldLeaf, mut.GetMutation())
 		if err != nil {
 			glog.Infof("Mutation did not verify: %v", err)
 			errs.AppendStatus(status.Newf(codes.DataLoss, "invalid mutation: %v", err).WithDetails(mut.GetMutation()))

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -125,7 +125,7 @@ func (m *Mutation) SerializeAndSign(signers []*tink.KeysetHandle) (*pb.UpdateEnt
 	}
 
 	// Sanity check the mutation's correctness.
-	if _, err := Mutate(m.prevSignedEntry, mutation); err != nil {
+	if _, err := MutateFn(m.prevSignedEntry, mutation); err != nil {
 		return nil, fmt.Errorf("presign mutation check: %v", err)
 	}
 

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -125,7 +125,7 @@ func (m *Mutation) SerializeAndSign(signers []*tink.KeysetHandle) (*pb.UpdateEnt
 	}
 
 	// Sanity check the mutation's correctness.
-	if _, err := New().Mutate(m.prevSignedEntry, mutation); err != nil {
+	if _, err := Mutate(m.prevSignedEntry, mutation); err != nil {
 		return nil, fmt.Errorf("presign mutation check: %v", err)
 	}
 

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -113,7 +113,7 @@ func TestCreateAndVerify(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromLeafValue(%v): %v", tc.old, err)
 			}
-			newSignedEntry, err := Mutate(oldSignedEntry, update.GetEntryUpdate().GetMutation())
+			newSignedEntry, err := MutateFn(oldSignedEntry, update.GetEntryUpdate().GetMutation())
 			if err != nil {
 				t.Fatalf("Mutate(%v): %v", update.GetEntryUpdate().GetMutation(), err)
 			}

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -113,8 +113,7 @@ func TestCreateAndVerify(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromLeafValue(%v): %v", tc.old, err)
 			}
-			f := New()
-			newSignedEntry, err := f.Mutate(oldSignedEntry, update.GetEntryUpdate().GetMutation())
+			newSignedEntry, err := Mutate(oldSignedEntry, update.GetEntryUpdate().GetMutation())
 			if err != nil {
 				t.Fatalf("Mutate(%v): %v", update.GetEntryUpdate().GetMutation(), err)
 			}

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -30,9 +30,9 @@ import (
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
-// Mutate verifies that newSignedEntry is a valid mutation for oldSignedEntry and returns the
+// MutateFn verifies that newSignedEntry is a valid mutation for oldSignedEntry and returns the
 // application of newSignedEntry to oldSignedEntry.
-func Mutate(oldSignedEntry, newSignedEntry *pb.SignedEntry) (*pb.SignedEntry, error) {
+func MutateFn(oldSignedEntry, newSignedEntry *pb.SignedEntry) (*pb.SignedEntry, error) {
 	// Ensure that the mutation size is within bounds.
 	if got, want := proto.Size(newSignedEntry), mutator.MaxMutationSize; got > want {
 		glog.Warningf("mutation is %v bytes, want <= %v", got, want)

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -30,18 +30,9 @@ import (
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
-// Mutator defines mutations to simply replace the current map value with the
-// contents of the mutation.
-type Mutator struct{}
-
-// New creates a new entry mutator.
-func New() *Mutator {
-	return &Mutator{}
-}
-
 // Mutate verifies that newSignedEntry is a valid mutation for oldSignedEntry and returns the
 // application of newSignedEntry to oldSignedEntry.
-func (*Mutator) Mutate(oldSignedEntry, newSignedEntry *pb.SignedEntry) (*pb.SignedEntry, error) {
+func Mutate(oldSignedEntry, newSignedEntry *pb.SignedEntry) (*pb.SignedEntry, error) {
 	// Ensure that the mutation size is within bounds.
 	if got, want := proto.Size(newSignedEntry), mutator.MaxMutationSize; got > want {
 		glog.Warningf("mutation is %v bytes, want <= %v", got, want)

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -177,7 +177,7 @@ func TestCheckMutation(t *testing.T) {
 			continue
 		}
 
-		if _, got := New().Mutate(tc.old, m); got != tc.err {
+		if _, got := Mutate(tc.old, m); got != tc.err {
 			t.Errorf("%v Mutate(): %v, want %v", tc.desc, got, tc.err)
 		}
 	}

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -177,7 +177,7 @@ func TestCheckMutation(t *testing.T) {
 			continue
 		}
 
-		if _, got := Mutate(tc.old, m); got != tc.err {
+		if _, got := MutateFn(tc.old, m); got != tc.err {
 			t.Errorf("%v Mutate(): %v, want %v", tc.desc, got, tc.err)
 		}
 	}

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -44,12 +44,10 @@ var (
 	ErrUnauthorized = errors.New("mutation: unauthorized")
 )
 
-// Func verifies mutations and transforms values in the map.
-type Func interface {
-	// Mutate verifies that this is a valid mutation for this item and
-	// applies mutation to value.  Mutate must be idempotent.
-	Mutate(value, mutation *pb.SignedEntry) (*pb.SignedEntry, error)
-}
+// ReduceMutationFn takes the existing mapleaf and a new mutation and returns the new value for that map leaf.
+// ReduceMutationFn verifies that this is a valid mutation for this item.
+// ReduceMutationFn must be idempotent.
+type ReduceMutationFn func(existingMapLeafValue, mutation *pb.SignedEntry) (*pb.SignedEntry, error)
 
 // LogMessage represents a change to a user, and associated data.
 type LogMessage struct {

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -265,7 +265,7 @@ func (s *Server) CreateRevision(ctx context.Context, in *spb.CreateRevisionReque
 	}
 
 	// Apply mutations to values.
-	newLeaves, err := s.applyMutations(directoryID, entry.Mutate, msgs, leaves)
+	newLeaves, err := s.applyMutations(directoryID, entry.MutateFn, msgs, leaves)
 	if err != nil {
 		return nil, err
 	}

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -265,7 +265,7 @@ func (s *Server) CreateRevision(ctx context.Context, in *spb.CreateRevisionReque
 	}
 
 	// Apply mutations to values.
-	newLeaves, err := s.applyMutations(directoryID, entry.New(), msgs, leaves)
+	newLeaves, err := s.applyMutations(directoryID, entry.Mutate, msgs, leaves)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (s *Server) PublishBatch(ctx context.Context, in *spb.PublishBatchRequest) 
 // Multiple mutations for the same leaf will be applied to provided leaf.
 // The last valid mutation for each leaf is included in the output.
 // Returns a list of map leaves that should be updated.
-func (s *Server) applyMutations(directoryID string, mutatorFunc mutator.Func,
+func (s *Server) applyMutations(directoryID string, mutatorFunc mutator.ReduceMutationFn,
 	msgs []*ktpb.EntryUpdate, leaves []*tpb.MapLeaf) ([]*tpb.MapLeaf, error) {
 	// Put leaves in a map from index to leaf value.
 	leafMap := make(map[string]*tpb.MapLeaf)
@@ -385,7 +385,7 @@ func (s *Server) applyMutations(directoryID string, mutatorFunc mutator.Func,
 			}
 		}
 
-		newValue, err := mutatorFunc.Mutate(oldValue, msg.Mutation)
+		newValue, err := mutatorFunc(oldValue, msg.Mutation)
 		if err != nil {
 			glog.Warningf("Mutate(): %v", err)
 			mutationFailures.Inc(directoryID, "Mutate")

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -191,7 +191,7 @@ func TestDuplicateMutations(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			directoryID := "test"
-			newLeaves, err := s.applyMutations(directoryID, entry.New(), tc.msgs, tc.leaves)
+			newLeaves, err := s.applyMutations(directoryID, entry.Mutate, tc.msgs, tc.leaves)
 			if err != nil {
 				t.Errorf("applyMutations(): %v", err)
 			}

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -191,7 +191,7 @@ func TestDuplicateMutations(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			directoryID := "test"
-			newLeaves, err := s.applyMutations(directoryID, entry.Mutate, tc.msgs, tc.leaves)
+			newLeaves, err := s.applyMutations(directoryID, entry.MutateFn, tc.msgs, tc.leaves)
 			if err != nil {
 				t.Errorf("applyMutations(): %v", err)
 			}

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -165,7 +165,7 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	authz := &authorization.AuthzPolicy{}
 
 	server := keyserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin,
-		entry.New(), directoryStorage, mutations, mutations)
+		entry.Mutate, directoryStorage, mutations, mutations)
 	gsvr := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			authorization.UnaryServerInterceptor(map[string]authorization.AuthPair{

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -165,7 +165,7 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	authz := &authorization.AuthzPolicy{}
 
 	server := keyserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin,
-		entry.Mutate, directoryStorage, mutations, mutations)
+		entry.MutateFn, directoryStorage, mutations, mutations)
 	gsvr := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			authorization.UnaryServerInterceptor(map[string]authorization.AuthPair{


### PR DESCRIPTION
Replaces the mutation interface with a reduce function type.

It is not generally true that a struct based mutation function
will work. This change clarifies that a bit and reduces code stutter.

This is part of making a multi-leaf mutation possible #1122 