### PR TITLE
Fix: Allow multiple updates to the same user in the same batch

### DIFF
--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -299,7 +299,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	for _, iv := range indexedValues {
 		groupByIndex[string(iv.Index)] = true
 	}
-	indexes := make([][]byte, 0, len(indexedValues))
+	indexes := make([][]byte, 0, len(groupByIndex))
 	for i := range groupByIndex {
 		indexes = append(indexes, []byte(i))
 	}

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -295,9 +295,13 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	}
 
 	// Collect Indexes.
-	indexes := make([][]byte, 0, len(indexedValues))
+	groupByIndex := make(map[string]bool)
 	for _, iv := range indexedValues {
-		indexes = append(indexes, iv.Index)
+		groupByIndex[string(iv.Index)] = true
+	}
+	indexes := make([][]byte, 0, len(indexedValues))
+	for i := range groupByIndex {
+		indexes = append(indexes, []byte(i))
 	}
 
 	// Read Map.

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -253,7 +253,7 @@ func TestHighWatermarks(t *testing.T) {
 	}
 }
 
-func TestRaceCondition(t *testing.T) {
+func TestDuplicateUpdates(t *testing.T) {
 	ctx := context.Background()
 	initMetrics.Do(func() { createMetrics(monitoring.InertMetricFactory{}) })
 	ks, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -275,8 +275,12 @@ func TestRaceCondition(t *testing.T) {
 	mapRev := int64(0)
 	for i, data := range []string{"data1", "data2"} {
 		m := entry.NewMutation(index, directoryID, userID)
-		m.SetCommitment([]byte(data))
-		m.ReplaceAuthorizedKeys(authorizedKeys.Keyset())
+		if err := m.SetCommitment([]byte(data)); err != nil {
+			t.Fatalf("%v", err)
+		}
+		if err := m.ReplaceAuthorizedKeys(authorizedKeys.Keyset()); err != nil {
+			t.Fatalf("%v", err)
+		}
 		update, err := m.SerializeAndSign([]tink.Signer{signer})
 		if err != nil {
 			t.Fatalf("SerializeAndSign(): %v", err)
@@ -293,7 +297,7 @@ func TestRaceCondition(t *testing.T) {
 		batcher: &fakeBatcher{
 			highestRev: mapRev,
 			batches: map[int64]*spb.MapMetadata{
-				1: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
+				1: {Sources: []*spb.MapMetadata_SourceSlice{
 					{LogId: 0, HighestExclusive: 2},
 				}},
 			},


### PR DESCRIPTION
If two updates to the same user occurred during the same batch, the sequencer would request the same index in the map multiple times, causing subsequent verifications to fail.

Adds a failing test and then a fix.
Fixes #1225 