### PR TITLE
Cleanup Sequencer API

### DIFF
--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -79,6 +79,7 @@ func (s *Sequencer) RunBatchForAllDirectories(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("admin.List(): %v", err)
 	}
+	// TODO(#565): Implement per-directory leader election here.
 	for _, d := range directories {
 		knownDirectories.Set(1, d.DirectoryID)
 		req := &spb.RunBatchRequest{

--- a/core/sequencer/sequencer_api.proto
+++ b/core/sequencer/sequencer_api.proto
@@ -44,19 +44,6 @@ message MapMetadata {
   repeated SourceSlice sources = 2;
 }
 
-// CreateRevisionRequest contains information needed to create a new revision.
-message CreateRevisionRequest {
-  // directory_id is the directory to apply the mutations to.
-  string directory_id = 1;
-  // deprecated messages. Server now reads messages via source watermarks.
-  reserved 2;
-  // revision is the expected revision of the new revision.
-  int64 revision = 3;
-  // deprecated map_metadata. Server now reads source watermarks from batch
-  // table.
-  reserved 4;
-}
-
 // RunBatchRequest triggers the sequencing of a batch of mutations for a
 // directory, with the batch size governed by the request parameters.
 message RunBatchRequest {
@@ -71,19 +58,66 @@ message RunBatchRequest {
   int32 max_batch = 3;
 }
 
-// PublishBatchRequest copies all SignedMapHeads into the Log of SignedMapHeads.
-message PublishBatchRequest {
+// DefineRevisionRequest contains information needed to define a new revision.
+message DefineRevisionsRequest {
+  // directory_id is the directory to examine the outstanding mutations for.
   string directory_id = 1;
+  // min_batch is the minimum number of items in a batch.
+  // If less than min_batch items are available, nothing happens.
+  // TODO(#1047): Replace with timeout so items in the log get processed
+  // eventually.
+  int32 min_batch = 2;
+  // max_batch is the maximum number of items in a batch.
+  int32 max_batch = 3;
+}
+
+// DefineRevisionResponse contains information about freshly defined revisions.
+message DefineRevisionsResponse {
+  // outsanding_revisions a list of all the defined revisions which are not yet applied.
+  repeated int64 outstanding_revisions = 1;
+}
+
+// ApplyRevisionRequest contains information needed to create a new revision.
+message ApplyRevisionRequest {
+  // directory_id is the directory to apply the mutations to.
+  string directory_id = 1;
+  // revision is the expected revision of the new revision.
+  int64 revision = 2;
+}
+
+// ApplyRevisionResponse contains stats about the created revision.
+message ApplyRevisionResponse {
+  string directory_id = 1;
+  // The revision this is for.
+  int64 revision = 2;
+  // mutations processed.
+  int64 mutations = 3;
+  // map_leaves written.
+  int64 map_leaves = 4;
+}
+
+// PublishRevisionRequest copies all SignedMapHeads into the Log of SignedMapHeads.
+message PublishRevisionsRequest {
+  string directory_id = 1;
+}
+
+// PublishRevisions
+message PublishRevisionsResponse {
+  // revisions published.
+  repeated int64 revisions = 1;
 }
 
 // The KeyTransparency Sequencer API.
 service KeyTransparencySequencer {
   // RunBatch reads outstanding mutations and calls CreateRevision.
   rpc RunBatch(RunBatchRequest) returns (google.protobuf.Empty);
-  // CreateRevision applies the contained mutations to the current map root.
+  // DefineRevision examines the outstanding items in the queue and optionally
+  // commits to one or more revisions.
+  rpc DefineRevisions(DefineRevisionsRequest) returns (DefineRevisionsResponse);
+  // ApplyRevision applies the contained mutations to the current map root.
   // If this method fails, it must be retried with the same arguments.
-  rpc CreateRevision(CreateRevisionRequest) returns (google.protobuf.Empty);
-  // PublishBatch copies the MapRoots of all known map revisions into the Log
+  rpc ApplyRevision(ApplyRevisionRequest) returns (ApplyRevisionResponse);
+  // PublishRevision copies the MapRoots of all known map revisions into the Log
   // of MapRoots.
-  rpc PublishBatch(PublishBatchRequest) returns (google.protobuf.Empty);
+  rpc PublishRevisions(PublishRevisionsRequest) returns (PublishRevisionsResponse);
 }

--- a/core/sequencer/sequencer_api.proto
+++ b/core/sequencer/sequencer_api.proto
@@ -96,28 +96,28 @@ message ApplyRevisionResponse {
   int64 map_leaves = 4;
 }
 
-// PublishRevisionRequest copies all SignedMapHeads into the Log of SignedMapHeads.
+// PublishRevisionsRequest copies all available SignedMapRoots into the Log of SignedMapRoots.
 message PublishRevisionsRequest {
   string directory_id = 1;
 }
 
-// PublishRevisions
+// PublishRevisionsResponse contains metrics about the publishing operation.
 message PublishRevisionsResponse {
-  // revisions published.
+  // revisions published to the log of signed map roots.
   repeated int64 revisions = 1;
 }
 
 // The KeyTransparency Sequencer API.
 service KeyTransparencySequencer {
-  // RunBatch reads outstanding mutations and calls CreateRevision.
+  // RunBatch calls DefineRevisions, ApplyRevision, and PublishRevisions successively.
   rpc RunBatch(RunBatchRequest) returns (google.protobuf.Empty);
   // DefineRevision examines the outstanding items in the queue and optionally
-  // commits to one or more revisions.
+  // writes the metadata for one or more revisions to the metadata database.
   rpc DefineRevisions(DefineRevisionsRequest) returns (DefineRevisionsResponse);
   // ApplyRevision applies the contained mutations to the current map root.
   // If this method fails, it must be retried with the same arguments.
   rpc ApplyRevision(ApplyRevisionRequest) returns (ApplyRevisionResponse);
-  // PublishRevision copies the MapRoots of all known map revisions into the Log
+  // PublishRevisions copies the MapRoots of all known map revisions into the Log
   // of MapRoots.
   rpc PublishRevisions(PublishRevisionsRequest) returns (PublishRevisionsResponse);
 }

--- a/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
+++ b/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
@@ -418,7 +418,7 @@ func (m *ApplyRevisionResponse) GetMapLeaves() int64 {
 	return 0
 }
 
-// PublishRevisionRequest copies all SignedMapHeads into the Log of SignedMapHeads.
+// PublishRevisionsRequest copies all available SignedMapRoots into the Log of SignedMapRoots.
 type PublishRevisionsRequest struct {
 	DirectoryId          string   `protobuf:"bytes,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -458,9 +458,9 @@ func (m *PublishRevisionsRequest) GetDirectoryId() string {
 	return ""
 }
 
-// PublishRevisions
+// PublishRevisionsResponse contains metrics about the publishing operation.
 type PublishRevisionsResponse struct {
-	// revisions published.
+	// revisions published to the log of signed map roots.
 	Revisions            []int64  `protobuf:"varint,1,rep,packed,name=revisions,proto3" json:"revisions,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -523,15 +523,15 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type KeyTransparencySequencerClient interface {
-	// RunBatch reads outstanding mutations and calls CreateRevision.
+	// RunBatch calls DefineRevisions, ApplyRevision, and PublishRevisions successively.
 	RunBatch(ctx context.Context, in *RunBatchRequest, opts ...grpc.CallOption) (*empty.Empty, error)
 	// DefineRevision examines the outstanding items in the queue and optionally
-	// commits to one or more revisions.
+	// writes the metadata for one or more revisions to the metadata database.
 	DefineRevisions(ctx context.Context, in *DefineRevisionsRequest, opts ...grpc.CallOption) (*DefineRevisionsResponse, error)
 	// ApplyRevision applies the contained mutations to the current map root.
 	// If this method fails, it must be retried with the same arguments.
 	ApplyRevision(ctx context.Context, in *ApplyRevisionRequest, opts ...grpc.CallOption) (*ApplyRevisionResponse, error)
-	// PublishRevision copies the MapRoots of all known map revisions into the Log
+	// PublishRevisions copies the MapRoots of all known map revisions into the Log
 	// of MapRoots.
 	PublishRevisions(ctx context.Context, in *PublishRevisionsRequest, opts ...grpc.CallOption) (*PublishRevisionsResponse, error)
 }
@@ -582,15 +582,15 @@ func (c *keyTransparencySequencerClient) PublishRevisions(ctx context.Context, i
 
 // KeyTransparencySequencerServer is the server API for KeyTransparencySequencer service.
 type KeyTransparencySequencerServer interface {
-	// RunBatch reads outstanding mutations and calls CreateRevision.
+	// RunBatch calls DefineRevisions, ApplyRevision, and PublishRevisions successively.
 	RunBatch(context.Context, *RunBatchRequest) (*empty.Empty, error)
 	// DefineRevision examines the outstanding items in the queue and optionally
-	// commits to one or more revisions.
+	// writes the metadata for one or more revisions to the metadata database.
 	DefineRevisions(context.Context, *DefineRevisionsRequest) (*DefineRevisionsResponse, error)
 	// ApplyRevision applies the contained mutations to the current map root.
 	// If this method fails, it must be retried with the same arguments.
 	ApplyRevision(context.Context, *ApplyRevisionRequest) (*ApplyRevisionResponse, error)
-	// PublishRevision copies the MapRoots of all known map revisions into the Log
+	// PublishRevisions copies the MapRoots of all known map revisions into the Log
 	// of MapRoots.
 	PublishRevisions(context.Context, *PublishRevisionsRequest) (*PublishRevisionsResponse, error)
 }

--- a/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
+++ b/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
@@ -135,56 +135,6 @@ func (m *MapMetadata_SourceSlice) GetLogId() int64 {
 	return 0
 }
 
-// CreateRevisionRequest contains information needed to create a new revision.
-type CreateRevisionRequest struct {
-	// directory_id is the directory to apply the mutations to.
-	DirectoryId string `protobuf:"bytes,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
-	// revision is the expected revision of the new revision.
-	Revision             int64    `protobuf:"varint,3,opt,name=revision,proto3" json:"revision,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *CreateRevisionRequest) Reset()         { *m = CreateRevisionRequest{} }
-func (m *CreateRevisionRequest) String() string { return proto.CompactTextString(m) }
-func (*CreateRevisionRequest) ProtoMessage()    {}
-func (*CreateRevisionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_0a5d61b2e27141ee, []int{1}
-}
-
-func (m *CreateRevisionRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CreateRevisionRequest.Unmarshal(m, b)
-}
-func (m *CreateRevisionRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CreateRevisionRequest.Marshal(b, m, deterministic)
-}
-func (m *CreateRevisionRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateRevisionRequest.Merge(m, src)
-}
-func (m *CreateRevisionRequest) XXX_Size() int {
-	return xxx_messageInfo_CreateRevisionRequest.Size(m)
-}
-func (m *CreateRevisionRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateRevisionRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_CreateRevisionRequest proto.InternalMessageInfo
-
-func (m *CreateRevisionRequest) GetDirectoryId() string {
-	if m != nil {
-		return m.DirectoryId
-	}
-	return ""
-}
-
-func (m *CreateRevisionRequest) GetRevision() int64 {
-	if m != nil {
-		return m.Revision
-	}
-	return 0
-}
-
 // RunBatchRequest triggers the sequencing of a batch of mutations for a
 // directory, with the batch size governed by the request parameters.
 type RunBatchRequest struct {
@@ -206,7 +156,7 @@ func (m *RunBatchRequest) Reset()         { *m = RunBatchRequest{} }
 func (m *RunBatchRequest) String() string { return proto.CompactTextString(m) }
 func (*RunBatchRequest) ProtoMessage()    {}
 func (*RunBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_0a5d61b2e27141ee, []int{2}
+	return fileDescriptor_0a5d61b2e27141ee, []int{1}
 }
 
 func (m *RunBatchRequest) XXX_Unmarshal(b []byte) error {
@@ -248,52 +198,317 @@ func (m *RunBatchRequest) GetMaxBatch() int32 {
 	return 0
 }
 
-// PublishBatchRequest copies all SignedMapHeads into the Log of SignedMapHeads.
-type PublishBatchRequest struct {
-	DirectoryId          string   `protobuf:"bytes,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
+// DefineRevisionRequest contains information needed to define a new revision.
+type DefineRevisionsRequest struct {
+	// directory_id is the directory to examine the outstanding mutations for.
+	DirectoryId string `protobuf:"bytes,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
+	// min_batch is the minimum number of items in a batch.
+	// If less than min_batch items are available, nothing happens.
+	// TODO(#1047): Replace with timeout so items in the log get processed
+	// eventually.
+	MinBatch int32 `protobuf:"varint,2,opt,name=min_batch,json=minBatch,proto3" json:"min_batch,omitempty"`
+	// max_batch is the maximum number of items in a batch.
+	MaxBatch             int32    `protobuf:"varint,3,opt,name=max_batch,json=maxBatch,proto3" json:"max_batch,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *PublishBatchRequest) Reset()         { *m = PublishBatchRequest{} }
-func (m *PublishBatchRequest) String() string { return proto.CompactTextString(m) }
-func (*PublishBatchRequest) ProtoMessage()    {}
-func (*PublishBatchRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_0a5d61b2e27141ee, []int{3}
+func (m *DefineRevisionsRequest) Reset()         { *m = DefineRevisionsRequest{} }
+func (m *DefineRevisionsRequest) String() string { return proto.CompactTextString(m) }
+func (*DefineRevisionsRequest) ProtoMessage()    {}
+func (*DefineRevisionsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0a5d61b2e27141ee, []int{2}
 }
 
-func (m *PublishBatchRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_PublishBatchRequest.Unmarshal(m, b)
+func (m *DefineRevisionsRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DefineRevisionsRequest.Unmarshal(m, b)
 }
-func (m *PublishBatchRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_PublishBatchRequest.Marshal(b, m, deterministic)
+func (m *DefineRevisionsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DefineRevisionsRequest.Marshal(b, m, deterministic)
 }
-func (m *PublishBatchRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_PublishBatchRequest.Merge(m, src)
+func (m *DefineRevisionsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DefineRevisionsRequest.Merge(m, src)
 }
-func (m *PublishBatchRequest) XXX_Size() int {
-	return xxx_messageInfo_PublishBatchRequest.Size(m)
+func (m *DefineRevisionsRequest) XXX_Size() int {
+	return xxx_messageInfo_DefineRevisionsRequest.Size(m)
 }
-func (m *PublishBatchRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_PublishBatchRequest.DiscardUnknown(m)
+func (m *DefineRevisionsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_DefineRevisionsRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_PublishBatchRequest proto.InternalMessageInfo
+var xxx_messageInfo_DefineRevisionsRequest proto.InternalMessageInfo
 
-func (m *PublishBatchRequest) GetDirectoryId() string {
+func (m *DefineRevisionsRequest) GetDirectoryId() string {
 	if m != nil {
 		return m.DirectoryId
 	}
 	return ""
 }
 
+func (m *DefineRevisionsRequest) GetMinBatch() int32 {
+	if m != nil {
+		return m.MinBatch
+	}
+	return 0
+}
+
+func (m *DefineRevisionsRequest) GetMaxBatch() int32 {
+	if m != nil {
+		return m.MaxBatch
+	}
+	return 0
+}
+
+// DefineRevisionResponse contains information about freshly defined revisions.
+type DefineRevisionsResponse struct {
+	// outsanding_revisions a list of all the defined revisions which are not yet applied.
+	OutstandingRevisions []int64  `protobuf:"varint,1,rep,packed,name=outstanding_revisions,json=outstandingRevisions,proto3" json:"outstanding_revisions,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *DefineRevisionsResponse) Reset()         { *m = DefineRevisionsResponse{} }
+func (m *DefineRevisionsResponse) String() string { return proto.CompactTextString(m) }
+func (*DefineRevisionsResponse) ProtoMessage()    {}
+func (*DefineRevisionsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0a5d61b2e27141ee, []int{3}
+}
+
+func (m *DefineRevisionsResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_DefineRevisionsResponse.Unmarshal(m, b)
+}
+func (m *DefineRevisionsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_DefineRevisionsResponse.Marshal(b, m, deterministic)
+}
+func (m *DefineRevisionsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DefineRevisionsResponse.Merge(m, src)
+}
+func (m *DefineRevisionsResponse) XXX_Size() int {
+	return xxx_messageInfo_DefineRevisionsResponse.Size(m)
+}
+func (m *DefineRevisionsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_DefineRevisionsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_DefineRevisionsResponse proto.InternalMessageInfo
+
+func (m *DefineRevisionsResponse) GetOutstandingRevisions() []int64 {
+	if m != nil {
+		return m.OutstandingRevisions
+	}
+	return nil
+}
+
+// ApplyRevisionRequest contains information needed to create a new revision.
+type ApplyRevisionRequest struct {
+	// directory_id is the directory to apply the mutations to.
+	DirectoryId string `protobuf:"bytes,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
+	// revision is the expected revision of the new revision.
+	Revision             int64    `protobuf:"varint,2,opt,name=revision,proto3" json:"revision,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ApplyRevisionRequest) Reset()         { *m = ApplyRevisionRequest{} }
+func (m *ApplyRevisionRequest) String() string { return proto.CompactTextString(m) }
+func (*ApplyRevisionRequest) ProtoMessage()    {}
+func (*ApplyRevisionRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0a5d61b2e27141ee, []int{4}
+}
+
+func (m *ApplyRevisionRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ApplyRevisionRequest.Unmarshal(m, b)
+}
+func (m *ApplyRevisionRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ApplyRevisionRequest.Marshal(b, m, deterministic)
+}
+func (m *ApplyRevisionRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ApplyRevisionRequest.Merge(m, src)
+}
+func (m *ApplyRevisionRequest) XXX_Size() int {
+	return xxx_messageInfo_ApplyRevisionRequest.Size(m)
+}
+func (m *ApplyRevisionRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_ApplyRevisionRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ApplyRevisionRequest proto.InternalMessageInfo
+
+func (m *ApplyRevisionRequest) GetDirectoryId() string {
+	if m != nil {
+		return m.DirectoryId
+	}
+	return ""
+}
+
+func (m *ApplyRevisionRequest) GetRevision() int64 {
+	if m != nil {
+		return m.Revision
+	}
+	return 0
+}
+
+// ApplyRevisionResponse contains stats about the created revision.
+type ApplyRevisionResponse struct {
+	DirectoryId string `protobuf:"bytes,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
+	// The revision this is for.
+	Revision int64 `protobuf:"varint,2,opt,name=revision,proto3" json:"revision,omitempty"`
+	// mutations processed.
+	Mutations int64 `protobuf:"varint,3,opt,name=mutations,proto3" json:"mutations,omitempty"`
+	// map_leaves written.
+	MapLeaves            int64    `protobuf:"varint,4,opt,name=map_leaves,json=mapLeaves,proto3" json:"map_leaves,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *ApplyRevisionResponse) Reset()         { *m = ApplyRevisionResponse{} }
+func (m *ApplyRevisionResponse) String() string { return proto.CompactTextString(m) }
+func (*ApplyRevisionResponse) ProtoMessage()    {}
+func (*ApplyRevisionResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0a5d61b2e27141ee, []int{5}
+}
+
+func (m *ApplyRevisionResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_ApplyRevisionResponse.Unmarshal(m, b)
+}
+func (m *ApplyRevisionResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_ApplyRevisionResponse.Marshal(b, m, deterministic)
+}
+func (m *ApplyRevisionResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ApplyRevisionResponse.Merge(m, src)
+}
+func (m *ApplyRevisionResponse) XXX_Size() int {
+	return xxx_messageInfo_ApplyRevisionResponse.Size(m)
+}
+func (m *ApplyRevisionResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_ApplyRevisionResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_ApplyRevisionResponse proto.InternalMessageInfo
+
+func (m *ApplyRevisionResponse) GetDirectoryId() string {
+	if m != nil {
+		return m.DirectoryId
+	}
+	return ""
+}
+
+func (m *ApplyRevisionResponse) GetRevision() int64 {
+	if m != nil {
+		return m.Revision
+	}
+	return 0
+}
+
+func (m *ApplyRevisionResponse) GetMutations() int64 {
+	if m != nil {
+		return m.Mutations
+	}
+	return 0
+}
+
+func (m *ApplyRevisionResponse) GetMapLeaves() int64 {
+	if m != nil {
+		return m.MapLeaves
+	}
+	return 0
+}
+
+// PublishRevisionRequest copies all SignedMapHeads into the Log of SignedMapHeads.
+type PublishRevisionsRequest struct {
+	DirectoryId          string   `protobuf:"bytes,1,opt,name=directory_id,json=directoryId,proto3" json:"directory_id,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *PublishRevisionsRequest) Reset()         { *m = PublishRevisionsRequest{} }
+func (m *PublishRevisionsRequest) String() string { return proto.CompactTextString(m) }
+func (*PublishRevisionsRequest) ProtoMessage()    {}
+func (*PublishRevisionsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0a5d61b2e27141ee, []int{6}
+}
+
+func (m *PublishRevisionsRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PublishRevisionsRequest.Unmarshal(m, b)
+}
+func (m *PublishRevisionsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PublishRevisionsRequest.Marshal(b, m, deterministic)
+}
+func (m *PublishRevisionsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PublishRevisionsRequest.Merge(m, src)
+}
+func (m *PublishRevisionsRequest) XXX_Size() int {
+	return xxx_messageInfo_PublishRevisionsRequest.Size(m)
+}
+func (m *PublishRevisionsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_PublishRevisionsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PublishRevisionsRequest proto.InternalMessageInfo
+
+func (m *PublishRevisionsRequest) GetDirectoryId() string {
+	if m != nil {
+		return m.DirectoryId
+	}
+	return ""
+}
+
+// PublishRevisions
+type PublishRevisionsResponse struct {
+	// revisions published.
+	Revisions            []int64  `protobuf:"varint,1,rep,packed,name=revisions,proto3" json:"revisions,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *PublishRevisionsResponse) Reset()         { *m = PublishRevisionsResponse{} }
+func (m *PublishRevisionsResponse) String() string { return proto.CompactTextString(m) }
+func (*PublishRevisionsResponse) ProtoMessage()    {}
+func (*PublishRevisionsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_0a5d61b2e27141ee, []int{7}
+}
+
+func (m *PublishRevisionsResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_PublishRevisionsResponse.Unmarshal(m, b)
+}
+func (m *PublishRevisionsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_PublishRevisionsResponse.Marshal(b, m, deterministic)
+}
+func (m *PublishRevisionsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_PublishRevisionsResponse.Merge(m, src)
+}
+func (m *PublishRevisionsResponse) XXX_Size() int {
+	return xxx_messageInfo_PublishRevisionsResponse.Size(m)
+}
+func (m *PublishRevisionsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_PublishRevisionsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_PublishRevisionsResponse proto.InternalMessageInfo
+
+func (m *PublishRevisionsResponse) GetRevisions() []int64 {
+	if m != nil {
+		return m.Revisions
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*MapMetadata)(nil), "google.keytransparency.sequencer.MapMetadata")
 	proto.RegisterType((*MapMetadata_SourceSlice)(nil), "google.keytransparency.sequencer.MapMetadata.SourceSlice")
-	proto.RegisterType((*CreateRevisionRequest)(nil), "google.keytransparency.sequencer.CreateRevisionRequest")
 	proto.RegisterType((*RunBatchRequest)(nil), "google.keytransparency.sequencer.RunBatchRequest")
-	proto.RegisterType((*PublishBatchRequest)(nil), "google.keytransparency.sequencer.PublishBatchRequest")
+	proto.RegisterType((*DefineRevisionsRequest)(nil), "google.keytransparency.sequencer.DefineRevisionsRequest")
+	proto.RegisterType((*DefineRevisionsResponse)(nil), "google.keytransparency.sequencer.DefineRevisionsResponse")
+	proto.RegisterType((*ApplyRevisionRequest)(nil), "google.keytransparency.sequencer.ApplyRevisionRequest")
+	proto.RegisterType((*ApplyRevisionResponse)(nil), "google.keytransparency.sequencer.ApplyRevisionResponse")
+	proto.RegisterType((*PublishRevisionsRequest)(nil), "google.keytransparency.sequencer.PublishRevisionsRequest")
+	proto.RegisterType((*PublishRevisionsResponse)(nil), "google.keytransparency.sequencer.PublishRevisionsResponse")
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -310,12 +525,15 @@ const _ = grpc.SupportPackageIsVersion4
 type KeyTransparencySequencerClient interface {
 	// RunBatch reads outstanding mutations and calls CreateRevision.
 	RunBatch(ctx context.Context, in *RunBatchRequest, opts ...grpc.CallOption) (*empty.Empty, error)
-	// CreateRevision applies the contained mutations to the current map root.
+	// DefineRevision examines the outstanding items in the queue and optionally
+	// commits to one or more revisions.
+	DefineRevisions(ctx context.Context, in *DefineRevisionsRequest, opts ...grpc.CallOption) (*DefineRevisionsResponse, error)
+	// ApplyRevision applies the contained mutations to the current map root.
 	// If this method fails, it must be retried with the same arguments.
-	CreateRevision(ctx context.Context, in *CreateRevisionRequest, opts ...grpc.CallOption) (*empty.Empty, error)
-	// PublishBatch copies the MapRoots of all known map revisions into the Log
+	ApplyRevision(ctx context.Context, in *ApplyRevisionRequest, opts ...grpc.CallOption) (*ApplyRevisionResponse, error)
+	// PublishRevision copies the MapRoots of all known map revisions into the Log
 	// of MapRoots.
-	PublishBatch(ctx context.Context, in *PublishBatchRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	PublishRevisions(ctx context.Context, in *PublishRevisionsRequest, opts ...grpc.CallOption) (*PublishRevisionsResponse, error)
 }
 
 type keyTransparencySequencerClient struct {
@@ -335,18 +553,27 @@ func (c *keyTransparencySequencerClient) RunBatch(ctx context.Context, in *RunBa
 	return out, nil
 }
 
-func (c *keyTransparencySequencerClient) CreateRevision(ctx context.Context, in *CreateRevisionRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
-	err := c.cc.Invoke(ctx, "/google.keytransparency.sequencer.KeyTransparencySequencer/CreateRevision", in, out, opts...)
+func (c *keyTransparencySequencerClient) DefineRevisions(ctx context.Context, in *DefineRevisionsRequest, opts ...grpc.CallOption) (*DefineRevisionsResponse, error) {
+	out := new(DefineRevisionsResponse)
+	err := c.cc.Invoke(ctx, "/google.keytransparency.sequencer.KeyTransparencySequencer/DefineRevisions", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *keyTransparencySequencerClient) PublishBatch(ctx context.Context, in *PublishBatchRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
-	err := c.cc.Invoke(ctx, "/google.keytransparency.sequencer.KeyTransparencySequencer/PublishBatch", in, out, opts...)
+func (c *keyTransparencySequencerClient) ApplyRevision(ctx context.Context, in *ApplyRevisionRequest, opts ...grpc.CallOption) (*ApplyRevisionResponse, error) {
+	out := new(ApplyRevisionResponse)
+	err := c.cc.Invoke(ctx, "/google.keytransparency.sequencer.KeyTransparencySequencer/ApplyRevision", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *keyTransparencySequencerClient) PublishRevisions(ctx context.Context, in *PublishRevisionsRequest, opts ...grpc.CallOption) (*PublishRevisionsResponse, error) {
+	out := new(PublishRevisionsResponse)
+	err := c.cc.Invoke(ctx, "/google.keytransparency.sequencer.KeyTransparencySequencer/PublishRevisions", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -357,12 +584,15 @@ func (c *keyTransparencySequencerClient) PublishBatch(ctx context.Context, in *P
 type KeyTransparencySequencerServer interface {
 	// RunBatch reads outstanding mutations and calls CreateRevision.
 	RunBatch(context.Context, *RunBatchRequest) (*empty.Empty, error)
-	// CreateRevision applies the contained mutations to the current map root.
+	// DefineRevision examines the outstanding items in the queue and optionally
+	// commits to one or more revisions.
+	DefineRevisions(context.Context, *DefineRevisionsRequest) (*DefineRevisionsResponse, error)
+	// ApplyRevision applies the contained mutations to the current map root.
 	// If this method fails, it must be retried with the same arguments.
-	CreateRevision(context.Context, *CreateRevisionRequest) (*empty.Empty, error)
-	// PublishBatch copies the MapRoots of all known map revisions into the Log
+	ApplyRevision(context.Context, *ApplyRevisionRequest) (*ApplyRevisionResponse, error)
+	// PublishRevision copies the MapRoots of all known map revisions into the Log
 	// of MapRoots.
-	PublishBatch(context.Context, *PublishBatchRequest) (*empty.Empty, error)
+	PublishRevisions(context.Context, *PublishRevisionsRequest) (*PublishRevisionsResponse, error)
 }
 
 func RegisterKeyTransparencySequencerServer(s *grpc.Server, srv KeyTransparencySequencerServer) {
@@ -387,38 +617,56 @@ func _KeyTransparencySequencer_RunBatch_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
-func _KeyTransparencySequencer_CreateRevision_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CreateRevisionRequest)
+func _KeyTransparencySequencer_DefineRevisions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DefineRevisionsRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(KeyTransparencySequencerServer).CreateRevision(ctx, in)
+		return srv.(KeyTransparencySequencerServer).DefineRevisions(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/google.keytransparency.sequencer.KeyTransparencySequencer/CreateRevision",
+		FullMethod: "/google.keytransparency.sequencer.KeyTransparencySequencer/DefineRevisions",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(KeyTransparencySequencerServer).CreateRevision(ctx, req.(*CreateRevisionRequest))
+		return srv.(KeyTransparencySequencerServer).DefineRevisions(ctx, req.(*DefineRevisionsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _KeyTransparencySequencer_PublishBatch_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(PublishBatchRequest)
+func _KeyTransparencySequencer_ApplyRevision_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ApplyRevisionRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(KeyTransparencySequencerServer).PublishBatch(ctx, in)
+		return srv.(KeyTransparencySequencerServer).ApplyRevision(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/google.keytransparency.sequencer.KeyTransparencySequencer/PublishBatch",
+		FullMethod: "/google.keytransparency.sequencer.KeyTransparencySequencer/ApplyRevision",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(KeyTransparencySequencerServer).PublishBatch(ctx, req.(*PublishBatchRequest))
+		return srv.(KeyTransparencySequencerServer).ApplyRevision(ctx, req.(*ApplyRevisionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _KeyTransparencySequencer_PublishRevisions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PublishRevisionsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(KeyTransparencySequencerServer).PublishRevisions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/google.keytransparency.sequencer.KeyTransparencySequencer/PublishRevisions",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(KeyTransparencySequencerServer).PublishRevisions(ctx, req.(*PublishRevisionsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -432,12 +680,16 @@ var _KeyTransparencySequencer_serviceDesc = grpc.ServiceDesc{
 			Handler:    _KeyTransparencySequencer_RunBatch_Handler,
 		},
 		{
-			MethodName: "CreateRevision",
-			Handler:    _KeyTransparencySequencer_CreateRevision_Handler,
+			MethodName: "DefineRevisions",
+			Handler:    _KeyTransparencySequencer_DefineRevisions_Handler,
 		},
 		{
-			MethodName: "PublishBatch",
-			Handler:    _KeyTransparencySequencer_PublishBatch_Handler,
+			MethodName: "ApplyRevision",
+			Handler:    _KeyTransparencySequencer_ApplyRevision_Handler,
+		},
+		{
+			MethodName: "PublishRevisions",
+			Handler:    _KeyTransparencySequencer_PublishRevisions_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -447,33 +699,41 @@ var _KeyTransparencySequencer_serviceDesc = grpc.ServiceDesc{
 func init() { proto.RegisterFile("sequencer_api.proto", fileDescriptor_0a5d61b2e27141ee) }
 
 var fileDescriptor_0a5d61b2e27141ee = []byte{
-	// 442 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x53, 0x5f, 0x6b, 0xd4, 0x40,
-	0x10, 0xe7, 0x92, 0xbb, 0x9a, 0xce, 0x15, 0x1b, 0xb7, 0x54, 0x8e, 0xeb, 0xcb, 0x79, 0x4f, 0x15,
-	0x21, 0xc1, 0x8a, 0xa8, 0xaf, 0x2d, 0x7d, 0xe8, 0x49, 0x41, 0x72, 0x8a, 0x20, 0x48, 0xd8, 0x6c,
-	0xc6, 0x64, 0x69, 0x92, 0x8d, 0xbb, 0x1b, 0xdb, 0x80, 0xdf, 0xca, 0xef, 0xe4, 0xe7, 0x28, 0xd9,
-	0x24, 0xd7, 0x6b, 0x69, 0x39, 0xee, 0x29, 0xc9, 0xfc, 0xfe, 0xcc, 0xce, 0xfe, 0x26, 0x70, 0xa0,
-	0xf0, 0x77, 0x85, 0x05, 0x43, 0x19, 0xd2, 0x92, 0x7b, 0xa5, 0x14, 0x5a, 0x90, 0x59, 0x22, 0x44,
-	0x92, 0xa1, 0x77, 0x85, 0xb5, 0x96, 0xb4, 0x50, 0x25, 0x95, 0x58, 0xb0, 0xda, 0x5b, 0x71, 0xa7,
-	0x47, 0x2d, 0xc3, 0x37, 0xfc, 0xa8, 0xfa, 0xe5, 0x63, 0x5e, 0xea, 0xba, 0x95, 0xcf, 0xff, 0x0f,
-	0x60, 0x7c, 0x49, 0xcb, 0x4b, 0xd4, 0x34, 0xa6, 0x9a, 0x92, 0x25, 0x3c, 0x53, 0xa2, 0x92, 0x0c,
-	0xd5, 0xc4, 0x9a, 0xd9, 0xc7, 0xe3, 0x93, 0x4f, 0xde, 0xa6, 0x06, 0xde, 0x9a, 0xde, 0x5b, 0x1a,
-	0xf1, 0x32, 0xe3, 0x0c, 0x83, 0xde, 0x69, 0xfa, 0x17, 0xc6, 0x6b, 0x75, 0xf2, 0x1a, 0xdc, 0x4c,
-	0x5c, 0xa3, 0xd2, 0xe1, 0x35, 0xd5, 0x28, 0x73, 0x2a, 0xaf, 0x26, 0x83, 0xd9, 0xe0, 0xd8, 0x0e,
-	0xf6, 0xdb, 0xfa, 0xf7, 0xbe, 0x4c, 0xde, 0xc0, 0x8b, 0x94, 0x27, 0xe9, 0x7d, 0xae, 0x65, 0xb8,
-	0x6e, 0x07, 0xdc, 0x91, 0x0f, 0x61, 0x27, 0x13, 0x49, 0xc8, 0xe3, 0x89, 0x6d, 0x18, 0xa3, 0x4c,
-	0x24, 0x17, 0xf1, 0x62, 0xe8, 0x0c, 0x5c, 0x6b, 0x1e, 0xc1, 0xe1, 0x99, 0x44, 0xaa, 0x31, 0xc0,
-	0x3f, 0x5c, 0x71, 0x51, 0x04, 0xcd, 0xf9, 0x95, 0x26, 0xaf, 0x60, 0x2f, 0xe6, 0x12, 0x99, 0x16,
-	0xb2, 0x6e, 0xb4, 0xcd, 0x49, 0x76, 0x83, 0xf1, 0xaa, 0x76, 0x11, 0x93, 0x29, 0x38, 0xb2, 0x53,
-	0x75, 0xd6, 0xab, 0xef, 0xc5, 0xd0, 0xb1, 0x5c, 0x7b, 0x31, 0x74, 0x86, 0xee, 0x68, 0x5e, 0xc0,
-	0x7e, 0x50, 0x15, 0xa7, 0x54, 0xb3, 0x74, 0x0b, 0xf7, 0x23, 0xd8, 0xcd, 0x79, 0x11, 0x46, 0x8d,
-	0xcc, 0xcc, 0x36, 0x0a, 0x9c, 0x9c, 0xb7, 0x36, 0x06, 0xa4, 0x37, 0x1d, 0x68, 0x77, 0x20, 0xbd,
-	0x31, 0xe0, 0xfc, 0x23, 0x1c, 0x7c, 0xa9, 0xa2, 0x8c, 0xab, 0x74, 0xcb, 0x9e, 0x27, 0xff, 0x2c,
-	0x98, 0x7c, 0xc6, 0xfa, 0xeb, 0x5a, 0xa0, 0xcb, 0x3e, 0x4f, 0xf2, 0x0d, 0x9c, 0x7e, 0x0c, 0xf2,
-	0x76, 0x73, 0xfc, 0x0f, 0x46, 0x9e, 0xbe, 0xec, 0x25, 0xfd, 0xc2, 0x79, 0xe7, 0xcd, 0xc2, 0x11,
-	0x0a, 0xcf, 0xef, 0x27, 0x40, 0x3e, 0x6c, 0x36, 0x7f, 0x34, 0xb3, 0x27, 0x5b, 0xfc, 0x84, 0xbd,
-	0xf5, 0x0b, 0x21, 0xef, 0x37, 0x37, 0x78, 0xe4, 0x02, 0x9f, 0xb2, 0x3f, 0x3d, 0xff, 0x71, 0x96,
-	0x70, 0x9d, 0x56, 0x91, 0xc7, 0x44, 0xee, 0x77, 0xbf, 0xd5, 0x03, 0x6b, 0x9f, 0x09, 0x89, 0xfe,
-	0xca, 0xff, 0xee, 0x2d, 0x4c, 0x44, 0xd8, 0xfa, 0xed, 0x98, 0xc7, 0xbb, 0xdb, 0x00, 0x00, 0x00,
-	0xff, 0xff, 0xf8, 0xa6, 0x8e, 0x7e, 0xd0, 0x03, 0x00, 0x00,
+	// 570 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x54, 0x4d, 0x6f, 0xd3, 0x40,
+	0x10, 0x95, 0xe3, 0xb4, 0x24, 0x13, 0x50, 0xc2, 0xd2, 0xb4, 0x96, 0x5b, 0xa4, 0xe0, 0x53, 0x10,
+	0x92, 0x23, 0x5a, 0x09, 0x5a, 0xc4, 0x85, 0x42, 0x0f, 0x05, 0x8a, 0x90, 0x43, 0x85, 0xc4, 0xc5,
+	0xda, 0xd8, 0x5b, 0x67, 0x55, 0x7b, 0xd7, 0xec, 0xae, 0xdb, 0x5a, 0xe2, 0xc0, 0x09, 0xa9, 0x67,
+	0xfe, 0x23, 0xbf, 0x03, 0xc5, 0x1f, 0x49, 0xea, 0x16, 0x85, 0x06, 0x89, 0x53, 0x92, 0x37, 0xef,
+	0xbd, 0x99, 0xdd, 0x7d, 0x13, 0x78, 0x20, 0xc9, 0xd7, 0x84, 0x30, 0x8f, 0x08, 0x17, 0xc7, 0xd4,
+	0x8e, 0x05, 0x57, 0x1c, 0xf5, 0x02, 0xce, 0x83, 0x90, 0xd8, 0xa7, 0x24, 0x55, 0x02, 0x33, 0x19,
+	0x63, 0x41, 0x98, 0x97, 0xda, 0x53, 0xae, 0xb9, 0x99, 0x33, 0x06, 0x19, 0x7f, 0x94, 0x9c, 0x0c,
+	0x48, 0x14, 0xab, 0x34, 0x97, 0x5b, 0xbf, 0x34, 0x68, 0x1d, 0xe1, 0xf8, 0x88, 0x28, 0xec, 0x63,
+	0x85, 0xd1, 0x10, 0xee, 0x48, 0x9e, 0x08, 0x8f, 0x48, 0xa3, 0xd6, 0xd3, 0xfb, 0xad, 0xed, 0x3d,
+	0x7b, 0x51, 0x03, 0x7b, 0x4e, 0x6f, 0x0f, 0x33, 0xf1, 0x30, 0xa4, 0x1e, 0x71, 0x4a, 0x27, 0xf3,
+	0x1b, 0xb4, 0xe6, 0x70, 0xf4, 0x18, 0x3a, 0x21, 0x3f, 0x27, 0x52, 0xb9, 0xe7, 0x58, 0x11, 0x11,
+	0x61, 0x71, 0x6a, 0x68, 0x3d, 0xad, 0xaf, 0x3b, 0xed, 0x1c, 0xff, 0x5c, 0xc2, 0xe8, 0x09, 0xdc,
+	0x1f, 0xd3, 0x60, 0x7c, 0x95, 0x5b, 0xcb, 0xb8, 0x9d, 0xa2, 0x30, 0x23, 0x77, 0x61, 0x35, 0xe4,
+	0x81, 0x4b, 0x7d, 0x43, 0xcf, 0x18, 0x2b, 0x21, 0x0f, 0x0e, 0xfd, 0xb7, 0xf5, 0x86, 0xd6, 0xa9,
+	0x59, 0x0c, 0xda, 0x4e, 0xc2, 0xf6, 0xb1, 0xf2, 0xc6, 0xce, 0x64, 0x72, 0xa9, 0xd0, 0x23, 0xb8,
+	0xeb, 0x53, 0x41, 0x3c, 0xc5, 0x45, 0x3a, 0x51, 0x4d, 0x66, 0x68, 0x3a, 0xad, 0x29, 0x76, 0xe8,
+	0xa3, 0x4d, 0x68, 0x46, 0x94, 0xb9, 0xa3, 0x89, 0x2c, 0xeb, 0xbb, 0xe2, 0x34, 0x22, 0x9a, 0xdb,
+	0x64, 0x45, 0x7c, 0x51, 0x14, 0xf5, 0xa2, 0x88, 0x2f, 0xb2, 0xa2, 0x95, 0xc0, 0xfa, 0x1b, 0x72,
+	0x42, 0x19, 0x71, 0xc8, 0x19, 0x95, 0x94, 0x33, 0xf9, 0x5f, 0xda, 0x7e, 0x80, 0x8d, 0x6b, 0x6d,
+	0x65, 0xcc, 0x99, 0x24, 0x68, 0x07, 0xba, 0x3c, 0x51, 0x52, 0x61, 0xe6, 0x53, 0x16, 0xb8, 0xa2,
+	0x24, 0x18, 0x5a, 0x4f, 0xef, 0xeb, 0xce, 0xda, 0x5c, 0x71, 0x2a, 0xb6, 0x8e, 0x61, 0xed, 0x55,
+	0x1c, 0x87, 0x69, 0x89, 0xdc, 0xe2, 0x10, 0x26, 0x34, 0xca, 0x1e, 0xc5, 0x93, 0x4d, 0x7f, 0x5b,
+	0x3f, 0x35, 0xe8, 0x56, 0x7c, 0x8b, 0x29, 0xff, 0xcd, 0x18, 0x6d, 0x41, 0x33, 0x4a, 0x14, 0x56,
+	0xd9, 0xc1, 0xf2, 0x18, 0xcc, 0x00, 0xf4, 0x10, 0x20, 0xc2, 0xb1, 0x1b, 0x12, 0x7c, 0x46, 0xa4,
+	0x51, 0x2f, 0xca, 0x38, 0x7e, 0x9f, 0x01, 0xd6, 0x4b, 0xd8, 0xf8, 0x98, 0x8c, 0x42, 0x2a, 0xc7,
+	0x4b, 0x3c, 0x9a, 0xb5, 0x0b, 0xc6, 0x75, 0x75, 0x71, 0xaa, 0x2d, 0x68, 0x56, 0xef, 0x7b, 0x06,
+	0x6c, 0x5f, 0xd6, 0xc1, 0x78, 0x47, 0xd2, 0x4f, 0x73, 0xeb, 0x35, 0x2c, 0xb7, 0x0b, 0x1d, 0x43,
+	0xa3, 0x0c, 0x2e, 0x7a, 0xba, 0x78, 0x19, 0x2b, 0x21, 0x37, 0xd7, 0x4b, 0x49, 0xb9, 0xfe, 0xf6,
+	0xc1, 0x64, 0xfd, 0xd1, 0x0f, 0x0d, 0xda, 0x95, 0xa4, 0xa0, 0xdd, 0xc5, 0xf6, 0x37, 0x67, 0xda,
+	0xdc, 0x5b, 0x42, 0x59, 0x5c, 0xcd, 0x77, 0x0d, 0xee, 0x5d, 0x89, 0x02, 0x7a, 0xb6, 0xd8, 0xec,
+	0xa6, 0x4c, 0x9a, 0xcf, 0x6f, 0xad, 0x2b, 0x46, 0xb8, 0xd4, 0xa0, 0x53, 0x7d, 0x3a, 0xf4, 0x17,
+	0x47, 0xfa, 0x43, 0x58, 0xcc, 0x17, 0xcb, 0x48, 0xf3, 0x59, 0xf6, 0x0f, 0xbe, 0xbc, 0x0e, 0xa8,
+	0x1a, 0x27, 0x23, 0xdb, 0xe3, 0xd1, 0xa0, 0xf8, 0xeb, 0xae, 0xf8, 0x0c, 0x3c, 0x2e, 0xc8, 0x60,
+	0x6a, 0x36, 0xfb, 0xe6, 0x06, 0xdc, 0xcd, 0xdf, 0x79, 0x35, 0xfb, 0xd8, 0xf9, 0x1d, 0x00, 0x00,
+	0xff, 0xff, 0x98, 0x54, 0xae, 0x72, 0x34, 0x06, 0x00, 0x00,
 }

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -152,6 +152,8 @@ func (s *Server) RunBatch(ctx context.Context, in *spb.RunBatchRequest) (*empty.
 			DirectoryId: in.DirectoryId,
 			Revision:    rev,
 		}); err != nil {
+			// Log the error and continue to publish any revsisions this run may have completed.
+			// This revision will be retried on the next execution of RunBatch.
 			glog.Errorf("ApplyRevision(dir: %v, rev: %v): %v", in.DirectoryId, rev, err)
 			break
 		}
@@ -194,7 +196,7 @@ func (s *Server) DefineRevisions(ctx context.Context,
 		return &spb.DefineRevisionsResponse{OutstandingRevisions: outstanding}, nil
 	}
 
-	// Query metadatab about outstanding log items.
+	// Query metadata about outstanding log items.
 	var lastMeta spb.MapMetadata
 	if err := proto.Unmarshal(latestMapRoot.Metadata, &lastMeta); err != nil {
 		return nil, err

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -128,11 +128,14 @@ func TestDefineRevisions(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			s.batcher = &fakeBatcher{highestRev: tc.highestRev}
-			got, err := s.DefineRevisions(ctx, directoryID, 1, 10)
+			got, err := s.DefineRevisions(ctx, &spb.DefineRevisionsRequest{
+				DirectoryId: directoryID,
+				MinBatch:    1,
+				MaxBatch:    10})
 			if err != nil {
 				t.Fatalf("DefineRevisions(): %v", err)
 			}
-			if !cmp.Equal(got, tc.want) {
+			if !cmp.Equal(got.OutstandingRevisions, tc.want) {
 				t.Errorf("DefineRevisions(): %v, want %v", got, tc.want)
 			}
 		})

--- a/core/sequencer/trillian_client.go
+++ b/core/sequencer/trillian_client.go
@@ -37,7 +37,7 @@ type trillianFactory interface {
 // trillianMap communicates with the Trilian map and verifies the responses.
 type trillianMap interface {
 	GetAndVerifyLatestMapRoot(ctx context.Context) (*tpb.SignedMapRoot, *types.MapRootV1, error)
-	SetLeaves(ctx context.Context, leaves []*tpb.MapLeaf, meatadata []byte) (*types.MapRootV1, error)
+	SetLeaves(ctx context.Context, leaves []*tpb.MapLeaf, meta []byte) (*types.MapRootV1, error)
 	GetAndVerifyMapRootByRevision(ctx context.Context, rev int64) (*tpb.SignedMapRoot, *types.MapRootV1, error)
 	GetAndVerifyMapLeavesByRevision(ctx context.Context, rev int64, indexes [][]byte) ([]*tpb.MapLeaf, error)
 }


### PR DESCRIPTION
Rework Sequencer API
 - Consistency of `Revision` terminology
 - Create `DefineRevisions` API
 - Return metrics in the API responses