### PR TITLE
PEM tink.KeysetReader

### DIFF
--- a/core/crypto/tinkio/pem.go
+++ b/core/crypto/tinkio/pem.go
@@ -1,0 +1,155 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tinkio
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"errors"
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/tink/go/signature"
+	"github.com/google/tink/go/tink"
+	"github.com/google/trillian/crypto/keys/pem"
+
+	commonpb "github.com/google/tink/proto/common_go_proto"
+	ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
+	tinkpb "github.com/google/tink/proto/tink_go_proto"
+)
+
+const (
+	outputPrefix = tinkpb.OutputPrefixType_RAW
+	hashType     = commonpb.HashType_SHA256
+)
+
+// PEMKeyset converts a set of PEMs into a tink.Keyset.
+// Implements tink.KeysetReader.
+type PEMKeyset struct {
+	PEMs     []string
+	Password string
+}
+
+// Read returns a (cleartext) Keyset object from a set of PEMs.
+func (p *PEMKeyset) Read() (*tinkpb.Keyset, error) {
+	keysetKeys := make([]*tinkpb.Keyset_Key, 0, len(p.PEMs))
+	var primaryKeyID uint32
+	for i, pem := range p.PEMs {
+		if pem == "" {
+			continue // Skip this keyID.
+		}
+		keyData, err := keyDataFromPEM(pem, p.Password)
+		if err != nil {
+			return nil, err
+		}
+		keyID := uint32(i + 1)
+		primaryKeyID = keyID
+		keysetKeys = append(keysetKeys,
+			tink.CreateKey(keyData, tinkpb.KeyStatusType_ENABLED, keyID, outputPrefix))
+	}
+	keyset := tink.CreateKeyset(primaryKeyID, keysetKeys)
+	if err := tink.ValidateKeyset(keyset); err != nil {
+		return nil, fmt.Errorf("tink.ValidateKeyset(): %v", err)
+	}
+	return keyset, nil
+}
+
+// ReadEncrypted returns an EncryptedKeyset object from disk.
+func (p *PEMKeyset) ReadEncrypted() (*tinkpb.EncryptedKeyset, error) {
+	return nil, errors.New("tinkio: Unimplemented")
+}
+
+// keyDataFromPEM returns tinkpb.KeyData for both public and private key PEMs.
+// Only ecdsa keys, however, are supported by Tink.
+func keyDataFromPEM(pem, password string) (*tinkpb.KeyData, error) {
+	key, err := unmarshalPEM(pem, password)
+	if err != nil {
+		return nil, err
+	}
+
+	switch t := key.(type) {
+	case *ecdsa.PrivateKey:
+		return privKeyData(t)
+	case *ecdsa.PublicKey:
+		return pubKeyData(t)
+	default:
+		return nil, fmt.Errorf("unknown key type: %T", key)
+	}
+}
+
+// unmarshalPEM returns a go native public or private key.
+func unmarshalPEM(pemData, password string) (interface{}, error) {
+	signer, err := pem.UnmarshalPrivateKey(pemData, password)
+	if err == nil {
+		return signer, nil
+	}
+	pubKey, err := pem.UnmarshalPublicKey(pemData)
+	if err == nil {
+		return pubKey, nil
+	}
+	return nil, err
+}
+
+// privKeyData produces tinkpb.KeyData from a private key.
+func privKeyData(priv *ecdsa.PrivateKey) (*tinkpb.KeyData, error) {
+	privKey := signature.NewECDSAPrivateKey(
+		signature.ECDSASignerKeyVersion,
+		ecdsaPubKeyPB(&priv.PublicKey),
+		priv.D.Bytes())
+	serializedKey, err := proto.Marshal(privKey)
+	if err != nil {
+		return nil, fmt.Errorf("proto.Marshal(): %v", err)
+	}
+	return tink.CreateKeyData(signature.ECDSASignerTypeURL,
+		serializedKey,
+		tinkpb.KeyData_ASYMMETRIC_PRIVATE), nil
+}
+
+// pubKeyData produces tinkpb.KeyData from a public key.
+func pubKeyData(pub *ecdsa.PublicKey) (*tinkpb.KeyData, error) {
+	serializedKey, err := proto.Marshal(ecdsaPubKeyPB(pub))
+	if err != nil {
+		return nil, fmt.Errorf("proto.Marshal(): %v", err)
+	}
+	return tink.CreateKeyData(signature.ECDSAVerifierTypeURL,
+		serializedKey,
+		tinkpb.KeyData_ASYMMETRIC_PUBLIC), nil
+}
+
+// ecdsaPubKeyPB returns a tink ecdsapb.EcdsaPublicKey
+func ecdsaPubKeyPB(pub *ecdsa.PublicKey) *ecdsapb.EcdsaPublicKey {
+	return signature.NewECDSAPublicKey(
+		signature.ECDSAVerifierKeyVersion,
+		signature.NewECDSAParams(
+			hashType,
+			tinkCurve(pub.Curve),
+			ecdsapb.EcdsaSignatureEncoding_DER),
+		pub.X.Bytes(),
+		pub.Y.Bytes())
+}
+
+// tinkCurve maps between elliptic.Curve and commonpb.EllipticCurveType.
+func tinkCurve(curve elliptic.Curve) commonpb.EllipticCurveType {
+	switch curve {
+	case elliptic.P256():
+		return commonpb.EllipticCurveType_NIST_P256
+	case elliptic.P384():
+		return commonpb.EllipticCurveType_NIST_P384
+	case elliptic.P521():
+		return commonpb.EllipticCurveType_NIST_P521
+	default:
+		return commonpb.EllipticCurveType_UNKNOWN_CURVE
+	}
+}

