### PR TITLE
Support testing with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,35 +87,20 @@ NB A default for the Key Transparency server URL is being used here. The default
 
 ## Running the server
 
-### Install
 1. [OpenSSL](https://www.openssl.org/community/binaries.html)
 1. [Docker](https://docs.docker.com/engine/installation/)
    - Docker Engine 1.13.0+ `docker version -f '{{.Server.APIVersion}}'`
    - Docker Compose 1.11.0+ `docker-compose --version`
-1. `go get -u github.com/google/keytransparency/...`
-1. `go get -u github.com/google/trillian/...`
-1. `./scripts/prepare_server.sh -f`
 
-### Run
-1. Run Key Transparency
-
-  ```sh
-$ cd $GOPATH/src/github.com/google/keytransparency
-$ docker-compose up -d
-Creating keytransparency_db_1 ...         done
-Creating keytransparency_map_server_1 ... done
-Creating keytransparency_log_server_1 ... done
-Creating keytransparency_log_server_1 ... done
-Creating keytransparency_server_1 ...     done
-Creating keytransparency_sequencer_1 ...  done
-Creating keytransparency_monitor_1 ...    done
-Creating keytransparency_init_1 ...       done
-Creating keytransparency_prometheus_1 ... done
-Creating keytransparency_monitor_1 ...    done
-  ```
+```sh
+go get -u github.com/google/keytransparency/...
+go get -u github.com/google/trillian/...
+cd $(go env GOPATH)/src/github.com/google/keytransparency
+./scripts/prepare_server.sh -f
+docker-compose up -f docker-compose.yml docker-compose.prod.yml
+```
 
 2. Watch it Run
-- `docker-compose logs --tail=0 --follow`
 - [Proof for foo@bar.com](https://localhost/v1/directories/default/users/foo@bar.com)
 - [Server configuration info](https://localhost/v1/directories/default)
 
@@ -124,6 +109,7 @@ Key Transparency and its [Trillian](https://github.com/google/trillian) backend
 use a [MySQL database](https://github.com/google/trillian/blob/master/README.md#mysql-setup),
 which must be setup in order for the Key Transparency tests to work.
 
+`docker-compose up -d db` will launch the database in the background.
 
 ### Directory structure
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,8 @@
+# Development configuration
+# docker-compose up will automatically find and apply this configuration
+
+version: "3"
+services:
+  db:
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,8 @@
+# Production configuration
+# docker-compose up -f docker-compose.yml docker-compose.prod.yml
+
+version: "3"
+services:
+  db:
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,6 @@ services:
       MYSQL_PASSWORD: zaphod
       MYSQL_USER: test
       MYSQL_DATABASE: test
-      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
 
   log-server:
     depends_on:


### PR DESCRIPTION
Rather than setting up a full mysql instance, which can be a hassle, support testing against the local database, run by docker with `docker-compose up -d db`. 

The tests require the mysql database to have an empty root password, which is not suitable for production, so this PR splits out the docker-compose file into a separate `dev` and `prod` configurations: 
- dev: `docker-compose up`
- prod: `docker-compose up -f docker-compose.yml docker-compose.prod.yml`

This feature depends on google/trillian#1425
Fixes #1184