### PR TITLE
Added keyset-file flag tp specify file path and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ development.
   keytransparency-client authorized-keys create-keyset --password=${PASSWORD}
   keytransparency-client authorized-keys list-keyset --password=${PASSWORD}
   ```
+The `create-keyset` will create a `.keyset` file in the user's working directory.
+To specify custom directory use `--keyset-file` or `--kf` shortcut.
+
 NB A default for the Key Transparency server URL is being used here. The default value is "35.202.56.9:443". The flag `--kt-url` may be used to specify the URL of Key Transparency server explicitly.
 
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ development.
   keytransparency-client authorized-keys create-keyset --password=${PASSWORD}
   keytransparency-client authorized-keys list-keyset --password=${PASSWORD}
   ```
-The `create-keyset` will create a `.keyset` file in the user's working directory.
+The `create-keyset` command will create a `.keyset` file in the user's working directory.
 To specify custom directory use `--keyset-file` or `--kf` shortcut.
 
 NB A default for the Key Transparency server URL is being used here. The default value is "35.202.56.9:443". The flag `--kt-url` may be used to specify the URL of Key Transparency server explicitly.

--- a/cmd/keytransparency-client/cmd/hammer.go
+++ b/cmd/keytransparency-client/cmd/hammer.go
@@ -55,6 +55,7 @@ func init() {
 	hammerCmd.Flags().IntVar(&maxWorkers, "workers", 1000, "Number of parallel workers. Best when workers = QPS * timeout")
 	hammerCmd.Flags().IntVar(&maxOperations, "operations", 10000, "Number of operations")
 	hammerCmd.Flags().StringVarP(&masterPassword, "password", "p", "", "The master key to the local keyset")
+	hammerCmd.Flags().StringVarP(&keysetFile, "keyset-file", "kf", defaultKeysetFile, "Keyset file name and path")
 }
 
 // hammerCmd represents the post command

--- a/cmd/keytransparency-client/cmd/keys.go
+++ b/cmd/keytransparency-client/cmd/keys.go
@@ -27,11 +27,12 @@ import (
 	tinkpb "github.com/google/tink/proto/tink_go_proto"
 )
 
-const keysetFile = ".keyset"
+const defaultKeysetFile = ".keyset"
 
 var (
 	keyType        string
 	masterPassword string
+	keysetFile     string
 )
 
 // keysCmd represents the authorized-keys command.
@@ -116,4 +117,6 @@ func init() {
 	keysCmd.PersistentFlags().StringVarP(&masterPassword, "password", "p", "", "The master key to the local keyset")
 
 	createCmd.Flags().StringVar(&keyType, "key-type", "P256", "Type of keys to generate: [P256, P384, P521]")
+	createCmd.Flags().StringVarP(&keysetFile, "keyset-file", "kf", defaultKeysetFile, "Keyset file name and path")
+	listCmd.Flags().StringVarP(&keysetFile, "keyset-file", "kf", defaultKeysetFile, "Keyset file name and path")
 }

--- a/cmd/keytransparency-client/cmd/post.go
+++ b/cmd/keytransparency-client/cmd/post.go
@@ -121,6 +121,7 @@ func init() {
 
 	postCmd.PersistentFlags().StringVarP(&masterPassword, "password", "p", "", "The master key to the local keyset")
 	postCmd.PersistentFlags().StringP("secret", "s", "", "Path to client secret json")
+	postCmd.Flags().StringVarP(&keysetFile, "keyset-file", "kf", defaultKeysetFile, "Keyset file name and path")
 	if err := viper.BindPFlag("client-secret", postCmd.PersistentFlags().Lookup("secret")); err != nil {
 		log.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/google/keytransparency/issues/1213
Fixes https://github.com/google/keytransparency/issues/1206

Added `keyset-file` flag to specify keyset file path and name, for CREATE, LIST, POST and HAMMER commands.
Added small description of the new flag to README