--- a/core/crypto/tinkio/pem.go
+++ b/core/crypto/tinkio/pem.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/tink/go/signature"
+	"github.com/google/tink/go/testutil"
 	"github.com/google/tink/go/tink"
 	"github.com/google/trillian/crypto/keys/pem"
 
@@ -104,7 +105,7 @@ func unmarshalPEM(pemData, password string) (interface{}, error) {
 
 // privKeyData produces tinkpb.KeyData from a private key.
 func privKeyData(priv *ecdsa.PrivateKey) (*tinkpb.KeyData, error) {
-	privKey := signature.NewECDSAPrivateKey(
+	privKey := testutil.NewECDSAPrivateKey(
 		signature.ECDSASignerKeyVersion,
 		ecdsaPubKeyPB(&priv.PublicKey),
 		priv.D.Bytes())
@@ -130,9 +131,9 @@ func pubKeyData(pub *ecdsa.PublicKey) (*tinkpb.KeyData, error) {
 
 // ecdsaPubKeyPB returns a tink ecdsapb.EcdsaPublicKey
 func ecdsaPubKeyPB(pub *ecdsa.PublicKey) *ecdsapb.EcdsaPublicKey {
-	return signature.NewECDSAPublicKey(
+	return testutil.NewECDSAPublicKey(
 		signature.ECDSAVerifierKeyVersion,
-		signature.NewECDSAParams(
+		testutil.NewECDSAParams(
 			hashType,
 			tinkCurve(pub.Curve),
 			ecdsapb.EcdsaSignatureEncoding_DER),

--- a/core/crypto/tinkio/pem.go
+++ b/core/crypto/tinkio/pem.go
@@ -36,15 +36,15 @@ const (
 	hashType     = commonpb.HashType_SHA256
 )
 
-// PEMKeyset converts a set of PEMs into a tink.Keyset.
+// ECDSAPEMKeyset converts a set of PEMs into a tink.Keyset.
 // Implements tink.KeysetReader.
-type PEMKeyset struct {
+type ECDSAPEMKeyset struct {
 	PEMs     []string
 	Password string
 }
 
 // Read returns a (cleartext) Keyset object from a set of PEMs.
-func (p *PEMKeyset) Read() (*tinkpb.Keyset, error) {
+func (p *ECDSAPEMKeyset) Read() (*tinkpb.Keyset, error) {
 	keysetKeys := make([]*tinkpb.Keyset_Key, 0, len(p.PEMs))
 	var primaryKeyID uint32
 	for i, pem := range p.PEMs {
@@ -68,7 +68,7 @@ func (p *PEMKeyset) Read() (*tinkpb.Keyset, error) {
 }
 
 // ReadEncrypted returns an EncryptedKeyset object from disk.
-func (p *PEMKeyset) ReadEncrypted() (*tinkpb.EncryptedKeyset, error) {
+func (p *ECDSAPEMKeyset) ReadEncrypted() (*tinkpb.EncryptedKeyset, error) {
 	return nil, errors.New("tinkio: Unimplemented")
 }
 

--- a/core/testutil/tink.go
+++ b/core/testutil/tink.go
@@ -1,4 +1,4 @@
-// Copyright 2018 Google Inc. All Rights Reserved.
+// Copyright 2019 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,119 +16,35 @@
 package testutil
 
 import (
-	"crypto/ecdsa"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/google/keytransparency/core/crypto/tinkio"
+	"github.com/google/tink/go/insecure"
 	"github.com/google/tink/go/signature"
-	"github.com/google/tink/go/testkeysethandle"
 	"github.com/google/tink/go/tink"
-	"github.com/google/trillian/crypto/keys/pem"
-
-	commonpb "github.com/google/tink/proto/common_go_proto"
-	ecdsapb "github.com/google/tink/proto/ecdsa_go_proto"
-	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
-
-// PrivateKeyFromPEM produces a Keyset_Key from privatePEM.
-func PrivateKeyFromPEM(privPEM string, keyID uint32) *tinkpb.Keyset_Key {
-	signer, err := pem.UnmarshalPrivateKey(privPEM, "")
-	if err != nil {
-		panic(err)
-	}
-
-	priv, ok := signer.(*ecdsa.PrivateKey)
-	if !ok {
-		panic(fmt.Sprintf("not ecdsa private key: %T", signer))
-	}
-
-	params := signature.NewECDSAParams(
-		commonpb.HashType_SHA256,
-		commonpb.EllipticCurveType_NIST_P256,
-		ecdsapb.EcdsaSignatureEncoding_DER)
-
-	publicKey := signature.NewECDSAPublicKey(
-		signature.ECDSAVerifierKeyVersion,
-		params, priv.X.Bytes(), priv.Y.Bytes())
-	privKey := signature.NewECDSAPrivateKey(
-		signature.ECDSASignerKeyVersion,
-		publicKey, priv.D.Bytes())
-	serializedKey, err := proto.Marshal(privKey)
-	if err != nil {
-		panic(fmt.Sprintf("proto.Marshal(): %v", err))
-	}
-	keyData := tink.CreateKeyData(signature.ECDSASignerTypeURL,
-		serializedKey,
-		tinkpb.KeyData_ASYMMETRIC_PRIVATE)
-	return tink.CreateKey(keyData, tinkpb.KeyStatusType_ENABLED, keyID, tinkpb.OutputPrefixType_TINK)
-}
-
-// PublicKeyFromPEM produces a Keyset_Key from pubPEM.
-func PublicKeyFromPEM(pubPEM string, keyID uint32) *tinkpb.Keyset_Key {
-	pubKey, err := pem.UnmarshalPublicKey(pubPEM)
-	if err != nil {
-		panic(err)
-	}
-	pub, ok := pubKey.(*ecdsa.PublicKey)
-	if !ok {
-		panic(fmt.Sprintf("not ecdsa public key: %T", pubKey))
-	}
-
-	params := signature.NewECDSAParams(
-		commonpb.HashType_SHA256,
-		commonpb.EllipticCurveType_NIST_P256,
-		ecdsapb.EcdsaSignatureEncoding_DER)
-	publicKey := signature.NewECDSAPublicKey(
-		signature.ECDSAVerifierKeyVersion,
-		params, pub.X.Bytes(), pub.Y.Bytes())
-	serializedKey, err := proto.Marshal(publicKey)
-	if err != nil {
-		panic(fmt.Sprintf("proto.Marshal(): %v", err))
-	}
-	keyData := tink.CreateKeyData(signature.ECDSAVerifierTypeURL,
-		serializedKey,
-		tinkpb.KeyData_ASYMMETRIC_PUBLIC)
-	return tink.CreateKey(keyData, tinkpb.KeyStatusType_ENABLED, keyID, tinkpb.OutputPrefixType_TINK)
-}
 
 // VerifyKeysetFromPEMs produces a Keyset with pubPEMs.
 func VerifyKeysetFromPEMs(pubPEMs ...string) *tink.KeysetHandle {
-	var primaryKeyID uint32
-	keys := make([]*tinkpb.Keyset_Key, 0, len(pubPEMs))
-	for i, pem := range pubPEMs {
-		if pem == "" {
-			continue
-		}
-		keyID := uint32(i + 1)
-		keysetKey := PublicKeyFromPEM(pem, keyID)
-		keys = append(keys, keysetKey)
-		primaryKeyID = keyID
-	}
-	keyset := tink.CreateKeyset(primaryKeyID, keys)
-	parsedHandle, err := tink.KeysetHandleWithNoSecret(keyset)
+	handle, err := insecure.KeysetHandle(&tinkio.PEMKeyset{PEMs: pubPEMs})
 	if err != nil {
-		panic(fmt.Sprintf("tink.KeysetHandleWithNoSecret(): %v", err))
+		panic(fmt.Sprintf("insecure.KeysetHandle(): %v", err))
 	}
-	if err := tink.ValidateKeyset(keyset); err != nil {
-		panic(fmt.Sprintf("tink.ValidateKeyset(): %v", err))
-	}
-	return parsedHandle
+	return handle
 }
 
 // SignKeysetsFromPEMs produces a slice of keysets, each with one private key.
 func SignKeysetsFromPEMs(privPEMs ...string) []tink.Signer {
 	signers := make([]tink.Signer, 0, len(privPEMs))
-	for i, pem := range privPEMs {
+	for _, pem := range privPEMs {
 		if pem == "" {
 			continue
 		}
-		keysetKey := PrivateKeyFromPEM(pem, uint32(i+1))
-		keyset := tink.CreateKeyset(uint32(i+1), []*tinkpb.Keyset_Key{keysetKey})
-		parsedHandle, err := testkeysethandle.KeysetHandle(keyset)
+		handle, err := insecure.KeysetHandle(&tinkio.PEMKeyset{PEMs: []string{pem}})
 		if err != nil {
-			panic(fmt.Sprintf("testkeysethandle.KeysetHandle(): %v", err))
+			panic(fmt.Sprintf("insecure.KeysetHandle(): %v", err))
 		}
-		signer, err := signature.NewSigner(parsedHandle)
+		signer, err := signature.NewSigner(handle)
 		if err != nil {
 			panic(fmt.Sprintf("testkeysethandle.NewSigner(): %v", err))
 		}

--- a/core/testutil/tink.go
+++ b/core/testutil/tink.go
@@ -26,7 +26,7 @@ import (
 
 // VerifyKeysetFromPEMs produces a Keyset with pubPEMs.
 func VerifyKeysetFromPEMs(pubPEMs ...string) *tink.KeysetHandle {
-	handle, err := insecure.KeysetHandle(&tinkio.PEMKeyset{PEMs: pubPEMs})
+	handle, err := insecure.KeysetHandle(&tinkio.ECDSAPEMKeyset{PEMs: pubPEMs})
 	if err != nil {
 		panic(fmt.Sprintf("insecure.KeysetHandle(): %v", err))
 	}
@@ -40,7 +40,7 @@ func SignKeysetsFromPEMs(privPEMs ...string) []tink.Signer {
 		if pem == "" {
 			continue
 		}
-		handle, err := insecure.KeysetHandle(&tinkio.PEMKeyset{PEMs: []string{pem}})
+		handle, err := insecure.KeysetHandle(&tinkio.ECDSAPEMKeyset{PEMs: []string{pem}})
 		if err != nil {
 			panic(fmt.Sprintf("insecure.KeysetHandle(): %v", err))
 		}


### PR DESCRIPTION
Migrate the uber-hacky `testutil` functions for creating tink keysets to a much less hacky object that uses the PEM `tink.KeysetReader` API.