### PR TITLE
Complete ApplyRevisions MR pipeline

### DIFF
--- a/core/mutator/mutator.go
+++ b/core/mutator/mutator.go
@@ -50,14 +50,6 @@ var (
 // VerifyMutationFn verifies that a mutation is internally consistent.
 type VerifyMutationFn func(mutation *pb.SignedEntry) error
 
-// ReduceMutationFn takes all the mutations for an index and an auxiliary input
-// of existing mapleaf(s) returns a new map leaf.  ReduceMutationFn must be
-// idempotent, commutative, and associative. i.e. must produce the same output
-// regardless of input order or grouping, and it must be safe to run multiple
-// times.
-type ReduceMutationFn func(msgs []*pb.EntryUpdate, leaves []*pb.EntryUpdate,
-	emit func(*pb.EntryUpdate), emitErr func(error))
-
 // MapLogItemFn takes a log item and emits 0 or more KV<index, mutations> pairs.
 type MapLogItemFn func(logItem *LogMessage,
 	emit func(index []byte, mutation *pb.EntryUpdate), emitErr func(error))

--- a/core/sequencer/runner/native.go
+++ b/core/sequencer/runner/native.go
@@ -88,10 +88,10 @@ func DoMapMapLeafFn(fn MapMapLeafFn, leaves []*tpb.MapLeaf) ([]*entry.IndexedVal
 }
 
 // ReduceMutationFn takes all the mutations for an index and an auxiliary input
-// of existing mapleaf(s) returns a new map leaf.  ReduceMutationFn must be
-// idempotent, commutative, and associative. i.e. must produce the same output
-// regardless of input order or grouping, and it must be safe to run multiple
-// times.
+// of existing mapleaf(s) and emits a new value for the index.
+// ReduceMutationFn must be  idempotent, commutative, and associative.  i.e.
+// must produce the same output  regardless of input order or grouping,
+// and it must be safe to run multiple times.
 type ReduceMutationFn func(msgs []*pb.EntryUpdate, leaves []*pb.EntryUpdate,
 	emit func(*pb.EntryUpdate), emitErr func(error))
 
@@ -111,6 +111,7 @@ func DoReduceFn(reduceFn ReduceMutationFn, joined []*Joined, emitErr func(error)
 }
 
 // DoMarshalIndexedValues executes Marshal on each IndexedValue
+// If marshal fails, it will emit an error and continue with a subset of ivs.
 func DoMarshalIndexedValues(ivs []*entry.IndexedValue, emitErr func(error)) []*tpb.MapLeaf {
 	ret := make([]*tpb.MapLeaf, 0, len(ivs))
 	for _, iv := range ivs {

--- a/core/sequencer/runner/native.go
+++ b/core/sequencer/runner/native.go
@@ -18,44 +18,12 @@ package runner
 import (
 	"fmt"
 
-	"github.com/golang/glog"
-
 	"github.com/google/keytransparency/core/mutator"
 	"github.com/google/keytransparency/core/mutator/entry"
-	"github.com/google/keytransparency/core/sequencer/mapper"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	tpb "github.com/google/trillian"
 )
-
-// ApplyMutations takes the set of mutations and applies them to given leaves.
-// Returns a list of map leaves that should be updated.
-func ApplyMutations(reduceFn mutator.ReduceMutationFn,
-	indexedUpdates []*entry.IndexedValue, leaves []*tpb.MapLeaf, emitErr func(error)) ([]*tpb.MapLeaf, error) {
-
-	indexedLeaves, err := DoMapMapLeafFn(mapper.MapMapLeafFn, leaves)
-	if err != nil {
-		return nil, err
-	}
-
-	joined := Join(indexedLeaves, indexedUpdates)
-
-	ret := make([]*tpb.MapLeaf, 0, len(joined))
-	for _, j := range joined {
-		reduceFn(j.Values1, j.Values2,
-			func(e *pb.EntryUpdate) {
-				mapLeaf, err := (&entry.IndexedValue{Index: j.Index, Value: e}).Marshal()
-				if err != nil {
-					emitErr(err)
-				}
-				ret = append(ret, mapLeaf)
-			},
-			func(err error) { emitErr(fmt.Errorf("reduceFn on index %x: %v", j.Index, err)) },
-		)
-	}
-	glog.V(2).Infof("ApplyMutations applied %v mutations to %v leaves", len(indexedUpdates), len(leaves))
-	return ret, nil
-}
 
 // Joined is the result of a CoGroupByKey on []*MapLeaf and []*IndexedValue.
 type Joined struct {
@@ -117,4 +85,40 @@ func DoMapMapLeafFn(fn MapMapLeafFn, leaves []*tpb.MapLeaf) ([]*entry.IndexedVal
 		outs = append(outs, out)
 	}
 	return outs, nil
+}
+
+// ReduceMutationFn takes all the mutations for an index and an auxiliary input
+// of existing mapleaf(s) returns a new map leaf.  ReduceMutationFn must be
+// idempotent, commutative, and associative. i.e. must produce the same output
+// regardless of input order or grouping, and it must be safe to run multiple
+// times.
+type ReduceMutationFn func(msgs []*pb.EntryUpdate, leaves []*pb.EntryUpdate,
+	emit func(*pb.EntryUpdate), emitErr func(error))
+
+// DoReduceFn takes the set of mutations and applies them to given leaves.
+// Returns a list of key value pairs that should be written to the map.
+func DoReduceFn(reduceFn ReduceMutationFn, joined []*Joined, emitErr func(error)) []*entry.IndexedValue {
+	ret := make([]*entry.IndexedValue, 0, len(joined))
+	for _, j := range joined {
+		reduceFn(j.Values1, j.Values2,
+			func(e *pb.EntryUpdate) {
+				ret = append(ret, &entry.IndexedValue{Index: j.Index, Value: e})
+			},
+			func(err error) { emitErr(fmt.Errorf("reduceFn on index %x: %v", j.Index, err)) },
+		)
+	}
+	return ret
+}
+
+// DoMarshalIndexedValues executes Marshal on each IndexedValue
+func DoMarshalIndexedValues(ivs []*entry.IndexedValue, emitErr func(error)) []*tpb.MapLeaf {
+	ret := make([]*tpb.MapLeaf, 0, len(ivs))
+	for _, iv := range ivs {
+		mapLeaf, err := iv.Marshal()
+		if err != nil {
+			emitErr(err)
+		}
+		ret = append(ret, mapLeaf)
+	}
+	return ret
 }

--- a/core/sequencer/runner/native.go
+++ b/core/sequencer/runner/native.go
@@ -117,6 +117,7 @@ func DoMarshalIndexedValues(ivs []*entry.IndexedValue, emitErr func(error)) []*t
 		mapLeaf, err := iv.Marshal()
 		if err != nil {
 			emitErr(err)
+			continue
 		}
 		ret = append(ret, mapLeaf)
 	}

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -325,9 +325,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	joined := runner.Join(indexedLeaves, indexedValues)
 
 	// Apply mutations to values.
-	newIndexedLeaves := runner.DoReduceFn(entry.ReduceFn, joined,
-		func(err error) { glog.Warning(err); mutationFailures.Inc(err.Error()) },
-	)
+	newIndexedLeaves := runner.DoReduceFn(entry.ReduceFn, joined, emitErrFn)
 	glog.V(2).Infof("DoReduceFn reduced %v values on %v indexes", len(indexedValues), len(joined))
 
 	// Map IndexedValues

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -249,7 +249,6 @@ func (s *Server) DefineRevisions(ctx context.Context,
 }
 
 // readMessages returns the full set of EntryUpdates defined by sources.
-
 // batchSize limits the number of messages to read from a log at one time.
 func (s *Server) readMessages(ctx context.Context, directoryID string, meta *spb.MapMetadata,
 	batchSize int32) ([]*mutator.LogMessage, error) {
@@ -314,7 +313,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 		return nil, err
 	}
 
-	// Map Map Leaves
+	// Convert Trillian map leaves into indexed KT updates.
 	indexedLeaves, err := runner.DoMapMapLeafFn(mapper.MapMapLeafFn, leaves)
 	if err != nil {
 		return nil, err
@@ -327,7 +326,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	newIndexedLeaves := runner.DoReduceFn(entry.ReduceFn, joined, emitErrFn)
 	glog.V(2).Infof("DoReduceFn reduced %v values on %v indexes", len(indexedValues), len(joined))
 
-	// Map IndexedValues
+	// Marshal new indexed values back into Trillian Map leaves.
 	newLeaves := runner.DoMarshalIndexedValues(newIndexedLeaves, emitErrFn)
 
 	// Serialize metadata


### PR DESCRIPTION
Fold the nebulously named `ApplyMutations` into separate MR functions. 
This makes `ApplyRevision` a contiguous series of MR steps that we can optimize and add metrics to going forward. 