### PR TITLE
Set write watermark in keyserver

### DIFF
--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -69,8 +69,8 @@ func (b batchStorage) ReadBatch(ctx context.Context, dirID string, rev int64) (*
 
 type mutations map[int64][]*mutator.LogMessage // Map of logID to Slice of LogMessages
 
-func (m *mutations) Send(ctx context.Context, dirID string, mutation ...*pb.EntryUpdate) error {
-	return errors.New("unimplemented")
+func (m *mutations) Send(ctx context.Context, dirID string, mutation ...*pb.EntryUpdate) (*WriteWatermark, error) {
+	return nil, errors.New("unimplemented")
 }
 
 func (m *mutations) ReadLog(ctx context.Context, dirID string,

--- a/impl/sql/mutationstorage/queue.go
+++ b/impl/sql/mutationstorage/queue.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
+	"github.com/google/keytransparency/core/keyserver"
 	"github.com/google/keytransparency/core/mutator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -46,27 +47,32 @@ func (m *Mutations) AddLogs(ctx context.Context, directoryID string, logIDs ...i
 }
 
 // Send writes mutations to the leading edge (by sequence number) of the mutations table.
+// Returns the logID/watermark pair that was written, or nil if nothing was written.
 // TODO(gbelvin): Make updates a slice.
-func (m *Mutations) Send(ctx context.Context, directoryID string, updates ...*pb.EntryUpdate) error {
+func (m *Mutations) Send(ctx context.Context, directoryID string, updates ...*pb.EntryUpdate) (*keyserver.WriteWatermark, error) {
 	glog.Infof("mutationstorage: Send(%v, <mutation>)", directoryID)
 	if len(updates) == 0 {
-		return nil
+		return nil, nil
 	}
 	logID, err := m.randLog(ctx, directoryID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	updateData := make([][]byte, 0, len(updates))
 	for _, u := range updates {
 		data, err := proto.Marshal(u)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		updateData = append(updateData, data)
 	}
 	// TODO(gbelvin): Implement retry with backoff for retryable errors if
 	// we get timestamp contention.
-	return m.send(ctx, time.Now(), directoryID, logID, updateData...)
+	ts := time.Now()
+	if err := m.send(ctx, ts, directoryID, logID, updateData...); err != nil {
+		return nil, err
+	}
+	return &keyserver.WriteWatermark{LogID: logID, Watermark: ts.UnixNano()}, nil
 }
 
 // ListLogs returns a list of all logs for directoryID, optionally filtered for writable logs.

--- a/impl/sql/mutationstorage/queue_test.go
+++ b/impl/sql/mutationstorage/queue_test.go
@@ -102,7 +102,7 @@ func BenchmarkSend(b *testing.B) {
 				updates = append(updates, update)
 			}
 			for n := 0; n < b.N; n++ {
-				if err := m.Send(ctx, directoryID, updates...); err != nil {
+				if _, err := m.Send(ctx, directoryID, updates...); err != nil {
 					b.Errorf("Send(): %v", err)
 				}
 			}
@@ -201,7 +201,7 @@ func TestReadLog(t *testing.T) {
 	m := newForTest(ctx, t, logID)
 	for i := byte(0); i < 10; i++ {
 		entry := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: mustMarshal(t, &pb.Entry{Index: []byte{i}})}}
-		if err := m.Send(ctx, directoryID, entry, entry, entry); err != nil {
+		if _, err := m.Send(ctx, directoryID, entry, entry, entry); err != nil {
 			t.Fatalf("Send(): %v", err)
 		}
 	}


### PR DESCRIPTION
Add an interface to return metadata about writes to the mutation queue so it can be exposed in the keyserver as a metric. 