### PR TITLE
Create an encrypted tink reader

### DIFF
--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -22,7 +22,9 @@ import (
 	"time"
 
 	"github.com/google/keytransparency/core/client/hammer"
+	"github.com/google/keytransparency/core/crypto/tinkreader"
 	"github.com/google/keytransparency/impl/authentication"
+	"github.com/google/tink/go/insecure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -61,7 +63,10 @@ var hammerCmd = &cobra.Command{
 	Long:  `Sends update requests for user_1 through user_n using a select number of workers in parallel.`,
 
 	PreRun: func(cmd *cobra.Command, args []string) {
-		handle, err := readKeysetFile(keysetFile, masterPassword)
+		handle, err := insecure.KeysetHandle(&tinkreader.EncryptedKeysetReader{
+			File:     keysetFile,
+			Password: masterPassword,
+		})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/keytransparency-client/cmd/keys.go
+++ b/cmd/keytransparency-client/cmd/keys.go
@@ -15,37 +15,26 @@
 package cmd
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"text/tabwriter"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/tink/go/insecure"
 	"github.com/google/tink/go/signature"
-	"github.com/google/tink/go/subtle/aead"
 	"github.com/google/tink/go/tink"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/pbkdf2"
+
+	"github.com/google/keytransparency/core/crypto/tinkreader"
 
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
-const (
-	keysetFile          = ".keyset"
-	masterKeyLen        = 32
-	masterKeyIterations = 4096
-)
+const keysetFile = ".keyset"
 
 var (
-	// openssl rand -hex 32
-	salt, _           = hex.DecodeString("00afc05d5b131a1dfd140a146b87f2f07826a8d4576cb4feef43f80f0c9b1c2f")
-	masterKeyHashFunc = sha256.New
-	keyType           string
-	masterPassword    string
+	keyType        string
+	masterPassword string
 )
 
 var keyset *tink.KeysetHandle
@@ -77,7 +66,10 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		return writeKeysetFile(keyset, keysetFile, masterPassword)
+		return (&tinkreader.EncryptedKeysetWriter{
+			File:     keysetFile,
+			Password: masterPassword,
+		}).Write(keyset.Keyset())
 	},
 }
 
