### PR TITLE
Fix CI

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -116,7 +116,8 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed opening cert file %v: %v", *certFile, err)
 	}
-	gwmux, err := serverutil.GrpcGatewayMux(*addr, tcreds,
+	dopts := []grpc.DialOption{grpc.WithTransportCredentials(tcreds)}
+	gwmux, err := serverutil.GrpcGatewayMux(ctx, *addr, dopts,
 		mopb.RegisterMonitorHandlerFromEndpoint)
 	if err != nil {
 		glog.Exitf("Failed setting up REST proxy: %v", err)

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -193,11 +192,6 @@ func main() {
 	httpServer := startHTTPServer(grpcServer, addr,
 		pb.RegisterKeyTransparencyAdminHandlerFromEndpoint,
 	)
-
-	cli, err := etcd.NewClient(strings.Split(*etcdServers, ","), 5*time.Second)
-	if err != nil || cli == nil {
-		glog.Exitf("Failed to create etcd client: %v", err)
-	}
 
 	// Periodically run batch.
 	electionFactory, closeFactory := getElectionFactory()

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -114,13 +114,15 @@ func getElectionFactory() (election2.Factory, func()) {
 func main() {
 	flag.Parse()
 	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	// Connect to trillian log and map backends.
-	mconn, err := grpc.Dial(*mapURL, grpc.WithInsecure())
+	mconn, err := grpc.DialContext(ctx, *mapURL, grpc.WithInsecure())
 	if err != nil {
 		glog.Exitf("grpc.Dial(%v): %v", *mapURL, err)
 	}
-	lconn, err := grpc.Dial(*logURL, grpc.WithInsecure())
+	lconn, err := grpc.DialContext(ctx, *logURL, grpc.WithInsecure())
 	if err != nil {
 		glog.Exitf("Failed to connect to %v: %v", *logURL, err)
 	}

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -151,9 +151,15 @@ func main() {
 	if err != nil {
 		glog.Exitf("error creating TCP listener: %v", err)
 	}
-	addr := lis.Addr().String()
+	glog.Infof("Listening on %v", lis.Addr().String())
 	// Non-blocking dial before we start the server.
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure())
+	tcreds, err := credentials.NewClientTLSFromFile(*certFile, "localhost")
+	if err != nil {
+		glog.Exitf("Failed opening cert file %v: %v", *certFile, err)
+	}
+	dopts := []grpc.DialOption{grpc.WithTransportCredentials(tcreds)}
+	addr := lis.Addr().String()
+	conn, err := grpc.DialContext(ctx, addr, dopts...)
 	if err != nil {
 		glog.Exitf("error connecting to %v: %v", addr, err)
 	}

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -191,6 +191,7 @@ func main() {
 	glog.Infof("Signer starting")
 
 	// Run servers
+	go serveHTTPMetric(*metricsAddr)
 	httpServer := startHTTPServer(grpcServer, addr,
 		pb.RegisterKeyTransparencyAdminHandlerFromEndpoint,
 	)

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -140,12 +140,7 @@ func main() {
 		glog.Exitf("Failed to create directory storage object: %v", err)
 	}
 
-	creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
-	if err != nil {
-		glog.Exitf("Failed to load server credentials %v", err)
-	}
 	grpcServer := grpc.NewServer(
-		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
 	)

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -188,7 +188,7 @@ func main() {
 
 	// Run servers
 	go serveHTTPMetric(*metricsAddr)
-	httpServer := startHTTPServer(grpcServer, addr,
+	go serveHTTPGateway(ctx, lis, dopts, grpcServer,
 		pb.RegisterKeyTransparencyAdminHandlerFromEndpoint,
 	)
 	runSequencer(ctx, conn, mconn, directoryStorage)

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -26,13 +26,13 @@ import (
 	"google.golang.org/grpc"
 )
 
-func serveHTTPMetric(port string) {
+func serveHTTPMetric(addr string) {
 	metricMux := http.NewServeMux()
 	metricMux.Handle("/metrics", promhttp.Handler())
 
-	glog.Infof("Hosting metrics on %v", port)
-	if err := http.ListenAndServe(port, metricMux); err != nil {
-		glog.Fatalf("ListenAndServeTLS(%v): %v", *metricsAddr, err)
+	glog.Infof("Hosting metrics on %v", addr)
+	if err := http.ListenAndServe(addr, metricMux); err != nil {
+		glog.Fatalf("ListenAndServeTLS(%v): %v", addr, err)
 	}
 }
 

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"context"
+	"net"
 	"net/http"
 
 	"github.com/google/keytransparency/cmd/serverutil"
@@ -22,7 +24,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 func serveHTTPMetric(port string) {
@@ -33,24 +34,21 @@ func serveHTTPMetric(port string) {
 	if err := http.ListenAndServe(port, metricMux); err != nil {
 		glog.Fatalf("ListenAndServeTLS(%v): %v", *metricsAddr, err)
 	}
-	gwmux, err := serverutil.GrpcGatewayMux(addr, tcreds, services...)
+}
+
+func serveHTTPGateway(ctx context.Context, lis net.Listener, dopts []grpc.DialOption,
+	grpcServer *grpc.Server, services ...serverutil.RegisterServiceFromEndpoint) {
+	// Wire up gRPC and HTTP servers.
+	gwmux, err := serverutil.GrpcGatewayMux(ctx, lis.Addr().String(), dopts, services...)
 	if err != nil {
 		glog.Exitf("Failed setting up REST proxy: %v", err)
 	}
+
 	mux := http.NewServeMux()
 	mux.Handle("/", gwmux)
 
-	server := &http.Server{
-		Addr:    addr,
-		Handler: serverutil.GrpcHandlerFunc(grpcServer, mux),
+	server := &http.Server{Handler: serverutil.GrpcHandlerFunc(grpcServer, mux)}
+	if err := server.ServeTLS(lis, *certFile, *keyFile); err != nil {
+		glog.Errorf("ListenAndServeTLS: %v", err)
 	}
-
-	go func() {
-		glog.Infof("Listening on %v", addr)
-		if err := server.ListenAndServeTLS(*certFile, *keyFile); err != nil {
-			glog.Errorf("ListenAndServeTLS: %v", err)
-		}
-	}()
-	// Return a handle to the http server to callers can call Shutdown().
-	return server
 }

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"context"
 	"database/sql"
 	"flag"
 	"net/http"
@@ -67,6 +68,7 @@ func openDB() *sql.DB {
 
 func main() {
 	flag.Parse()
+	ctx := context.Background()
 
 	// Open Resources.
 	sqldb := openDB()
@@ -149,7 +151,8 @@ func main() {
 	if err != nil {
 		glog.Exitf("Failed opening cert file %v: %v", *certFile, err)
 	}
-	gwmux, err := serverutil.GrpcGatewayMux(*addr, tcreds,
+	dopts := []grpc.DialOption{grpc.WithTransportCredentials(tcreds)}
+	gwmux, err := serverutil.GrpcGatewayMux(ctx, *addr, dopts,
 		pb.RegisterKeyTransparencyHandlerFromEndpoint)
 	if err != nil {
 		glog.Exitf("Failed setting up REST proxy: %v", err)

--- a/cmd/serverutil/serverutil.go
+++ b/cmd/serverutil/serverutil.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // GrpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
@@ -43,11 +42,8 @@ func GrpcHandlerFunc(grpcServer http.Handler, otherHandler http.Handler) http.Ha
 type RegisterServiceFromEndpoint func(context.Context, *runtime.ServeMux, string, []grpc.DialOption) error
 
 // GrpcGatewayMux registers multiple gRPC services with a gRPC ServeMux
-func GrpcGatewayMux(addr string, transportCreds credentials.TransportCredentials,
+func GrpcGatewayMux(ctx context.Context, addr string, dopts []grpc.DialOption,
 	services ...RegisterServiceFromEndpoint) (*runtime.ServeMux, error) {
-	ctx := context.Background()
-
-	dopts := []grpc.DialOption{grpc.WithTransportCredentials(transportCreds)}
 
 	gwmux := runtime.NewServeMux()
 	for _, s := range services {

--- a/cmd/serverutil/serverutil.go
+++ b/cmd/serverutil/serverutil.go
@@ -30,7 +30,8 @@ func GrpcHandlerFunc(grpcServer http.Handler, otherHandler http.Handler) http.Ha
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This is a partial recreation of gRPC's internal checks.
 		// https://github.com/grpc/grpc-go/blob/master/transport/handler_server.go#L62
-		if r.ProtoMajor == 2 && strings.Contains(r.Header.Get("Content-Type"), "application/grpc") {
+		if r.ProtoMajor == 2 && strings.HasPrefix(
+			r.Header.Get("Content-Type"), "application/grpc") {
 			grpcServer.ServeHTTP(w, r)
 		} else {
 			otherHandler.ServeHTTP(w, r)

--- a/deploy/kubernetes/log-server-deployment.yaml
+++ b/deploy/kubernetes/log-server-deployment.yaml
@@ -18,12 +18,13 @@ spec:
         io.kompose.service: log-server
     spec:
       containers:
-      - command:
-        - /go/bin/trillian_log_server
-        - --mysql_uri=test:zaphod@tcp(db:3306)/test
-        - --rpc_endpoint=0.0.0.0:8090
-        - --http_endpoint=0.0.0.0:8091
-        - --alsologtostderr
+      - name: trillian-logserver
+        args: [
+        "--mysql_uri=test:zaphod@tcp(db:3306)/test",
+        "--rpc_endpoint=0.0.0.0:8090",
+        "--http_endpoint=0.0.0.0:8091",
+        "--alsologtostderr"
+        ]
         image: us.gcr.io/key-transparency/log-server:latest
         livenessProbe:
          httpGet:

--- a/deploy/kubernetes/log-signer-deployment.yaml
+++ b/deploy/kubernetes/log-signer-deployment.yaml
@@ -18,16 +18,17 @@ spec:
         io.kompose.service: log-signer
     spec:
       containers:
-      - command:
-        - /go/bin/trillian_log_signer
-        - --mysql_uri=test:zaphod@tcp(db:3306)/test
-        - --http_endpoint=0.0.0.0:8091
-        - --sequencer_guard_window=0s
-        - --sequencer_interval=1s
-        - --num_sequencers=1
-        - --batch_size=50
-        - --force_master=true
-        - --alsologtostderr
+      - name: trillian-logsigner
+        args: [
+        "--mysql_uri=test:zaphod@tcp(db:3306)/test",
+        "--http_endpoint=0.0.0.0:8091",
+        "--sequencer_guard_window=0s",
+        "--sequencer_interval=1s",
+        "--num_sequencers=1",
+        "--batch_size=50",
+        "--force_master=true",
+        "--alsologtostderr"
+        ]
         image: us.gcr.io/key-transparency/log-signer:latest
         livenessProbe:
          httpGet:

--- a/deploy/kubernetes/map-server-deployment.yaml
+++ b/deploy/kubernetes/map-server-deployment.yaml
@@ -18,12 +18,13 @@ spec:
         io.kompose.service: map-server
     spec:
       containers:
-      - command:
-        - /go/bin/trillian_map_server
-        - --mysql_uri=test:zaphod@tcp(db:3306)/test
-        - --rpc_endpoint=0.0.0.0:8090
-        - --http_endpoint=0.0.0.0:8091
-        - --alsologtostderr
+      - name: trillian-mapserver
+        args: [
+        "--mysql_uri=test:zaphod@tcp(db:3306)/test",
+        "--rpc_endpoint=0.0.0.0:8090",
+        "--http_endpoint=0.0.0.0:8091",
+        "--alsologtostderr"
+        ]
         image: us.gcr.io/key-transparency/map-server:latest
         livenessProbe:
          httpGet:


### PR DESCRIPTION
This PR is best reviewed commit by commit. 

There were two essential issues that had the Continuous Integration environment wedged. 
- The kubernetes configs for Trillian had stale paths for the binaries. 
-  The key transparency sequencer was opening the same port twice.  

Fixing the later involved refactoring the server setup to reuse a common `net.Listener`.  

Contrary to best practice, this PR also includes a few fixups and optimizations: 
- `strings.HasPrefix` vs. `strings.Contains` should be faster for matching non-GRPC connections.
- Split out a few functions to be purpose specific. 
- Use `DialContext` 