### PR TITLE
Highwatermark metrics

### DIFF
--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -38,6 +38,7 @@ import (
 const (
 	directoryIDLabel = "directoryid"
 	logIDLabel       = "logid"
+	phaseLabel       = "phase"
 	definedLabel     = "defined"
 	appliedLabel     = "applied"
 	reasonLabel      = "reason"
@@ -69,7 +70,7 @@ func createMetrics(mf monitoring.MetricFactory) {
 		"batch_size",
 		"Number of mutations the signer is attempting to process for directoryid",
 		directoryIDLabel)
-	watermark = mf.NewGauge("watermark", "High Watermark", directoryIDLabel, logIDLabel)
+	watermark = mf.NewGauge("watermark", "High Watermark", directoryIDLabel, logIDLabel, phaseLabel)
 }
 
 // Watermarks is a map of watermarks by logID.
@@ -225,9 +226,9 @@ func (s *Server) DefineRevisions(ctx context.Context,
 		if err := s.batcher.WriteBatchSources(ctx, in.DirectoryId, nextRev, meta); err != nil {
 			return nil, err
 		}
-		for _, s := range meta.Sources {
-			watermark.Set(float64(s.HighestWatermark),
-				in.DirectoryId, fmt.Sprintf("%v", s.LogId), definedLabel)
+		for _, source := range meta.Sources {
+			watermark.Set(float64(source.HighestWatermark),
+				in.DirectoryId, fmt.Sprintf("%v", source.LogId), definedLabel)
 		}
 		outstanding = append(outstanding, nextRev)
 

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -28,6 +28,7 @@ import (
 	ktpb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 	tpb "github.com/google/trillian"
+	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/types"
 )
 
@@ -106,6 +107,7 @@ func TestDefineRevisions(t *testing.T) {
 	// Verify that outstanding revisions prevent future revisions from being created.
 	ctx := context.Background()
 	mapRev := int64(2)
+	once.Do(func() { createMetrics(monitoring.InertMetricFactory{}) })
 	s := Server{
 		logs: fakeLogs{
 			0: make([]mutator.LogMessage, 10),


### PR DESCRIPTION
Define metrics for high watermarks as they pass through the system.
- Watermark of each log as it is committed to in a revision definition.
- Watermark of each log as it is applied into a map revision. 
