### PR TITLE
Implement batched queue mutation

### DIFF
--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -38,7 +38,7 @@ import (
 // MutationLogs provides sets of time ordered message logs.
 type MutationLogs interface {
 	// Send submits an item to a random log.
-	Send(ctx context.Context, directoryID string, mutation *pb.EntryUpdate) error
+	Send(ctx context.Context, directoryID string, mutation ...*pb.EntryUpdate) error
 	// ReadLog returns the messages in the (low, high] range stored in the specified log.
 	ReadLog(ctx context.Context, directoryID string, logID, low, high int64,
 		batchSize int32) ([]*mutator.LogMessage, error)

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -69,7 +69,7 @@ func (b batchStorage) ReadBatch(ctx context.Context, dirID string, rev int64) (*
 
 type mutations map[int64][]*mutator.LogMessage // Map of logID to Slice of LogMessages
 
-func (m *mutations) Send(ctx context.Context, dirID string, mutation *pb.EntryUpdate) error {
+func (m *mutations) Send(ctx context.Context, dirID string, mutation ...*pb.EntryUpdate) error {
 	return errors.New("unimplemented")
 }
 

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -55,6 +55,7 @@ type MapLogItemFn func(logItem *LogMessage, emit func(index []byte, mutation *pb
 // LogMessage represents a change to a user, and associated data.
 type LogMessage struct {
 	ID        int64
+	LocalID   int64
 	Mutation  *pb.SignedEntry
 	ExtraData *pb.Committed
 }

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -40,7 +40,7 @@ var (
 		Time     BIGINT           NOT NULL,
 		Sequence BIGINT           NOT NULL,
 		Mutation BLOB             NOT NULL,
-		PRIMARY KEY(DirectoryID, LogID, Time)
+		PRIMARY KEY(DirectoryID, LogID, Time, Sequence)
 	);`,
 		`CREATE TABLE IF NOT EXISTS Logs (
 		DirectoryID VARCHAR(30)   NOT NULL,

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -38,9 +38,9 @@ var (
 		DirectoryID VARCHAR(30)   NOT NULL,
 		LogID    BIGINT           NOT NULL,
 		Time     BIGINT           NOT NULL,
-		Sequence BIGINT           NOT NULL,
+		LocalID  BIGINT           NOT NULL,
 		Mutation BLOB             NOT NULL,
-		PRIMARY KEY(DirectoryID, LogID, Time, Sequence)
+		PRIMARY KEY(DirectoryID, LogID, Time, LocalID )
 	);`,
 		`CREATE TABLE IF NOT EXISTS Logs (
 		DirectoryID VARCHAR(30)   NOT NULL,

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -38,7 +38,7 @@ var (
 		DirectoryID VARCHAR(30)   NOT NULL,
 		LogID    BIGINT           NOT NULL,
 		Time     BIGINT           NOT NULL,
-		ID       BIGINT           NOT NULL,
+		Sequence BIGINT           NOT NULL,
 		Mutation BLOB             NOT NULL,
 		PRIMARY KEY(DirectoryID, LogID, Time)
 	);`,

--- a/impl/sql/mutationstorage/mutations.go
+++ b/impl/sql/mutationstorage/mutations.go
@@ -38,6 +38,7 @@ var (
 		DirectoryID VARCHAR(30)   NOT NULL,
 		LogID    BIGINT           NOT NULL,
 		Time     BIGINT           NOT NULL,
+		ID       BIGINT           NOT NULL,
 		Mutation BLOB             NOT NULL,
 		PRIMARY KEY(DirectoryID, LogID, Time)
 	);`,

--- a/impl/sql/mutationstorage/queue.go
+++ b/impl/sql/mutationstorage/queue.go
@@ -142,7 +142,7 @@ func (m *Mutations) send(ctx context.Context, ts time.Time, directoryID string, 
 
 	for i, data := range mData {
 		if _, err = tx.ExecContext(ctx,
-			`INSERT INTO Queue (DirectoryID, LogID, Time, Sequence, Mutation) VALUES (?, ?, ?, ?, ?);`,
+			`INSERT INTO Queue (DirectoryID, LogID, Time, LocalID, Mutation) VALUES (?, ?, ?, ?, ?);`,
 			directoryID, logID, tsTime, i, data); err != nil {
 			return status.Errorf(codes.Internal, "failed inserting into queue: %v", err)
 		}

--- a/impl/sql/mutationstorage/queue.go
+++ b/impl/sql/mutationstorage/queue.go
@@ -114,8 +114,10 @@ func (m *Mutations) randLog(ctx context.Context, directoryID string) (int64, err
 }
 
 // ts must be greater than all other timestamps currently recorded for directoryID.
-func (m *Mutations) send(ctx context.Context, ts time.Time, directoryID string, logID int64, mData ...[]byte) (ret error) {
-	tx, err := m.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+func (m *Mutations) send(ctx context.Context, ts time.Time, directoryID string,
+	logID int64, mData ...[]byte) (ret error) {
+	tx, err := m.db.BeginTx(ctx,
+		&sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
 		return err
 	}
@@ -172,6 +174,7 @@ func (m *Mutations) HighWatermark(ctx context.Context, directoryID string, logID
 }
 
 // ReadLog reads all mutations in logID between (low, high].
+// ReadLog may return more rows than batchSize in order to fetch all the rows at a particular timestamp.
 func (m *Mutations) ReadLog(ctx context.Context, directoryID string,
 	logID, low, high int64, batchSize int32) ([]*mutator.LogMessage, error) {
 	rows, err := m.db.QueryContext(ctx,

--- a/impl/sql/mutationstorage/queue_test.go
+++ b/impl/sql/mutationstorage/queue_test.go
@@ -98,7 +98,7 @@ func BenchmarkSend(b *testing.B) {
 	} {
 		b.Run(fmt.Sprintf("%d", tc.batch), func(b *testing.B) {
 			updates := make([]*pb.EntryUpdate, 0, tc.batch)
-			for range updates {
+			for i := 0; i < tc.batch; i++ {
 				updates = append(updates, update)
 			}
 			for n := 0; n < b.N; n++ {
@@ -132,7 +132,7 @@ func TestSend(t *testing.T) {
 		{desc: "Old", ts: ts1, wantCode: codes.Aborted},
 		{desc: "New", ts: ts3},
 	} {
-		err := m.send(ctx, tc.ts, directoryID, 1, update)
+		err := m.send(ctx, tc.ts, directoryID, 1, update, update)
 		if got, want := status.Code(err), tc.wantCode; got != want {
 			t.Errorf("%v: send(): %v, got: %v, want %v", tc.desc, err, got, want)
 		}

--- a/impl/sql/mutationstorage/queue_test.go
+++ b/impl/sql/mutationstorage/queue_test.go
@@ -28,7 +28,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-func newForTest(ctx context.Context, t *testing.T, logIDs ...int64) *Mutations {
+func newForTest(ctx context.Context, t testing.TB, logIDs ...int64) *Mutations {
 	m, err := New(newDB(t))
 	if err != nil {
 		t.Fatalf("Failed to create Mutations: %v", err)
@@ -73,6 +73,18 @@ func TestRandLog(t *testing.T) {
 				t.Errorf("logs: %v, want %v", got, want)
 			}
 		})
+	}
+}
+
+func BenchmarkSend(b *testing.B) {
+	ctx := context.Background()
+	logID := int64(1)
+	update := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: []byte("xxxxxxxxxxxxxxxxxx")}}
+	m := newForTest(ctx, b, logID)
+	for n := 0; n < b.N; n++ {
+		if err := m.Send(ctx, directoryID, update); err != nil {
+			b.Errorf("Send(): %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
This improves the write performance from ~10k entries/s to ~100 k/s

Before
```
BenchmarkSend-8 		10000 			101075 ns/op
```

After
```
BenchmarkSend/1-8 	   	   20000	     92531 ns/op
BenchmarkSend/2-8 	   	   10000	    104603 ns/op
BenchmarkSend/4-8 	   	   10000	    125030 ns/op
BenchmarkSend/8-8 	   	   10000	    164034 ns/op
BenchmarkSend/16-8         	    5000	    247246 ns/op
BenchmarkSend/32-8         	    3000	    406327 ns/op
BenchmarkSend/64-8         	    2000	    730439 ns/op
BenchmarkSend/128-8        	    1000	   1330174 ns/op
BenchmarkSend/256-8        	     500	   2521275 ns/op
```
![screen shot 2018-11-27 at 12 48 55](https://user-images.githubusercontent.com/198478/49082933-0414c200-f243-11e8-8c7c-2ae658d6c135.png)


Part of #1229