### PR TITLE
Don't timeout users entering OAuth info

### DIFF
--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -75,9 +75,7 @@ User email MUST match the OAuth account used to authorize the update.
 			return fmt.Errorf("hex.Decode(%v): %v", data, err)
 		}
 		userID := args[0]
-		timeout := viper.GetDuration("timeout")
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
+		ctx := context.Background()
 
 		// Create client.
 		userCreds, err := userCreds(ctx)
@@ -107,7 +105,10 @@ User email MUST match the OAuth account used to authorize the update.
 			PublicKeyData:  profileData,
 			AuthorizedKeys: authorizedKeys.Keyset(),
 		}
-		if _, err := c.Update(ctx, u, []tink.Signer{signer},
+		timeout := viper.GetDuration("timeout")
+		cctx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		if _, err := c.Update(cctx, u, []tink.Signer{signer},
 			grpc.PerRPCCredentials(userCreds)); err != nil {
 			return fmt.Errorf("update failed: %v", err)
 		}


### PR DESCRIPTION
Note that this is an incomplete fix

Before
```
go run ./cmd/keytransparency-client/main.go post dazwilkin@google.com --client-secret=/Users/gbelvin/Downloads/client_secret_442418751519-0dgrd0631a9e0n1289g2ebp9evg6ln2m.apps.googleusercontent.com.json --insecure --data='dGVzdA==' --password=${PASSWORD} --kt-url=0.0.0.0:443 --verbose --logtostderr --timeout=10s
Go to the following link in your browser then type the authorization code:
Error: context deadline exceeded
```

After
```
go run ./cmd/keytransparency-client/main.go post dazwilkin@google.com --client-secret=/Users/gbelvin/Downloads/client_secret_442418751519-0dgrd0631a9e0n1289g2ebp9evg6ln2m.apps.googleusercontent.com.json --insecure --data='dGVzdA==' --password=${PASSWORD} --kt-url=0.0.0.0:443 --verbose --logtostderr
Go to the following link in your browser then type the authorization code:
xxxxxxxx
2019/02/07 19:39:08 ✓ Signed Map Head signature verified.
2019/02/07 19:39:08 ✓ Log inclusion proof verified.
I0207 19:39:08.291734   43214 client.go:145] Trusted root updated to TreeSize 1
2019/02/07 19:39:08 ✓ Log root updated.
2019/02/07 19:39:08 ✓ Commitment verified.
2019/02/07 19:39:08 ✓ VRF verified.
2019/02/07 19:39:08 ✓ map inclusion proof verified.
2019/02/07 19:39:08 Got current entry...
2019/02/07 19:39:08 Sending Update request...
2019/02/07 19:39:10 ✓ Signed Map Head signature verified.
2019/02/07 19:39:10 ✓ Log inclusion proof verified.
2019/02/07 19:39:12 ✓ Signed Map Head signature verified.
2019/02/07 19:39:12 ✓ Log inclusion proof verified.
2019/02/07 19:39:14 ✓ Signed Map Head signature verified.
2019/02/07 19:39:14 ✓ Log inclusion proof verified.
2019/02/07 19:39:16 ✓ Signed Map Head signature verified.
2019/02/07 19:39:16 ✓ Log inclusion proof verified.
2019/02/07 19:39:18 ✓ Signed Map Head signature verified.
2019/02/07 19:39:18 ✓ Log inclusion proof verified.
2019/02/07 19:39:20 ✓ Signed Map Head signature verified.
2019/02/07 19:39:20 ✓ Log inclusion proof verified.
Error: update failed: context deadline exceeded
```