### PR TITLE
Fix invalid http.body mapping for KeyTransparencyFrontend.QueueKeyUpdate

### DIFF
--- a/core/api/v1/frontend.proto
+++ b/core/api/v1/frontend.proto
@@ -44,7 +44,7 @@ service KeyTransparencyFrontend {
   rpc QueueKeyUpdate(QueueKeyUpdateRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = {
       post: "/v1/directories/{directory_id}/users/{user_id}"
-      body: "key_data"
+      body: "*"
     };
   }
 }


### PR DESCRIPTION
"*" maps all request fields not captured by the path.