### PR TITLE
Fixes (!?) `init` container command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,13 @@ services:
       dockerfile: ./deploy/docker/init/Dockerfile
     depends_on:
       - sequencer
-    command:  sequencer:8080 -- curl -k https://sequencer:8080/v1/directories -d'{"directory_id":"default","min_interval":"1s","max_interval":"60s"}'
+    command:
+      - sequencer:8080
+      - --
+      - curl
+      - -k
+      - https://sequencer:8080/v1/directories
+      - -d{"directory_id":"default","min_interval":"1s","max_interval":"60s"}
 
   monitor:
     depends_on:


### PR DESCRIPTION
The `curl` command embedded within the `init` container was failing for `docker-compose`.

It's companion Kubernetes Pod, works.

By correcting the `command` (YAML) syntax and aligning this with the Kubernetes Pod definition, it appears to now work correctly:

It creates the `default` directory.