### PR TITLE
Factor out addr from DialFunc

### DIFF
--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -64,7 +64,6 @@ var hammerCmd = &cobra.Command{
 	Long:  `Sends update requests for user_1 through user_n using a select number of workers in parallel.`,
 
 	RunE: func(_ *cobra.Command, _ []string) error {
-		ktURL := viper.GetString("kt-url")
 		directoryID := viper.GetString("directory")
 		timeout := viper.GetDuration("timeout")
 
@@ -79,12 +78,11 @@ var hammerCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		log.Printf("Hammering %v/directories/%v: with %v timeout", ktURL, directoryID, timeout)
+		log.Printf("Hammering %v: with %v timeout", directoryID, timeout)
 
 		ctx := context.Background()
 
-		h, err := hammer.New(ctx, dial, callOptions,
-			ktURL, directoryID, timeout, handle)
+		h, err := hammer.New(ctx, dial, callOptions, directoryID, timeout, handle)
 		if err != nil {
 			return err
 		}

--- a/core/client/hammer/hammer.go
+++ b/core/client/hammer/hammer.go
@@ -35,7 +35,7 @@ import (
 )
 
 // DialFunc returns a connected grpc client for Key Transparency.
-type DialFunc func(ctx context.Context, addr string, opts ...grpc.DialOption) (pb.KeyTransparencyClient, error)
+type DialFunc func(ctx context.Context) (pb.KeyTransparencyClient, error)
 
 // CallOptions returns PerRPCCredentials for the requested user.
 type CallOptions func(userID string) []grpc.CallOption
@@ -75,8 +75,8 @@ type Hammer struct {
 
 // New returns a new hammer job
 func New(ctx context.Context, dial DialFunc, callOptions CallOptions,
-	ktAddr, directoryID string, timeout time.Duration, keyset *keyset.Handle) (*Hammer, error) {
-	ktCli, err := dial(ctx, ktAddr)
+	directoryID string, timeout time.Duration, keyset *keyset.Handle) (*Hammer, error) {
+	ktCli, err := dial(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow custom address definitions that are more complex than `string`.