### PR TITLE
Proposed changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,22 @@ development.
 #### Generate a private key
 
   ```sh
-  keytransparency-client authorized-keys create-keyset -p password
-  keytransparency-client authorized-keys list-keyset -p password
+  PASSWORD=[[YOUR-KEYSET-PASSWORD]]
+  keytransparency-client authorized-keys create-keyset --password=${PASSWORD}
+  keytransparency-client authorized-keys list-keyset --password=${PASSWORD}
   ```
+NB A default for the Key Transparency server URL is being used here. The default value is "35.202.56.9:443". The flag `--kt-url` may be used to specify the URL of Key Transparency server explicitly.
+
 
 #### Publish the public key
 1. Get an [OAuth client ID](https://console.developers.google.com/apis/credentials) and download the generated JSON file to `client_secret.json`.
 
   ```sh
-  keytransparency-client post user@domain.com --client-secret=client_secret.json --insecure -d 'dGVzdA==' #Base64
+  keytransparency-client post user@domain.com \
+  --client-secret=client_secret.json \
+  --insecure \
+  --password=${PASSWORD} \
+  --data='dGVzdA==' #Base64
   ```
 
 #### Get and verify a public key
@@ -74,6 +81,9 @@ development.
   4        |Mon Sep 12 22:23:54 UTC 2016 |keys:<key:"app1" value:"test" >
   ```
 
+#### Checks
+- [Proof for foo@bar.com](https://35.202.56.9/v1/directories/default/users/foo@bar.com)
+- [Server configuration info](https://35.202.56.9/v1/directories/default)
 
 ## Running the server
 
@@ -106,8 +116,8 @@ Creating keytransparency_monitor_1 ...    done
 
 2. Watch it Run
 - `docker-compose logs --tail=0 --follow`
-- [Proof for foo@bar.com](https://35.202.56.9/v1/directories/default/users/foo@bar.com)
-- [Server configuration info](https://35.202.56.9/v1/directories/default)
+- [Proof for foo@bar.com](https://localhost/v1/directories/default/users/foo@bar.com)
+- [Server configuration info](https://localhost/v1/directories/default)
 
 ## Development and Testing
 Key Transparency and its [Trillian](https://github.com/google/trillian) backend


### PR DESCRIPTION
Some proposals to address #1158.

1. Consistent usage of `--[flag]`
1. Be more explicit about the key set password: `${PASSWORD}` rather than `password`
1. Added clarity to the use of an implicit URL for the Key Transparency server (`35.202.56.9:443`)
1. L119 and L120 incorrectly refer to the published server but ought -- I think? -- reference the locally running service. Revised the URLs.
1. Duplicated these as LL84-86 to use the public Key Transparency server
1. Propose (haven't done) adding commands to create and test a specific email address rather than `user@domain.com` and `foo@bar.com`

Unsures:
1. L40 reads `Generate a private key` and this complements L50 `Publish the public key` but these aren't (I think and not in the example given) a public-private key pair?
1. The example posts data with value `test` (base64 encoded: `dGVzdA==`) not a public key. Would it be more clear to state that arbitrary data may be posted? [Or am I missing something (else)?]
1. Add predefined (perhaps `foo@bar.com`) email address to the public server so that users can lookup a known email? Or, would this need to be gdbelvin@google.com? Is that a problem?