### PR TITLE
Lazy load key material

### DIFF
--- a/cmd/gen-test-vectors/main.go
+++ b/cmd/gen-test-vectors/main.go
@@ -111,7 +111,7 @@ func GenerateTestVectors(ctx context.Context, env *integration.Env) error {
 		setProfile     []byte
 		ctx            context.Context
 		userID         string
-		signers        []*tink.KeysetHandle
+		signers        []tink.Signer
 		authorizedKeys *tinkpb.Keyset
 	}{
 		{

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 
 	tpb "github.com/google/keytransparency/core/api/type/type_go_proto"
+	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/tink"
 )
 
@@ -81,6 +82,11 @@ User email MUST match the OAuth account used to authorize the update.
 			return fmt.Errorf("error connecting: %v", err)
 		}
 
+		signer, err := signature.NewSigner(keyset)
+		if err != nil {
+			return err
+		}
+
 		// Update.
 		authorizedKeys, err := keyset.Public()
 		if err != nil {
@@ -95,7 +101,7 @@ User email MUST match the OAuth account used to authorize the update.
 			PublicKeyData:  profileData,
 			AuthorizedKeys: authorizedKeys.Keyset(),
 		}
-		if _, err := c.Update(ctx, u, []*tink.KeysetHandle{keyset},
+		if _, err := c.Update(ctx, u, []tink.Signer{signer},
 			grpc.PerRPCCredentials(userCreds)); err != nil {
 			return fmt.Errorf("update failed: %v", err)
 		}

--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -31,7 +31,7 @@ import (
 // BatchCreateUser inserts mutations for new users that do not currently have entries.
 // Calling BatchCreate for a user that already exists will produce no change.
 func (c *Client) BatchCreateUser(ctx context.Context, users []*tpb.User,
-	signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
+	signers []tink.Signer, opts ...grpc.CallOption) error {
 	// 1. Fetch user indexes
 	userIDs := make([]string, 0, len(users))
 	for _, u := range users {
@@ -61,7 +61,7 @@ func (c *Client) BatchCreateUser(ctx context.Context, users []*tpb.User,
 
 // BatchQueueUserUpdate signs the mutations and sends them to the server.
 func (c *Client) BatchQueueUserUpdate(ctx context.Context, mutations []*entry.Mutation,
-	signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
+	signers []tink.Signer, opts ...grpc.CallOption) error {
 	updates := make([]*pb.EntryUpdate, 0, len(mutations))
 	for _, m := range mutations {
 		update, err := m.SerializeAndSign(signers)

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -232,7 +232,7 @@ func (m uint64Slice) Less(i, j int) bool { return m[i] < m[j] }
 
 // Update creates and submits a mutation for a user, and waits for it to appear.
 // Returns codes.FailedPrecondition if there was a race condition.
-func (c *Client) Update(ctx context.Context, u *tpb.User, signers []*tink.KeysetHandle, opts ...grpc.CallOption) (*entry.Mutation, error) {
+func (c *Client) Update(ctx context.Context, u *tpb.User, signers []tink.Signer, opts ...grpc.CallOption) (*entry.Mutation, error) {
 	if got, want := u.DirectoryId, c.directoryID; got != want {
 		return nil, fmt.Errorf("u.DirectoryID: %v, want %v", got, want)
 	}
@@ -252,7 +252,7 @@ func (c *Client) Update(ctx context.Context, u *tpb.User, signers []*tink.Keyset
 }
 
 // QueueMutation signs an entry.Mutation and sends it to the server.
-func (c *Client) QueueMutation(ctx context.Context, m *entry.Mutation, signers []*tink.KeysetHandle, opts ...grpc.CallOption) error {
+func (c *Client) QueueMutation(ctx context.Context, m *entry.Mutation, signers []tink.Signer, opts ...grpc.CallOption) error {
 	update, err := m.SerializeAndSign(signers)
 	if err != nil {
 		return fmt.Errorf("failed SerializeAndSign: %v", err)

--- a/core/frontend/frontend.go
+++ b/core/frontend/frontend.go
@@ -34,8 +34,8 @@ var _ pb.KeyTransparencyFrontendServer = &Frontend{}
 
 // Frontend implements KeyTransparencyFrontend.
 type Frontend struct {
-	Client client.Client
-	Signer *tink.KeysetHandle
+	Client  client.Client
+	Signers []tink.Signer
 }
 
 // QueueKeyUpdate signs an update and forwards it to the keyserver.
@@ -55,7 +55,7 @@ func (f *Frontend) QueueKeyUpdate(ctx context.Context, in *pb.QueueKeyUpdateRequ
 	if err != nil {
 		return nil, err
 	}
-	if err := f.Client.QueueMutation(ctx, m, []*tink.KeysetHandle{f.Signer}); err != nil {
+	if err := f.Client.QueueMutation(ctx, m, f.Signers); err != nil {
 		return nil, err
 	}
 	return &empty.Empty{}, nil

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -180,7 +180,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) {
 		setProfile     []byte
 		opts           []grpc.CallOption
 		userID         string
-		signers        []*tink.KeysetHandle
+		signers        []tink.Signer
 		authorizedKeys *tinkpb.Keyset
 	}{
 		{
@@ -334,7 +334,7 @@ func TestListHistory(ctx context.Context, env *Env, t *testing.T) {
 	}
 }
 
-func (env *Env) setupHistory(ctx context.Context, directory *pb.Directory, userID string, signers []*tink.KeysetHandle,
+func (env *Env) setupHistory(ctx context.Context, directory *pb.Directory, userID string, signers []tink.Signer,
 	authorizedKeys *tinkpb.Keyset, opts []grpc.CallOption) error {
 	// Setup. Each profile entry is either nil, to indicate that the user
 	// did not submit a new profile in that revision, or contains the profile

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -58,7 +58,7 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) {
 	// Setup a bunch of revisions with data to verify.
 	for _, e := range []struct {
 		revision    int64
-		signers     []*tink.KeysetHandle
+		signers     []tink.Signer
 		userUpdates []*tpb.User
 	}{
 		{

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -34,7 +34,7 @@ func TestSerializeAndSign(t *testing.T) {
 		desc    string
 		old     []byte
 		pubKeys *tink.KeysetHandle
-		signers []*tink.KeysetHandle
+		signers []tink.Signer
 		data    []byte
 		want    codes.Code
 	}{
@@ -79,7 +79,7 @@ func TestCreateAndVerify(t *testing.T) {
 		desc    string
 		old     []byte
 		pubKeys *tink.KeysetHandle
-		signers []*tink.KeysetHandle
+		signers []tink.Signer
 		data    []byte
 	}{
 		{

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -68,7 +68,7 @@ func TestCheckMutation(t *testing.T) {
 	for _, tc := range []struct {
 		desc     string
 		mutation *Mutation
-		signers  []*tink.KeysetHandle
+		signers  []tink.Signer
 		old      *tpb.SignedEntry
 		err      error
 	}{

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -234,13 +234,17 @@ func TestHighWatermarks(t *testing.T) {
 	}
 }
 
-func logMsg(t *testing.T, id int64, signer *tink.KeysetHandle) *ktpb.EntryUpdate {
+func logMsg(t *testing.T, id int64, keyHandle *tink.KeysetHandle) *ktpb.EntryUpdate {
 	t.Helper()
 	index := []byte{byte(id)}
 	userID := string(id)
 	m := entry.NewMutation(index, "directory", userID)
-	signers := []*tink.KeysetHandle{signer}
-	pubkey, err := signer.Public()
+	signer, err := signature.NewSigner(keyHandle)
+	if err != nil {
+		t.Fatalf("signer.NewSigner(): %v", err)
+	}
+	signers := []tink.Signer{signer}
+	pubkey, err := keyHandle.Public()
 	if err != nil {
 		t.Fatalf("Public(): %v", err)
 	}

--- a/core/testutil/tink.go
+++ b/core/testutil/tink.go
@@ -116,8 +116,8 @@ func VerifyKeysetFromPEMs(pubPEMs ...string) *tink.KeysetHandle {
 }
 
 // SignKeysetsFromPEMs produces a slice of keysets, each with one private key.
-func SignKeysetsFromPEMs(privPEMs ...string) []*tink.KeysetHandle {
-	handles := make([]*tink.KeysetHandle, 0, len(privPEMs))
+func SignKeysetsFromPEMs(privPEMs ...string) []tink.Signer {
+	signers := make([]tink.Signer, 0, len(privPEMs))
 	for i, pem := range privPEMs {
 		if pem == "" {
 			continue
@@ -128,7 +128,11 @@ func SignKeysetsFromPEMs(privPEMs ...string) []*tink.KeysetHandle {
 		if err != nil {
 			panic(fmt.Sprintf("testkeysethandle.KeysetHandle(): %v", err))
 		}
-		handles = append(handles, parsedHandle)
+		signer, err := signature.NewSigner(parsedHandle)
+		if err != nil {
+			panic(fmt.Sprintf("testkeysethandle.NewSigner(): %v", err))
+		}
+		signers = append(signers, signer)
 	}
-	return handles
+	return signers
 }


### PR DESCRIPTION
This PR swaps out uses of  `tink.KeysetHandle` which references loaded key material for `tink.Signer`  which is an interface that permits remote key material and lazy loaded keys.  As a result, the servers can start without blocking on key material loading. 