@@ -105,7 +97,10 @@ var listCmd = &cobra.Command{
 The actual keys are not listed, only their corresponding metadata.
 `,
 	PreRun: func(cmd *cobra.Command, args []string) {
-		handle, err := readKeysetFile(keysetFile, masterPassword)
+		handle, err := insecure.KeysetHandle(&tinkreader.EncryptedKeysetReader{
+			File:     keysetFile,
+			Password: masterPassword,
+		})
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -134,88 +129,6 @@ The actual keys are not listed, only their corresponding metadata.
 		}
 		return nil
 	},
-}
-
-// masterPBKDF converts the master password into the master key.
-func masterPBKDF(masterPassword string) (tink.AEAD, error) {
-	if masterPassword == "" {
-		return nil, fmt.Errorf("please provide a master password")
-	}
-	dk := pbkdf2.Key([]byte(masterPassword), salt,
-		masterKeyIterations, masterKeyLen, masterKeyHashFunc)
-	return aead.NewAESGCM(dk)
-}
-
-func encryptKeyset(keyset *tinkpb.Keyset, masterKey tink.AEAD) (*tinkpb.EncryptedKeyset, error) {
-	serializedKeyset, err := proto.Marshal(keyset)
-	if err != nil {
-		return nil, fmt.Errorf("invalid keyset")
-	}
-	encrypted, err := masterKey.Encrypt(serializedKeyset, []byte{})
-	if err != nil {
-		return nil, fmt.Errorf("encrypted failed: %s", err)
-	}
-	// get keyset info
-	info, err := tink.GetKeysetInfo(keyset)
-	if err != nil {
-		return nil, fmt.Errorf("cannot get keyset info: %s", err)
-	}
-	encryptedKeyset := &tinkpb.EncryptedKeyset{
-		EncryptedKeyset: encrypted,
-		KeysetInfo:      info,
-	}
-	return encryptedKeyset, nil
-}
-
-func readKeysetFile(file, password string) (*tink.KeysetHandle, error) {
-	masterKey, err := masterPBKDF(password)
-	if err != nil {
-		return nil, err
-	}
-	data, err := ioutil.ReadFile(file)
-	if err != nil {
-		return nil, fmt.Errorf("reading keystore file %q failed: %v", file, err)
-	}
-
-	encryptedKeyset := new(tinkpb.EncryptedKeyset)
-	if err := proto.Unmarshal(data, encryptedKeyset); err != nil {
-		return nil, fmt.Errorf("could not parse encrypted keyset: %v", err)
-	}
-
-	keyset, err := decryptKeyset(encryptedKeyset, masterKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return insecure.KeysetHandle(keyset)
-}
-
-func decryptKeyset(encryptedKeyset *tinkpb.EncryptedKeyset, masterKey tink.AEAD) (*tinkpb.Keyset, error) {
-	decrypted, err := masterKey.Decrypt(encryptedKeyset.EncryptedKeyset, []byte{})
-	if err != nil {
-		return nil, fmt.Errorf("decryption failed: %s", err)
-	}
-	keyset := new(tinkpb.Keyset)
-	if err := proto.Unmarshal(decrypted, keyset); err != nil {
-		return nil, fmt.Errorf("invalid encrypted keyset")
-	}
-	return keyset, nil
-}
-
-func writeKeysetFile(keyset *tink.KeysetHandle, file, password string) error {
-	masterKey, err := masterPBKDF(password)
-	if err != nil {
-		return err
-	}
-	encryptedKeyset, err := encryptKeyset(keyset.Keyset(), masterKey)
-	if err != nil {
-		return err
-	}
-	serialized, err := proto.Marshal(encryptedKeyset)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(file, serialized, 0600)
 }
 
 func init() {

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -25,6 +25,8 @@ import (
 	"google.golang.org/grpc"
 
 	tpb "github.com/google/keytransparency/core/api/type/type_go_proto"
+	"github.com/google/keytransparency/core/crypto/tinkreader"
+	"github.com/google/tink/go/insecure"
 	"github.com/google/tink/go/signature"
 	"github.com/google/tink/go/tink"
 )
@@ -46,7 +48,10 @@ User email MUST match the OAuth account used to authorize the update.
 `,
 
 	PreRun: func(cmd *cobra.Command, args []string) {
-		handle, err := readKeysetFile(keysetFile, masterPassword)
+		handle, err := insecure.KeysetHandle(&tinkreader.EncryptedKeysetReader{
+			File:     keysetFile,
+			Password: masterPassword,
+		})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/core/crypto/tinkreader/encreader.go
+++ b/core/crypto/tinkreader/encreader.go
@@ -1,0 +1,81 @@
+package tinkreader
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/tink/go/subtle/aead"
+	"github.com/google/tink/go/tink"
+	"golang.org/x/crypto/pbkdf2"
+
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+)
+
+const (
+	masterKeyLen        = 32
+	masterKeyIterations = 4096
+)
+
+var (
+	// openssl rand -hex 32
+	salt, _           = hex.DecodeString("00afc05d5b131a1dfd140a146b87f2f07826a8d4576cb4feef43f80f0c9b1c2f")
+	masterKeyHashFunc = sha256.New
+)
+
+// EncryptedKeysetReader reads encrypted keysets from disk.
+// EncryptedKeysetReader implements tink.KeysetReader.
+type EncryptedKeysetReader struct {
+	File, Password string
+}
+
+// Read returns a (cleartext) Keyset object from the underlying source.
+func (r *EncryptedKeysetReader) Read() (*tinkpb.Keyset, error) {
+	encryptedKeyset, err := r.ReadEncrypted()
+	if err != nil {
+		return nil, err
+	}
+	masterKey, err := masterPBKDF(r.Password)
+	if err != nil {
+		return nil, err
+	}
+	return decryptKeyset(encryptedKeyset, masterKey)
+}
+
+// ReadEncrypted returns an EncryptedKeyset object from the underlying source.
+func (r *EncryptedKeysetReader) ReadEncrypted() (*tinkpb.EncryptedKeyset, error) {
+	data, err := ioutil.ReadFile(r.File)
+	if err != nil {
+		return nil, fmt.Errorf("reading keystore file %q failed: %v", r.File, err)
+	}
+
+	encryptedKeyset := new(tinkpb.EncryptedKeyset)
+	if err := proto.Unmarshal(data, encryptedKeyset); err != nil {
+		return nil, fmt.Errorf("could not parse encrypted keyset: %v", err)
+	}
+	return encryptedKeyset, nil
+}
+
+func decryptKeyset(encryptedKeyset *tinkpb.EncryptedKeyset, masterKey tink.AEAD) (*tinkpb.Keyset, error) {
+	decrypted, err := masterKey.Decrypt(encryptedKeyset.EncryptedKeyset, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("decryption failed: %s", err)
+	}
+	keyset := new(tinkpb.Keyset)
+	if err := proto.Unmarshal(decrypted, keyset); err != nil {
+		return nil, fmt.Errorf("invalid encrypted keyset")
+	}
+	return keyset, nil
+}
+
+// masterPBKDF converts the master password into the master key.
+func masterPBKDF(masterPassword string) (tink.AEAD, error) {
+	if masterPassword == "" {
+		return nil, fmt.Errorf("please provide a master password")
+	}
+	dk := pbkdf2.Key([]byte(masterPassword), salt,
+		masterKeyIterations, masterKeyLen, masterKeyHashFunc)
+	return aead.NewAESGCM(dk)
+}

--- a/core/crypto/tinkreader/encwritier.go
+++ b/core/crypto/tinkreader/encwritier.go
@@ -1,0 +1,67 @@
+package tinkreader
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/tink/go/tink"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+)
+
+// KeysetWriter knows how to write a Keyset or an EncryptedKeyset to some source.
+type KeysetWriter interface {
+	// Write keyset to some storage system.
+	Write(Keyset *tinkpb.Keyset) error
+
+	// Write EncryptedKeyset to some storage system.
+	WriteEncrypted(keyset *tinkpb.EncryptedKeyset) error
+}
+
+// EncryptedKeysetWriter writes encrypted keysets to disk.
+type EncryptedKeysetWriter struct {
+	File, Password string
+}
+
+// Write encrypts and writes the keyset to disk.
+func (w *EncryptedKeysetWriter) Write(keyset *tinkpb.Keyset) error {
+	masterKey, err := masterPBKDF(w.Password)
+	if err != nil {
+		return err
+	}
+	encryptedKeyset, err := encryptKeyset(keyset, masterKey)
+	if err != nil {
+		return err
+	}
+	return w.WriteEncrypted(encryptedKeyset)
+}
+
+// WriteEncrypted writes the keyset to disk.
+func (w *EncryptedKeysetWriter) WriteEncrypted(keyset *tinkpb.EncryptedKeyset) error {
+	serialized, err := proto.Marshal(keyset)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(w.File, serialized, 0600)
+}
+
+func encryptKeyset(keyset *tinkpb.Keyset, masterKey tink.AEAD) (*tinkpb.EncryptedKeyset, error) {
+	serializedKeyset, err := proto.Marshal(keyset)
+	if err != nil {
+		return nil, fmt.Errorf("invalid keyset")
+	}
+	encrypted, err := masterKey.Encrypt(serializedKeyset, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("encrypted failed: %s", err)
+	}
+	// get keyset info
+	info, err := tink.GetKeysetInfo(keyset)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get keyset info: %s", err)
+	}
+	encryptedKeyset := &tinkpb.EncryptedKeyset{
+		EncryptedKeyset: encrypted,
+		KeysetInfo:      info,
+	}
+	return encryptedKeyset, nil
+}


### PR DESCRIPTION
Tink has a new `tink.KeysetReader` interface in google/tink#4e4d11e 

This PR refactors the keyset reader and writer implementations into their own package in a format that implements the new interface. 