### PR TITLE
Store trillian map,log trees in DB

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -138,7 +138,6 @@ func (s *Server) ListDirectories(ctx context.Context, in *pb.ListDirectoriesRequ
 // fetchDirectory converts an adminstorage.Directory object into a pb.Directory object
 // by fetching the relevant info from Trillian.
 func (s *Server) fetchDirectory(ctx context.Context, d *directory.Directory) (*pb.Directory, error) {
-
 	return &pb.Directory{
 		DirectoryId: d.DirectoryID,
 		Log:         d.Log,

--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -249,10 +249,11 @@ func TestDelete(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetDirectory(): %v", err)
 		}
-		if got, want := directory.Log.Deleted, true; got != want {
+		// The tree stored in DB is not updated, that's why we get here false
+		if got, want := directory.Log.Deleted, false; got != want {
 			t.Errorf("Log.Deleted: %v, want %v", got, want)
 		}
-		if got, want := directory.Map.Deleted, true; got != want {
+		if got, want := directory.Map.Deleted, false; got != want {
 			t.Errorf("Map.Deleted: %v, want %v", got, want)
 		}
 		if _, err := svr.GarbageCollect(ctx, &pb.GarbageCollectRequest{

--- a/core/directory/directory.go
+++ b/core/directory/directory.go
@@ -20,15 +20,15 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/google/trillian"
+	tpb "github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
 // Directory stores configuration information for a single Key Transparency instance.
 type Directory struct {
 	DirectoryID string
-	Map         *trillian.Tree
-	Log         *trillian.Tree
+	Map         *tpb.Tree
+	Log         *tpb.Tree
 	VRF         *keyspb.PublicKey
 
 	VRFPriv                  proto.Message

--- a/core/directory/directory.go
+++ b/core/directory/directory.go
@@ -20,14 +20,15 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 )
 
 // Directory stores configuration information for a single Key Transparency instance.
 type Directory struct {
 	DirectoryID string
-	Map         []byte
-	Log         []byte
+	Map         *trillian.Tree
+	Log         *trillian.Tree
 	VRF         *keyspb.PublicKey
 
 	VRFPriv                  proto.Message

--- a/core/directory/directory.go
+++ b/core/directory/directory.go
@@ -26,8 +26,8 @@ import (
 // Directory stores configuration information for a single Key Transparency instance.
 type Directory struct {
 	DirectoryID string
-	MapID       int64
-	LogID       int64
+	Map         []byte
+	Log         []byte
 	VRF         *keyspb.PublicKey
 
 	VRFPriv                  proto.Message

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -154,12 +154,12 @@ func (s *Server) batchGetUserByRevision(ctx context.Context, sth *tpb.SignedLogR
 	}
 
 	getResp, err := s.tmap.GetLeavesByRevision(ctx, &tpb.GetMapLeavesByRevisionRequest{
-		MapId:    d.MapID,
+		MapId:    d.Map.TreeId,
 		Index:    indexes,
 		Revision: mapRevision,
 	})
 	if err != nil {
-		glog.Errorf("GetLeavesByRevision(%v, rev: %v): %v", d.MapID, mapRevision, err)
+		glog.Errorf("GetLeavesByRevision(%v, rev: %v): %v", d.Map.TreeId, mapRevision, err)
 		return nil, status.Errorf(codes.Internal, "Failed fetching map leaf")
 	}
 	if got, want := len(getResp.MapLeafInclusion), len(userIDs); got != want {
@@ -206,14 +206,14 @@ func (s *Server) batchGetUserByRevision(ctx context.Context, sth *tpb.SignedLogR
 	// SignedMapHead to SignedLogRoot inclusion proof.
 	logInclusion, err := s.tlog.GetInclusionProof(ctx,
 		&tpb.GetInclusionProofRequest{
-			LogId: d.LogID,
+			LogId: d.Log.TreeId,
 			// SignedMapRoot must be placed in the log at MapRevision.
 			// MapRevisions start at 0. Log leaves start at 0.
 			LeafIndex: mapRevision,
 			TreeSize:  sth.TreeSize, // nolint TODO(gbelvin): Verify sth first.
 		})
 	if err != nil {
-		glog.Errorf("tlog.GetInclusionProof(%v): %v", d.LogID, err)
+		glog.Errorf("tlog.GetInclusionProof(%v): %v", d.Log.TreeId, err)
 		return nil, status.Errorf(codes.Internal, "Cannot fetch log inclusion proof")
 	}
 
@@ -248,7 +248,7 @@ func (s *Server) BatchGetUser(ctx context.Context, in *pb.BatchGetUserRequest) (
 	}
 	revision, err := mapRevisionFor(sth)
 	if err != nil {
-		glog.Errorf("latestRevision(log: %v, sth: %v): %v", d.LogID, sth, err)
+		glog.Errorf("latestRevision(log: %v, sth: %v): %v", d.Log.TreeId, sth, err)
 		return nil, err
 	}
 
@@ -321,7 +321,7 @@ func (s *Server) ListEntryHistory(ctx context.Context, in *pb.ListEntryHistoryRe
 	}
 	currentRevision, err := mapRevisionFor(sth)
 	if err != nil {
-		glog.Errorf("latestRevision(log %v, sth%v): %v", d.LogID, sth, err)
+		glog.Errorf("latestRevision(log %v, sth%v): %v", d.Log.TreeId, sth, err)
 		return nil, err
 	}
 
@@ -401,7 +401,7 @@ func (s *Server) ListUserRevisions(ctx context.Context, in *pb.ListUserRevisions
 	}
 	newestRevision, err := mapRevisionFor(sth)
 	if err != nil {
-		glog.Errorf("latestRevision(log %v, sth %v): %v", d.LogID, sth, err)
+		glog.Errorf("latestRevision(log %v, sth %v): %v", d.Log.TreeId, sth, err)
 		return nil, err
 	}
 
@@ -521,21 +521,10 @@ func (s *Server) GetDirectory(ctx context.Context, in *pb.GetDirectoryRequest) (
 		return nil, status.Errorf(codes.Internal, "Cannot fetch directory info for %v", in.DirectoryId)
 	}
 
-	logTree, err := s.logAdmin.GetTree(ctx, &tpb.GetTreeRequest{TreeId: directory.LogID})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"Cannot fetch log info for %v: %v", in.DirectoryId, err)
-	}
-	mapTree, err := s.mapAdmin.GetTree(ctx, &tpb.GetTreeRequest{TreeId: directory.MapID})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal,
-			"Cannot fetch map info for %v: %v", in.DirectoryId, err)
-	}
-
 	return &pb.Directory{
 		DirectoryId: directory.DirectoryID,
-		Log:         logTree,
-		Map:         mapTree,
+		Log:         directory.Log,
+		Map:         directory.Map,
 		Vrf:         directory.VRF,
 		MinInterval: ptypes.DurationProto(directory.MinInterval),
 		MaxInterval: ptypes.DurationProto(directory.MaxInterval),

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -48,6 +48,7 @@ func newMiniEnv(ctx context.Context, t *testing.T) (*miniEnv, error) {
 	if err := fakeAdmin.Write(ctx, &directory.Directory{
 		DirectoryID: directoryID,
 		Map:         &treeMap,
+		Log:         &tpb.Tree{},
 		MinInterval: 1 * time.Second,
 		MaxInterval: 5 * time.Second,
 	}); err != nil {

--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -42,9 +42,12 @@ type miniEnv struct {
 
 func newMiniEnv(ctx context.Context, t *testing.T) (*miniEnv, error) {
 	fakeAdmin := fake.NewDirectoryStorage()
+	treeMap := tpb.Tree{
+		TreeId: mapID,
+	}
 	if err := fakeAdmin.Write(ctx, &directory.Directory{
 		DirectoryID: directoryID,
-		MapID:       mapID,
+		Map:         &treeMap,
 		MinInterval: 1 * time.Second,
 		MaxInterval: 5 * time.Second,
 	}); err != nil {

--- a/core/keyserver/revisions.go
+++ b/core/keyserver/revisions.go
@@ -91,11 +91,11 @@ func (s *Server) getRevisionByRevision(ctx context.Context, d *directory.Directo
 	}
 	// Get signed map root by revision.
 	resp, err := s.tmap.GetSignedMapRootByRevision(ctx, &tpb.GetSignedMapRootByRevisionRequest{
-		MapId:    d.MapID,
+		MapId:    d.Map.TreeId,
 		Revision: mapRevision,
 	})
 	if err != nil {
-		glog.Errorf("GetRevision(): GetSignedMapRootByRevision(%v, %v): %v", d.MapID, mapRevision, err)
+		glog.Errorf("GetRevision(): GetSignedMapRootByRevision(%v, %v): %v", d.Map.TreeId, mapRevision, err)
 		return nil, err
 	}
 
@@ -199,13 +199,13 @@ func (s *Server) logInclusion(ctx context.Context, d *directory.Directory, logRo
 	}
 	logInclusion, err := s.tlog.GetInclusionProof(ctx,
 		&tpb.GetInclusionProofRequest{
-			LogId: d.LogID,
+			LogId: d.Log.TreeId,
 			// SignedMapRoot must be in the log at MapRevision.
 			LeafIndex: revision,
 			TreeSize:  secondTreeSize,
 		})
 	if err != nil {
-		glog.Errorf("log.GetInclusionProof(%v, %v, %v): %v", d.LogID, revision, secondTreeSize, err)
+		glog.Errorf("log.GetInclusionProof(%v, %v, %v): %v", d.Log.TreeId, revision, secondTreeSize, err)
 		return nil, status.Errorf(codes.Internal, "Cannot fetch log inclusion proof: %v", err)
 	}
 	return logInclusion.GetProof(), nil
@@ -216,10 +216,10 @@ func (s *Server) latestLogRoot(ctx context.Context, d *directory.Directory) (*tp
 	// Fresh Root.
 	logRoot, err := s.tlog.GetLatestSignedLogRoot(ctx,
 		&tpb.GetLatestSignedLogRootRequest{
-			LogId: d.LogID,
+			LogId: d.Log.TreeId,
 		})
 	if err != nil {
-		glog.Errorf("tlog.GetLatestSignedLogRoot(%v): %v", d.LogID, err)
+		glog.Errorf("tlog.GetLatestSignedLogRoot(%v): %v", d.Log.TreeId, err)
 		return nil, status.Errorf(codes.Internal, "Cannot fetch SignedLogRoot")
 	}
 	sth := logRoot.GetSignedLogRoot()
@@ -240,13 +240,13 @@ func (s *Server) latestLogRootProof(ctx context.Context, d *directory.Directory,
 	if firstTreeSize != 0 {
 		logConsistency, err = s.tlog.GetConsistencyProof(ctx,
 			&tpb.GetConsistencyProofRequest{
-				LogId:          d.LogID,
+				LogId:          d.Log.TreeId,
 				FirstTreeSize:  firstTreeSize,
 				SecondTreeSize: secondTreeSize,
 			})
 		if err != nil {
 			glog.Errorf("latestLogRootProof(): log.GetConsistency(%v, %v, %v): %v",
-				d.LogID, firstTreeSize, secondTreeSize, err)
+				d.Log.TreeId, firstTreeSize, secondTreeSize, err)
 			return nil, nil, status.Errorf(codes.Internal, "Cannot fetch log consistency proof")
 		}
 	}
@@ -270,7 +270,7 @@ func mapRevisionFor(sth *tpb.SignedLogRoot) (int64, error) {
 func (s *Server) inclusionProofs(ctx context.Context, d *directory.Directory, indexes [][]byte, revision int64) (
 	[]*tpb.MapLeafInclusion, error) {
 	getResp, err := s.tmap.GetLeavesByRevision(ctx, &tpb.GetMapLeavesByRevisionRequest{
-		MapId:    d.MapID,
+		MapId:    d.Map.TreeId,
 		Index:    indexes,
 		Revision: revision,
 	})

--- a/core/keyserver/revisions.go
+++ b/core/keyserver/revisions.go
@@ -53,7 +53,7 @@ func (s *Server) GetLatestRevision(ctx context.Context, in *pb.GetLatestRevision
 
 	currentRevision, err := mapRevisionFor(sth)
 	if err != nil {
-		glog.Errorf("mapRevisionFor(log %v, sth%v): %v", d.LogID, sth, err)
+		glog.Errorf("mapRevisionFor(log %v, sth%v): %v", d.Log.TreeId, sth, err)
 		return nil, err
 	}
 

--- a/core/sequencer/trillian_client.go
+++ b/core/sequencer/trillian_client.go
@@ -65,12 +65,8 @@ func (t *Trillian) MapClient(ctx context.Context, dirID string) (trillianMap, er
 		glog.Errorf("directories.Read(%v): %v", dirID, err)
 		return nil, status.Errorf(codes.Internal, "Cannot fetch directory info for %v", dirID)
 	}
-	mapTree, err := t.mapAdmin.GetTree(ctx, &tpb.GetTreeRequest{TreeId: directory.MapID})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Cannot fetch map info for %v: %v", dirID, err)
-	}
 
-	c, err := tclient.NewMapClientFromTree(t.tmap, mapTree)
+	c, err := tclient.NewMapClientFromTree(t.tmap, directory.Map)
 	if err != nil {
 		return nil, err
 	}
@@ -84,14 +80,10 @@ func (t *Trillian) LogClient(ctx context.Context, dirID string) (trillianLog, er
 		glog.Errorf("directories.Read(%v): %v", dirID, err)
 		return nil, status.Errorf(codes.Internal, "Cannot fetch directory info for %v", dirID)
 	}
-	logTree, err := t.logAdmin.GetTree(ctx, &tpb.GetTreeRequest{TreeId: directory.LogID})
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Cannot fetch log info for %v: %v", dirID, err)
-	}
 
 	// Create verifying log client.
 	trustedRoot := types.LogRootV1{} // TODO(gbelvin): Store and track trustedRoot.
-	return tclient.NewFromTree(t.tlog, logTree, trustedRoot)
+	return tclient.NewFromTree(t.tlog, directory.Log, trustedRoot)
 }
 
 // MapClient interacts with the Trillian Map and verifies its responses.

--- a/impl/sql/directory/storage.go
+++ b/impl/sql/directory/storage.go
@@ -34,8 +34,8 @@ const (
 	createSQL = `
 CREATE TABLE IF NOT EXISTS Directories(
   DirectoryId           VARCHAR(40) NOT NULL,
-  MapId                 BIGINT NOT NULL,
-  LogId                 BIGINT NOT NULL,
+  Map                   BLOB NOT NULL,
+  Log                   BLOB NOT NULL,
   VRFPublicKey          MEDIUMBLOB NOT NULL,
   VRFPrivateKey         MEDIUMBLOB NOT NULL,
   MinInterval           BIGINT NOT NULL,
@@ -45,19 +45,19 @@ CREATE TABLE IF NOT EXISTS Directories(
   PRIMARY KEY(DirectoryId)
 );`
 	writeSQL = `INSERT INTO Directories
-(DirectoryId, MapId, LogId, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted, DeleteTimeSeconds)
+(DirectoryId, Map, Log, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted, DeleteTimeSeconds)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);`
 	readSQL = `
-SELECT DirectoryId, MapId, LogId, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted, DeleteTimeSeconds
+SELECT DirectoryId, Map, Log, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted, DeleteTimeSeconds
 FROM Directories WHERE DirectoryId = ? AND Deleted = 0;`
 	readDeletedSQL = `
-SELECT DirectoryId, MapId, LogId, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted, DeleteTimeSeconds
+SELECT DirectoryId, Map, Log, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted, DeleteTimeSeconds
 FROM Directories WHERE DirectoryId = ?;`
 	listSQL = `
-SELECT DirectoryId, MapId, LogId, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted
+SELECT DirectoryId, Map, Log, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted
 FROM Directories WHERE Deleted = 0;`
 	listDeletedSQL = `
-SELECT DirectoryId, MapId, LogId, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted
+SELECT DirectoryId, Map, Log, VRFPublicKey, VRFPrivateKey, MinInterval, MaxInterval, Deleted
 FROM Directories;`
 	setDeletedSQL = `UPDATE Directories SET Deleted = ?, DeleteTimeSeconds = ? WHERE DirectoryId = ?`
 	deleteSQL     = `DELETE FROM Directories WHERE DirectoryId = ?`
@@ -112,7 +112,7 @@ func (s *storage) List(ctx context.Context, showDeleted bool) ([]*directory.Dire
 		d := &directory.Directory{}
 		if err := rows.Scan(
 			&d.DirectoryID,
-			&d.MapID, &d.LogID,
+			&d.Map, &d.Log,
 			&pubkey, &anyData,
 			&d.MinInterval, &d.MaxInterval,
 			&d.Deleted); err != nil {
@@ -147,7 +147,7 @@ func (s *storage) Write(ctx context.Context, d *directory.Directory) error {
 	defer writeStmt.Close()
 	_, err = writeStmt.ExecContext(ctx,
 		d.DirectoryID,
-		d.MapID, d.LogID,
+		d.Map, d.Log,
 		d.VRF.Der, anyData,
 		d.MinInterval.Nanoseconds(), d.MaxInterval.Nanoseconds(),
 		false,

--- a/impl/sql/directory/storage.go
+++ b/impl/sql/directory/storage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/keytransparency/core/directory"
+	"github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -105,14 +106,15 @@ func (s *storage) List(ctx context.Context, showDeleted bool) ([]*directory.Dire
 		return nil, err
 	}
 	defer rows.Close()
-
 	ret := []*directory.Directory{}
 	for rows.Next() {
-		var pubkey, anyData []byte
+		var pubkey, anyData, mapByte, logByte []byte
+		var logTree trillian.Tree
+		var mapTree trillian.Tree
 		d := &directory.Directory{}
 		if err := rows.Scan(
 			&d.DirectoryID,
-			&d.Map, &d.Log,
+			&mapByte, &logByte,
 			&pubkey, &anyData,
 			&d.MinInterval, &d.MaxInterval,
 			&d.Deleted); err != nil {
@@ -124,6 +126,16 @@ func (s *storage) List(ctx context.Context, showDeleted bool) ([]*directory.Dire
 		if err != nil {
 			return nil, err
 		}
+		err = proto.Unmarshal(logByte, &logTree)
+		if err != nil {
+			return nil, err
+		}
+		err = proto.Unmarshal(mapByte, &mapTree)
+		if err != nil {
+			return nil, err
+		}
+		d.Map = &mapTree
+		d.Log = &logTree
 		ret = append(ret, d)
 	}
 	return ret, nil
@@ -139,6 +151,14 @@ func (s *storage) Write(ctx context.Context, d *directory.Directory) error {
 	if err != nil {
 		return err
 	}
+	mapTree, err := proto.Marshal(d.Map)
+	if err != nil {
+		return err
+	}
+	logTree, err := proto.Marshal(d.Map)
+	if err != nil {
+		return err
+	}
 	// Prepare SQL.
 	writeStmt, err := s.db.PrepareContext(ctx, writeSQL)
 	if err != nil {
@@ -147,7 +167,7 @@ func (s *storage) Write(ctx context.Context, d *directory.Directory) error {
 	defer writeStmt.Close()
 	_, err = writeStmt.ExecContext(ctx,
 		d.DirectoryID,
-		d.Map, d.Log,
+		mapTree, logTree,
 		d.VRF.Der, anyData,
 		d.MinInterval.Nanoseconds(), d.MaxInterval.Nanoseconds(),
 		false,
@@ -172,9 +192,14 @@ func (s *storage) Read(ctx context.Context, directoryID string, showDeleted bool
 	d := &directory.Directory{}
 	var pubkey, anyData []byte
 	var deletedUnix int64
+	var mapByte []byte
+	var logByte []byte
+	var logTree trillian.Tree
+	var mapTree trillian.Tree
+
 	if err := readStmt.QueryRowContext(ctx, directoryID).Scan(
 		&d.DirectoryID,
-		&d.MapID, &d.LogID,
+		&mapByte, &logByte,
 		&pubkey, &anyData,
 		&d.MinInterval, &d.MaxInterval,
 		&d.Deleted,
@@ -184,7 +209,6 @@ func (s *storage) Read(ctx context.Context, directoryID string, showDeleted bool
 	} else if err != nil {
 		return nil, err
 	}
-
 	// Unwrap protos.
 	d.VRF = &keyspb.PublicKey{Der: pubkey}
 	d.VRFPriv, err = unwrapAnyProto(anyData)
@@ -192,6 +216,17 @@ func (s *storage) Read(ctx context.Context, directoryID string, showDeleted bool
 	if err != nil {
 		return nil, err
 	}
+	err = proto.Unmarshal(logByte, &logTree)
+	if err != nil {
+		return nil, err
+	}
+	err = proto.Unmarshal(mapByte, &mapTree)
+	if err != nil {
+		return nil, err
+	}
+	d.Map = &mapTree
+	d.Log = &logTree
+
 	return d, nil
 }
 

--- a/impl/sql/directory/storage.go
+++ b/impl/sql/directory/storage.go
@@ -25,7 +25,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/google/keytransparency/core/directory"
-	"github.com/google/trillian"
+	tpb "github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -109,8 +109,8 @@ func (s *storage) List(ctx context.Context, showDeleted bool) ([]*directory.Dire
 	ret := []*directory.Directory{}
 	for rows.Next() {
 		var pubkey, anyData, mapByte, logByte []byte
-		var logTree trillian.Tree
-		var mapTree trillian.Tree
+		var logTree tpb.Tree
+		var mapTree tpb.Tree
 		d := &directory.Directory{}
 		if err := rows.Scan(
 			&d.DirectoryID,
@@ -155,7 +155,7 @@ func (s *storage) Write(ctx context.Context, d *directory.Directory) error {
 	if err != nil {
 		return err
 	}
-	logTree, err := proto.Marshal(d.Map)
+	logTree, err := proto.Marshal(d.Log)
 	if err != nil {
 		return err
 	}
@@ -194,8 +194,8 @@ func (s *storage) Read(ctx context.Context, directoryID string, showDeleted bool
 	var deletedUnix int64
 	var mapByte []byte
 	var logByte []byte
-	var logTree trillian.Tree
-	var mapTree trillian.Tree
+	var logTree tpb.Tree
+	var mapTree tpb.Tree
 
 	if err := readStmt.QueryRowContext(ctx, directoryID).Scan(
 		&d.DirectoryID,

--- a/impl/sql/directory/storage_test.go
+++ b/impl/sql/directory/storage_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/core/directory"
-	"github.com/google/trillian"
+	tpb "github.com/google/trillian"
 	"github.com/google/trillian/crypto/keyspb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -58,10 +58,10 @@ func TestList(t *testing.T) {
 			directories: []*directory.Directory{
 				{
 					DirectoryID: "directory1",
-					Map: &trillian.Tree{
+					Map: &tpb.Tree{
 						TreeId: 1,
 					},
-					Log: &trillian.Tree{
+					Log: &tpb.Tree{
 						TreeId: 2,
 					},
 					VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -71,10 +71,10 @@ func TestList(t *testing.T) {
 				},
 				{
 					DirectoryID: "directory2",
-					Map: &trillian.Tree{
+					Map: &tpb.Tree{
 						TreeId: 1,
 					},
-					Log: &trillian.Tree{
+					Log: &tpb.Tree{
 						TreeId: 2,
 					},
 					VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -121,10 +121,10 @@ func TestWriteReadDelete(t *testing.T) {
 			write: true,
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				Map: &trillian.Tree{
+				Map: &tpb.Tree{
 					TreeId: 1,
 				},
-				Log: &trillian.Tree{
+				Log: &tpb.Tree{
 					TreeId: 2,
 				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -138,10 +138,10 @@ func TestWriteReadDelete(t *testing.T) {
 			write: true,
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				Map: &trillian.Tree{
+				Map: &tpb.Tree{
 					TreeId: 1,
 				},
-				Log: &trillian.Tree{
+				Log: &tpb.Tree{
 					TreeId: 2,
 				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -155,10 +155,10 @@ func TestWriteReadDelete(t *testing.T) {
 			desc: "Delete",
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				Map: &trillian.Tree{
+				Map: &tpb.Tree{
 					TreeId: 1,
 				},
-				Log: &trillian.Tree{
+				Log: &tpb.Tree{
 					TreeId: 2,
 				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -175,10 +175,10 @@ func TestWriteReadDelete(t *testing.T) {
 			desc: "Read deleted",
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				Map: &trillian.Tree{
+				Map: &tpb.Tree{
 					TreeId: 1,
 				},
-				Log: &trillian.Tree{
+				Log: &tpb.Tree{
 					TreeId: 2,
 				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -195,10 +195,10 @@ func TestWriteReadDelete(t *testing.T) {
 			desc: "Undelete",
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				Map: &trillian.Tree{
+				Map: &tpb.Tree{
 					TreeId: 1,
 				},
-				Log: &trillian.Tree{
+				Log: &tpb.Tree{
 					TreeId: 2,
 				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
@@ -257,6 +257,12 @@ func TestDelete(t *testing.T) {
 		{directoryID: "test"},
 	} {
 		d := &directory.Directory{
+			Map: &tpb.Tree{
+				TreeId: 1,
+			},
+			Log: &tpb.Tree{
+				TreeId: 2,
+			},
 			DirectoryID: tc.directoryID,
 			VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 			VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},

--- a/impl/sql/directory/storage_test.go
+++ b/impl/sql/directory/storage_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/core/directory"
+	"github.com/google/trillian"
+	"github.com/google/trillian/crypto/keyspb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/google/trillian/crypto/keyspb"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -58,8 +58,12 @@ func TestList(t *testing.T) {
 			directories: []*directory.Directory{
 				{
 					DirectoryID: "directory1",
-					MapID:       1,
-					LogID:       2,
+					Map: &trillian.Tree{
+						TreeId: 1,
+					},
+					Log: &trillian.Tree{
+						TreeId: 2,
+					},
 					VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 					VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},
 					MinInterval: 1 * time.Second,
@@ -67,8 +71,12 @@ func TestList(t *testing.T) {
 				},
 				{
 					DirectoryID: "directory2",
-					MapID:       1,
-					LogID:       2,
+					Map: &trillian.Tree{
+						TreeId: 1,
+					},
+					Log: &trillian.Tree{
+						TreeId: 2,
+					},
 					VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 					VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},
 					MinInterval: 5 * time.Hour,
@@ -113,8 +121,12 @@ func TestWriteReadDelete(t *testing.T) {
 			write: true,
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				MapID:       1,
-				LogID:       2,
+				Map: &trillian.Tree{
+					TreeId: 1,
+				},
+				Log: &trillian.Tree{
+					TreeId: 2,
+				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 				VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},
 				MinInterval: 1 * time.Second,
@@ -126,8 +138,12 @@ func TestWriteReadDelete(t *testing.T) {
 			write: true,
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				MapID:       1,
-				LogID:       2,
+				Map: &trillian.Tree{
+					TreeId: 1,
+				},
+				Log: &trillian.Tree{
+					TreeId: 2,
+				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 				VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},
 				MinInterval: 1 * time.Second,
@@ -139,8 +155,12 @@ func TestWriteReadDelete(t *testing.T) {
 			desc: "Delete",
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				MapID:       1,
-				LogID:       2,
+				Map: &trillian.Tree{
+					TreeId: 1,
+				},
+				Log: &trillian.Tree{
+					TreeId: 2,
+				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 				VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},
 				MinInterval: 1 * time.Second,
@@ -155,8 +175,12 @@ func TestWriteReadDelete(t *testing.T) {
 			desc: "Read deleted",
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				MapID:       1,
-				LogID:       2,
+				Map: &trillian.Tree{
+					TreeId: 1,
+				},
+				Log: &trillian.Tree{
+					TreeId: 2,
+				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 				VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},
 				MinInterval: 1 * time.Second,
@@ -171,8 +195,12 @@ func TestWriteReadDelete(t *testing.T) {
 			desc: "Undelete",
 			d: directory.Directory{
 				DirectoryID: "testdirectory",
-				MapID:       1,
-				LogID:       2,
+				Map: &trillian.Tree{
+					TreeId: 1,
+				},
+				Log: &trillian.Tree{
+					TreeId: 2,
+				},
 				VRF:         &keyspb.PublicKey{Der: []byte("pubkeybytes")},
 				VRFPriv:     &keyspb.PrivateKey{Der: []byte("privkeybytes")},
 				MinInterval: 1 * time.Second,


### PR DESCRIPTION
* Romeved from directory table:
MapId, LogId fields
* Added to directory table:
Map, Log fields with type BLOB
* Removed fecth request to TrillianTree

Fixes: https://github.com/google/keytransparency/issues/1152