### PR TITLE
Made logical split for mutation validation function

### DIFF
--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -109,7 +109,7 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot *trillian.Si
 		}
 
 		// compute the new leaf
-		newValue, err := entry.MutateFn(oldLeaf, mut.GetMutation())
+		newValue, err := entry.MutateFn(oldLeaf, mut.GetMutation(), true)
 		if err != nil {
 			glog.Infof("Mutation did not verify: %v", err)
 			errs.AppendStatus(status.Newf(codes.DataLoss, "invalid mutation: %v", err).WithDetails(mut.GetMutation()))

--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -19,12 +19,9 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/google/keytransparency/core/crypto/commitments"
 	"github.com/google/tink/go/keyset"
 	"github.com/google/tink/go/tink"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
-	"github.com/google/keytransparency/core/crypto/commitments"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
@@ -113,18 +110,8 @@ func (m *Mutation) SerializeAndSign(signers []tink.Signer) (*pb.EntryUpdate, err
 		return nil, err
 	}
 
-	// Check authorization.
-	if err := verifyKeys(m.prevEntry.GetAuthorizedKeys(), m.entry.GetAuthorizedKeys(),
-		mutation.Entry, mutation.Signatures); err != nil {
-		return nil, status.Errorf(codes.PermissionDenied,
-			"verifyKeys(oldKeys: %v, newKeys: %v, sigs: %v): %v",
-			len(m.prevEntry.GetAuthorizedKeys().GetKey()),
-			len(m.entry.GetAuthorizedKeys().GetKey()),
-			len(mutation.GetSignatures()), err)
-	}
-
 	// Sanity check the mutation's correctness.
-	if _, err := MutateFn(m.prevSignedEntry, mutation); err != nil {
+	if _, err := MutateFn(m.prevSignedEntry, mutation, true); err != nil {
 		return nil, fmt.Errorf("presign mutation check: %v", err)
 	}
 

--- a/core/mutator/entry/mutation_test.go
+++ b/core/mutator/entry/mutation_test.go
@@ -114,7 +114,7 @@ func TestCreateAndVerify(t *testing.T) {
 			if err != nil {
 				t.Fatalf("FromLeafValue(%v): %v", tc.old, err)
 			}
-			newSignedEntry, err := MutateFn(oldSignedEntry, update.GetMutation())
+			newSignedEntry, err := MutateFn(oldSignedEntry, update.GetMutation(), true)
 			if err != nil {
 				t.Fatalf("Mutate(%v): %v", update.GetMutation(), err)
 			}

--- a/core/mutator/entry/mutator_test.go
+++ b/core/mutator/entry/mutator_test.go
@@ -177,7 +177,7 @@ func TestCheckMutation(t *testing.T) {
 			continue
 		}
 
-		if _, got := MutateFn(tc.old, m); got != tc.err {
+		if _, got := MutateFn(tc.old, m, true); got != tc.err {
 			t.Errorf("%v Mutate(): %v, want %v", tc.desc, got, tc.err)
 		}
 	}

--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -47,7 +47,7 @@ var (
 // ReduceMutationFn takes the existing mapleaf and a new mutation and returns the new value for that map leaf.
 // ReduceMutationFn verifies that this is a valid mutation for this item.
 // ReduceMutationFn must be idempotent.
-type ReduceMutationFn func(existingMapLeafValue, mutation *pb.SignedEntry) (*pb.SignedEntry, error)
+type ReduceMutationFn func(existingMapLeafValue, mutation *pb.SignedEntry, fullCheck bool) (*pb.SignedEntry, error)
 
 // MapLogItemFn takes a log item and emits 0 or more KV<index, mutations> pairs.
 type MapLogItemFn func(logItem *LogMessage, emit func(index []byte, mutation *pb.EntryUpdate)) error

--- a/core/sequencer/mapper/fns.go
+++ b/core/sequencer/mapper/fns.go
@@ -69,7 +69,7 @@ func ReduceFn(mutatorFn mutator.ReduceMutationFn,
 	// TODO(gbelvin): Choose the mutation deterministically, regardless of the messages order.
 	// (optional): Select the mutation based on it's correctness.
 	msg := msgs[0]
-	newValue, err := mutatorFn(oldValue, msg.Mutation)
+	newValue, err := mutatorFn(oldValue, msg.Mutation, true)
 	if err != nil {
 		glog.Warningf("Mutate(): %v", err)
 		return nil // A bad mutation should not make the whole batch to fail.


### PR DESCRIPTION
Fixes https://github.com/google/keytransparency/issues/1177

Since `MutateFn` is used in many places as a argumant, I decided not split it in two functions and not multiply arguments, I made logical split by pathing flag `fullCheck`.
