### PR TITLE
Remove deleted status from map and log trees

### DIFF
--- a/core/adminserver/admin_server.go
+++ b/core/adminserver/admin_server.go
@@ -157,7 +157,6 @@ func trimTree(t *tpb.Tree) *tpb.Tree {
 		HashStrategy:       t.HashStrategy,
 		HashAlgorithm:      t.HashAlgorithm,
 		SignatureAlgorithm: t.SignatureAlgorithm,
-		Deleted:            t.Deleted,
 	}
 }
 

--- a/core/adminserver/admin_server_test.go
+++ b/core/adminserver/admin_server_test.go
@@ -245,17 +245,6 @@ func TestDelete(t *testing.T) {
 		if _, err := svr.DeleteDirectory(ctx, &pb.DeleteDirectoryRequest{DirectoryId: tc.directoryID}); err != nil {
 			t.Fatalf("DeleteDirectory(): %v", err)
 		}
-		directory, err := svr.GetDirectory(ctx, &pb.GetDirectoryRequest{DirectoryId: tc.directoryID, ShowDeleted: true})
-		if err != nil {
-			t.Fatalf("GetDirectory(): %v", err)
-		}
-		// The tree stored in DB is not updated, that's why we get here false
-		if got, want := directory.Log.Deleted, false; got != want {
-			t.Errorf("Log.Deleted: %v, want %v", got, want)
-		}
-		if got, want := directory.Map.Deleted, false; got != want {
-			t.Errorf("Map.Deleted: %v, want %v", got, want)
-		}
 		if _, err := svr.GarbageCollect(ctx, &pb.GarbageCollectRequest{
 			Before: ptypes.TimestampNow(),
 		}); err != nil {


### PR DESCRIPTION
Removed unused field `deleted` from Trillian tree struct we store in our DB.
Removed part of the tests related to this field.