### PR TITLE
Client: BatchCreateUser

### DIFF
--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -57,7 +57,7 @@ func (c *Client) BatchCreateUser(ctx context.Context, users []*tpb.User,
 	return c.BatchQueueUserUpdate(ctx, mutations, signers, opts...)
 }
 
-// BatchQueueUserUpdate signs an entry.Mutation and sends it to the server.
+// BatchQueueUserUpdate signs the mutations and sends them to the server.
 func (c *Client) BatchQueueUserUpdate(ctx context.Context, mutations []*entry.Mutation,
 	signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
 	updates := make([]*pb.EntryUpdate, 0, len(mutations))

--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -1,0 +1,74 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/tink/go/tink"
+	"google.golang.org/grpc"
+
+	"github.com/google/keytransparency/core/mutator/entry"
+
+	tpb "github.com/google/keytransparency/core/api/type/type_go_proto"
+	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+)
+
+// BatchCreate inserts mutations for new users that do not currently have entries.
+// Calling BatchCreate for a user that already exists will produce no change.
+func (c *Client) BatchCreate(ctx context.Context, users []*tpb.User, signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
+	// 1. Fetch user indexes
+	userIDs := make([]string, 0, len(users))
+	for _, u := range users {
+		userIDs = append(userIDs, u.UserId)
+	}
+	indexByUser, err := c.BatchVerifyGetUserIndex(ctx, userIDs)
+	if err != nil {
+		return err
+	}
+
+	mutations := make([]*entry.Mutation, 0, len(users))
+	for _, u := range users {
+		mutation := entry.NewMutation(indexByUser[u.UserId], u.DirectoryId, u.UserId)
+
+		if err := mutation.SetCommitment(u.PublicKeyData); err != nil {
+			return err
+		}
+		if len(u.AuthorizedKeys.Key) != 0 {
+			if err := mutation.ReplaceAuthorizedKeys(u.AuthorizedKeys); err != nil {
+				return err
+			}
+		}
+		mutations = append(mutations, mutation)
+	}
+	return c.BatchQueueUserUpdate(ctx, mutations, signers, opts...)
+}
+
+// BatchQueueUserUpdate signs an entry.Mutation and sends it to the server.
+func (c *Client) BatchQueueUserUpdate(ctx context.Context, mutations []*entry.Mutation, signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
+	updates := make([]*pb.EntryUpdate, 0, len(mutations))
+	for _, m := range mutations {
+		update, err := m.SerializeAndSign(signers)
+		if err != nil {
+			return fmt.Errorf("SerializeAndSign(): %v", err)
+		}
+		updates = append(updates, update)
+	}
+
+	req := &pb.BatchQueueUserUpdateRequest{DirectoryId: c.directoryID, Updates: updates}
+	_, err := c.cli.BatchQueueUserUpdate(ctx, req, opts...)
+	return err
+}

--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -16,7 +16,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/tink/go/tink"
 	"google.golang.org/grpc"
@@ -27,9 +26,10 @@ import (
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
-// BatchCreate inserts mutations for new users that do not currently have entries.
+// BatchCreateUser inserts mutations for new users that do not currently have entries.
 // Calling BatchCreate for a user that already exists will produce no change.
-func (c *Client) BatchCreate(ctx context.Context, users []*tpb.User, signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
+func (c *Client) BatchCreateUser(ctx context.Context, users []*tpb.User,
+	signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
 	// 1. Fetch user indexes
 	userIDs := make([]string, 0, len(users))
 	for _, u := range users {
@@ -58,12 +58,13 @@ func (c *Client) BatchCreate(ctx context.Context, users []*tpb.User, signers []*
 }
 
 // BatchQueueUserUpdate signs an entry.Mutation and sends it to the server.
-func (c *Client) BatchQueueUserUpdate(ctx context.Context, mutations []*entry.Mutation, signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
+func (c *Client) BatchQueueUserUpdate(ctx context.Context, mutations []*entry.Mutation,
+	signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
 	updates := make([]*pb.EntryUpdate, 0, len(mutations))
 	for _, m := range mutations {
 		update, err := m.SerializeAndSign(signers)
 		if err != nil {
-			return fmt.Errorf("SerializeAndSign(): %v", err)
+			return err
 		}
 		updates = append(updates, update)
 	}

--- a/core/client/batch_get_and_verify.go
+++ b/core/client/batch_get_and_verify.go
@@ -1,0 +1,42 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client
+
+import (
+	"context"
+
+	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+)
+
+// BatchVerifyGetUserIndex fetches and verifies the indexes for a list of users.
+func (c *Client) BatchVerifyGetUserIndex(ctx context.Context, userIDs []string) (map[string][]byte, error) {
+	resp, err := c.cli.BatchGetUserIndex(ctx, &pb.BatchGetUserIndexRequest{
+		DirectoryId: c.directoryID,
+		UserIds:     userIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	indexByUser := make(map[string][]byte)
+	for userID, proof := range resp.Proofs {
+		index, err := c.Index(proof, c.directoryID, userID)
+		if err != nil {
+			return nil, err
+		}
+		indexByUser[userID] = index
+	}
+	return indexByUser, nil
+}

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -254,12 +254,13 @@ func (c *Client) Update(ctx context.Context, u *tpb.User, signers []*tink.Keyset
 
 // QueueMutation signs an entry.Mutation and sends it to the server.
 func (c *Client) QueueMutation(ctx context.Context, m *entry.Mutation, signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
-	req, err := m.SerializeAndSign(signers)
+	update, err := m.SerializeAndSign(signers)
 	if err != nil {
 		return fmt.Errorf("SerializeAndSign(): %v", err)
 	}
 
 	Vlog.Printf("Sending Update request...")
+	req := &pb.UpdateEntryRequest{DirectoryId: c.directoryID, EntryUpdate: update}
 	_, err = c.cli.QueueEntryUpdate(ctx, req, opts...)
 	return err
 }

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -113,9 +113,9 @@ func TestCreateAndVerify(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromLeafValue(%v): %v", tc.old, err)
 			}
-			newSignedEntry, err := MutateFn(oldSignedEntry, update.GetEntryUpdate().GetMutation())
+			newSignedEntry, err := MutateFn(oldSignedEntry, update.GetMutation())
 			if err != nil {
-				t.Fatalf("Mutate(%v): %v", update.GetEntryUpdate().GetMutation(), err)
+				t.Fatalf("Mutate(%v): %v", update.GetMutation(), err)
 			}
 
 			var wantEntry pb.Entry

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -252,7 +252,7 @@ func logMsg(t *testing.T, id int64, signer *tink.KeysetHandle) *ktpb.EntryUpdate
 	}
 
 	return &ktpb.EntryUpdate{
-		Mutation:  update.EntryUpdate.Mutation,
+		Mutation:  update.Mutation,
 		Committed: &ktpb.Committed{},
 	}
 }


### PR DESCRIPTION
A shortcut for creating brand new users that avoids the round trip that's needed to fetch the current user state. 