### PR TITLE
Nits

### DIFF
--- a/core/frontend/frontend.go
+++ b/core/frontend/frontend.go
@@ -40,7 +40,7 @@ var _ pb.KeyTransparencyFrontendServer = &Frontend{}
 
 // Frontend implements KeyTransparencyFrontend.
 type Frontend struct {
-	Client  client.Client
+	Client  *client.Client
 	Signers []tink.Signer
 	PubKeys PublicKeyGetter
 }

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -45,7 +45,7 @@ const (
 )
 
 var (
-	once             sync.Once
+	initMetrics      sync.Once
 	knownDirectories monitoring.Gauge
 	batchSize        monitoring.Gauge
 	mutationCount    monitoring.Counter
@@ -125,7 +125,7 @@ func NewServer(
 	loopback spb.KeyTransparencySequencerClient,
 	metricsFactory monitoring.MetricFactory,
 ) *Server {
-	once.Do(func() { createMetrics(metricsFactory) })
+	initMetrics.Do(func() { createMetrics(metricsFactory) })
 	return &Server{
 		trillian: &Trillian{
 			directories: directories,

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -108,7 +108,7 @@ func TestDefineRevisions(t *testing.T) {
 	// Verify that outstanding revisions prevent future revisions from being created.
 	ctx := context.Background()
 	mapRev := int64(2)
-	once.Do(func() { createMetrics(monitoring.InertMetricFactory{}) })
+	initMetrics.Do(func() { createMetrics(monitoring.InertMetricFactory{}) })
 	s := Server{
 		logs: fakeLogs{
 			0: make([]mutator.LogMessage, 10),


### PR DESCRIPTION
* Accept a pointer receiver in `core/frontend`
* Use a less ambiguous name than `once` in `core/sequencer`