### PR TITLE
Expose mysql docker container port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       dockerfile: examples/deployment/docker/db_server/Dockerfile
     restart: always
     ports:
-      - "3306"
+      - "3306:3306"
     environment:
       MYSQL_PASSWORD: zaphod
       MYSQL_USER: test


### PR DESCRIPTION
Exposed my-sql DB port 3306 on same port outside.
At least it fails on `go generate ./core/testdata` step.

Fixes: https://github.com/google/keytransparency/issues/1182