### PR TITLE
Use Loopback Connection in Sequencer

### DIFF
--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -25,7 +25,8 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-func startHTTPServer(grpcServer *grpc.Server, addr string, services ...serverutil.RegisterServiceFromEndpoint) *http.Server {
+func startHTTPServer(grpcServer *grpc.Server, addr string,
+	services ...serverutil.RegisterServiceFromEndpoint) *http.Server {
 	// Wire up gRPC and HTTP servers.
 	tcreds, err := credentials.NewClientTLSFromFile(*certFile, "")
 	if err != nil {

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"flag"
 	"net/http"
 
 	"github.com/google/keytransparency/cmd/serverutil"
@@ -24,39 +23,15 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/reflection"
-
-	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
-	_ "github.com/google/trillian/crypto/keys/der/proto"
-	_ "github.com/google/trillian/merkle/coniks"  // Register hasher
-	_ "github.com/google/trillian/merkle/rfc6962" // Register hasher
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 )
 
-var (
-	addr        = flag.String("addr", ":8080", "The ip:port to serve on")
-	metricsAddr = flag.String("metrics-addr", ":8081", "The ip:port to publish metrics on")
-	keyFile     = flag.String("tls-key", "genfiles/server.key", "TLS private key file")
-	certFile    = flag.String("tls-cert", "genfiles/server.crt", "TLS cert file")
-)
-
-func startHTTPServer(svr pb.KeyTransparencyAdminServer) *http.Server {
+func startHTTPServer(grpcServer *grpc.Server, addr string, services ...serverutil.RegisterServiceFromEndpoint) *http.Server {
 	// Wire up gRPC and HTTP servers.
-	creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
-	if err != nil {
-		glog.Exitf("Failed to load server credentials %v", err)
-	}
-	grpcServer := grpc.NewServer(
-		grpc.Creds(creds),
-		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
-		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
-	)
 	tcreds, err := credentials.NewClientTLSFromFile(*certFile, "")
 	if err != nil {
 		glog.Exitf("Failed opening cert file %v: %v", *certFile, err)
 	}
-	gwmux, err := serverutil.GrpcGatewayMux(*addr, tcreds,
-		pb.RegisterKeyTransparencyAdminHandlerFromEndpoint)
+	gwmux, err := serverutil.GrpcGatewayMux(addr, tcreds, services...)
 	if err != nil {
 		glog.Exitf("Failed setting up REST proxy: %v", err)
 	}
@@ -72,18 +47,13 @@ func startHTTPServer(svr pb.KeyTransparencyAdminServer) *http.Server {
 		}
 	}()
 
-	pb.RegisterKeyTransparencyAdminServer(grpcServer, svr)
-	reflection.Register(grpcServer)
-	grpc_prometheus.Register(grpcServer)
-	grpc_prometheus.EnableHandlingTimeHistogram()
-
 	server := &http.Server{
-		Addr:    *addr,
+		Addr:    addr,
 		Handler: serverutil.GrpcHandlerFunc(grpcServer, mux),
 	}
 
 	go func() {
-		glog.Infof("Listening on %v", *addr)
+		glog.Infof("Listening on %v", addr)
 		if err := server.ListenAndServeTLS(*certFile, *keyFile); err != nil {
 			glog.Errorf("ListenAndServeTLS: %v", err)
 		}

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -45,6 +45,7 @@ import (
 	"github.com/google/trillian/storage/testdb"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 	ttest "github.com/google/trillian/testonly/integration"
 
 	_ "github.com/google/trillian/merkle/coniks"  // Register hasher
@@ -72,29 +73,28 @@ EeNeHYEb/T2jBFH4eYg4iSN7D/VYaJxJRA==
 )
 
 // Listen opens a random local port and listens on it.
-func Listen() (string, net.Listener, error) {
+func Listen() (net.Listener, *grpc.ClientConn, error) {
 	lis, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to listen: %v", err)
+		return nil, nil, fmt.Errorf("failed to listen: %v", err)
 	}
-	_, port, err := net.SplitHostPort(lis.Addr().String())
+	addr := lis.Addr().String()
+	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
-		return "", nil, fmt.Errorf("Failed to parse listener address: %v", err)
+		return nil, nil, fmt.Errorf("error connecting to %v: %v", addr, err)
 	}
-	addr := "localhost:" + port
-	return addr, lis, nil
+	return lis, conn, nil
 }
 
 // Env holds a complete testing environment for end-to-end tests.
 type Env struct {
 	*integration.Env
-	mapEnv        *ttest.MapEnv
-	logEnv        *ttest.LogEnv
-	admin         *adminserver.Server
-	grpcServer    *grpc.Server
-	grpcCC        *grpc.ClientConn
-	db            *sql.DB
-	stopSequencer func()
+	mapEnv     *ttest.MapEnv
+	logEnv     *ttest.LogEnv
+	admin      *adminserver.Server
+	grpcServer *grpc.Server
+	grpcCC     *grpc.ClientConn
+	db         *sql.DB
 }
 
 func vrfKeyGen(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
@@ -161,48 +161,41 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	glog.V(5).Infof("Directory: %# v", pretty.Formatter(directoryPB))
 
 	// Common data structures.
-	authFunc := authentication.FakeAuthFunc
 	authz := &authorization.AuthzPolicy{}
 
-	server := keyserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin,
-		entry.MutateFn, directoryStorage, mutations, mutations)
+	lis, cc, err := Listen()
+	if err != nil {
+		return nil, fmt.Errorf("env: Listen(): %v", err)
+	}
+
 	gsvr := grpc.NewServer(
 		grpc.UnaryInterceptor(
 			authorization.UnaryServerInterceptor(map[string]authorization.AuthPair{
 				"/google.keytransparency.v1.KeyTransparency/UpdateEntry": {
-					AuthnFunc: authFunc,
+					AuthnFunc: authentication.FakeAuthFunc,
 					AuthzFunc: authz.Authorize,
 				},
 			}),
 		),
 	)
-	pb.RegisterKeyTransparencyServer(gsvr, server)
 
-	// Sequencer Server.
-	sequencerServer := sequencer.NewServer(
+	pb.RegisterKeyTransparencyServer(gsvr, keyserver.New(
+		logEnv.Log, mapEnv.Map,
+		logEnv.Admin, mapEnv.Admin,
+		entry.MutateFn, directoryStorage,
+		mutations, mutations))
+
+	spb.RegisterKeyTransparencySequencerServer(gsvr, sequencer.NewServer(
 		directoryStorage,
 		logEnv.Admin, mapEnv.Admin,
 		logEnv.Log, mapEnv.Map,
 		mutations, mutations,
+		spb.NewKeyTransparencySequencerClient(cc),
 		monitoring.InertMetricFactory{},
-	)
+	))
 
-	sequencerClient, stop, err := sequencer.RunAndConnect(ctx, sequencerServer)
-	if err != nil {
-		return nil, fmt.Errorf("error launching sequencer server: %v", err)
-	}
-
-	// Serve and listen.
-	addr, lis, err := Listen()
-	if err != nil {
-		return nil, fmt.Errorf("env: Listen(): %v", err)
-	}
 	go gsvr.Serve(lis)
 
-	cc, err := grpc.Dial(addr, grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("Dial(%v): %v", addr, err)
-	}
 	ktClient := pb.NewKeyTransparencyClient(cc)
 	client, err := client.NewFromConfig(ktClient, directoryPB)
 	if err != nil {
@@ -213,27 +206,25 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	return &Env{
 		Env: &integration.Env{
 			Client:    client,
-			Cli:       ktClient,
-			Sequencer: sequencerClient,
+			Cli:       pb.NewKeyTransparencyClient(cc),
+			Sequencer: spb.NewKeyTransparencySequencerClient(cc),
 			Directory: directoryPB,
 			Timeout:   timeout,
 			CallOpts: func(userID string) []grpc.CallOption {
 				return []grpc.CallOption{grpc.PerRPCCredentials(authentication.GetFakeCredential(userID))}
 			},
 		},
-		mapEnv:        mapEnv,
-		logEnv:        logEnv,
-		admin:         adminSvr,
-		grpcServer:    gsvr,
-		grpcCC:        cc,
-		db:            db,
-		stopSequencer: stop,
+		mapEnv:     mapEnv,
+		logEnv:     logEnv,
+		admin:      adminSvr,
+		grpcServer: gsvr,
+		grpcCC:     cc,
+		db:         db,
 	}, nil
 }
 
 // Close releases resources allocated by NewEnv.
 func (env *Env) Close() {
-	env.stopSequencer()
 	ctx := context.Background()
 	if _, err := env.admin.DeleteDirectory(ctx, &pb.DeleteDirectoryRequest{
 		DirectoryId: env.Directory.DirectoryId,


### PR DESCRIPTION
By making calls through the rpc layer, we produce rpc layer metrics through prometheus about `DefineRevision`, `CreateRevision`, and `PublishRevision`.  These include periodicity, failure codes, latency, and a whole range of other metrics. 