### PR TITLE
Improved Metrics

### DIFF
--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -38,6 +38,7 @@ import (
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	_ "github.com/google/trillian/crypto/keys/der/proto"
+	"github.com/google/trillian/monitoring/prometheus"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -119,7 +120,8 @@ func main() {
 	tmap := trillian.NewTrillianMapClient(mconn)
 
 	// Create gRPC server.
-	ksvr := keyserver.New(tlog, tmap, entry.MutateFn, directories, logs, logs)
+	ksvr := keyserver.New(tlog, tmap, entry.MutateFn, directories, logs, logs,
+		prometheus.MetricFactory{})
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -20,6 +20,14 @@ import (
 	"flag"
 	"net/http"
 
+	"github.com/golang/glog"
+	"github.com/google/trillian"
+	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
+
 	"github.com/google/keytransparency/cmd/serverutil"
 	"github.com/google/keytransparency/core/keyserver"
 	"github.com/google/keytransparency/core/mutator/entry"
@@ -29,19 +37,12 @@ import (
 	"github.com/google/keytransparency/impl/sql/engine"
 	"github.com/google/keytransparency/impl/sql/mutationstorage"
 
-	"github.com/golang/glog"
-	"github.com/google/trillian"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/reflection"
-
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
-	_ "github.com/google/trillian/crypto/keys/der/proto"
-	"github.com/google/trillian/monitoring/prometheus"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+
+	_ "github.com/google/trillian/crypto/keys/der/proto"
 )
 
 var (

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -19,17 +19,17 @@ import (
 	"context"
 	"sync"
 
-	"github.com/google/keytransparency/core/crypto/vrf/p256"
-	"github.com/google/keytransparency/core/directory"
-	"github.com/google/keytransparency/core/mutator"
-	"github.com/google/trillian/monitoring"
-
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/google/trillian/monitoring"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/google/keytransparency/core/crypto/vrf/p256"
+	"github.com/google/keytransparency/core/directory"
+	"github.com/google/keytransparency/core/mutator"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	rtpb "github.com/google/keytransparency/core/keyserver/readtoken_go_proto"

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -53,7 +53,6 @@ var (
 	mapLeafCount     monitoring.Counter
 	mapRevisionCount monitoring.Counter
 
-	batchSize        monitoring.Gauge
 	mutationFailures monitoring.Counter
 	watermark        monitoring.Gauge
 )
@@ -79,10 +78,6 @@ func createMetrics(mf monitoring.MetricFactory) {
 		"mutation_failures",
 		"Number of invalid mutations the signer has processed for directoryid since process start",
 		directoryIDLabel, reasonLabel)
-	batchSize = mf.NewGauge(
-		"batch_size",
-		"Number of mutations the signer is attempting to process for directoryid",
-		directoryIDLabel)
 	watermark = mf.NewGauge("watermark", "High Watermark", directoryIDLabel, logIDLabel, phaseLabel)
 }
 
@@ -296,7 +291,6 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	}
 
 	// Parse mutations using the mutator for this directory.
-	batchSize.Set(float64(len(msgs)), in.DirectoryId)
 	indexes := make([][]byte, 0, len(msgs))
 	mutations := make([]*ktpb.EntryUpdate, 0, len(msgs))
 	for _, m := range msgs {

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -51,6 +51,7 @@ var (
 	knownDirectories monitoring.Gauge
 	logEntryCount    monitoring.Counter
 	mapLeafCount     monitoring.Counter
+	mapRevisionCount monitoring.Counter
 
 	batchSize        monitoring.Gauge
 	mutationFailures monitoring.Counter
@@ -69,6 +70,10 @@ func createMetrics(mf monitoring.MetricFactory) {
 	mapLeafCount = mf.NewCounter(
 		"map_leaf_count",
 		"Total number of map leaves written since process start. Duplicates are not removed.",
+		directoryIDLabel)
+	mapRevisionCount = mf.NewCounter(
+		"map_revision_count",
+		"Total number of map revisions written since process start.",
 		directoryIDLabel)
 	mutationFailures = mf.NewCounter(
 		"mutation_failures",
@@ -333,10 +338,9 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 			in.DirectoryId, fmt.Sprintf("%v", s.LogId), appliedLabel)
 	}
 	mapLeafCount.Add(float64(len(newLeaves)), in.DirectoryId)
-	mapRevisionCount.Add(1, directoryId)
+	mapRevisionCount.Add(1, in.DirectoryId)
 	glog.Infof("ApplyRevision(): dir: %v, rev: %v, root: %x, mutations: %v, indexes: %v, newleaves: %v",
 		in.DirectoryId, mapRoot.Revision, mapRoot.RootHash, len(msgs), len(indexes), len(newLeaves))
-	mapLeafCount.Add(float64(len(newLeaves)), directoryId)
 	return &spb.ApplyRevisionResponse{
 		DirectoryId: in.DirectoryId,
 		Revision:    in.Revision,

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -23,13 +23,13 @@ import (
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/google/keytransparency/core/directory"
-	"github.com/google/keytransparency/core/mutator"
-	"github.com/google/keytransparency/core/mutator/entry"
 	"github.com/google/trillian/monitoring"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/google/keytransparency/core/directory"
+	"github.com/google/keytransparency/core/mutator"
+	"github.com/google/keytransparency/core/mutator/entry"
 	"github.com/google/keytransparency/core/sequencer/runner"
 
 	ktpb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -182,7 +182,9 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	pb.RegisterKeyTransparencyServer(gsvr, keyserver.New(
 		logEnv.Log, mapEnv.Map,
 		entry.MutateFn, directoryStorage,
-		mutations, mutations))
+		mutations, mutations,
+		monitoring.InertMetricFactory{},
+	))
 
 	spb.RegisterKeyTransparencySequencerServer(gsvr, sequencer.NewServer(
 		directoryStorage,


### PR DESCRIPTION
New and improved metrics that support
- Rate of log entries being read by the sequencer
- Rate of map leaves being written by the sequencer
- Rate of map revisions being written by the sequencer
- High watermarks for each input log as they are being 
   - Written to
   - Defined in a batch definition for a revision
   - Written to a map revision