### PR TITLE
update travis.yml to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ go:
 dist: trusty
 services:
 - docker-ce
+
+go_import_path: github.com/google/keytransparency
+
 cache:
   directories:
   - "$HOME/gcloud/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 go:
 - 1.x
-dist: trusty
-services:
-- docker-ce
+dist: xenial
 
 go_import_path: github.com/google/keytransparency
 
@@ -12,14 +10,8 @@ cache:
   - "$HOME/gcloud/"
 env:
   global:
-  - DOCKER_COMPOSE_VERSION="1.13.0"
   - PATH=$PATH:${HOME}/google-cloud-sdk/bin
   - CLOUDSDK_CORE_DISABLE_PROMPTS=1
-
-addons:
-  apt:
-    packages:
-    - python3-pip
 
 before_install:
   - |
@@ -50,7 +42,6 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:
-  - pip3 install -U --user docker-compose
   - docker --version
   - docker-compose --version
   - openssl aes-256-cbc -K $encrypted_555d9b2948d2_key -iv $encrypted_555d9b2948d2_iv


### PR DESCRIPTION
fixes #1214 
I fix .travis.yml to be able to use xenial images, docker and docker-compose which are default package in this images.

I don't know how fast build it using xenial images...
https://travis-ci.com/u5surf/keytransparency/jobs/178577965