### PR TITLE
Add metrics for each stage of the sequencing pipeline

### DIFF
--- a/core/sequencer/runner/native.go
+++ b/core/sequencer/runner/native.go
@@ -27,6 +27,9 @@ import (
 	tpb "github.com/google/trillian"
 )
 
+// IncMetricFn increments a metric
+type IncMetricFn func(label string)
+
 // Joined is the result of a CoGroupByKey on []*MapLeaf and []*IndexedValue.
 type Joined struct {
 	Index   []byte
@@ -35,9 +38,10 @@ type Joined struct {
 }
 
 // Join pairs up MapLeaves and IndexedValue by index.
-func Join(leaves []*entry.IndexedValue, msgs []*entry.IndexedValue) []*Joined {
+func Join(leaves []*entry.IndexedValue, msgs []*entry.IndexedValue, incFn IncMetricFn) []*Joined {
 	joinMap := make(map[string]*Joined)
 	for _, l := range leaves {
+		incFn("Join1")
 		row, ok := joinMap[string(l.Index)]
 		if !ok {
 			row = &Joined{Index: l.Index}
@@ -46,6 +50,7 @@ func Join(leaves []*entry.IndexedValue, msgs []*entry.IndexedValue) []*Joined {
 		joinMap[string(l.Index)] = row
 	}
 	for _, m := range msgs {
+		incFn("Join2")
 		row, ok := joinMap[string(m.Index)]
 		if !ok {
 			row = &Joined{Index: m.Index}
@@ -64,8 +69,9 @@ func Join(leaves []*entry.IndexedValue, msgs []*entry.IndexedValue) []*Joined {
 type MapMetaFn func(meta *spb.MapMetadata, emit func(*spb.MapMetadata_SourceSlice))
 
 // DoMapMetaFn runs MapMetaFn on meta and collects the outputs.
-func DoMapMetaFn(fn MapMetaFn, meta *spb.MapMetadata) []*spb.MapMetadata_SourceSlice {
+func DoMapMetaFn(fn MapMetaFn, meta *spb.MapMetadata, incFn IncMetricFn) []*spb.MapMetadata_SourceSlice {
 	outs := make([]*spb.MapMetadata_SourceSlice, 0, len(meta.GetSources()))
+	incFn("MapMetaFn")
 	fn(meta, func(slice *spb.MapMetadata_SourceSlice) { outs = append(outs, slice) })
 	return outs
 }
@@ -77,9 +83,10 @@ type ReadSliceFn func(ctx context.Context, slice *spb.MapMetadata_SourceSlice,
 
 // DoReadFn runs ReadSliceFn on every source slice and collects the outputs.
 func DoReadFn(ctx context.Context, fn ReadSliceFn, slices []*spb.MapMetadata_SourceSlice,
-	directoryID string, chunkSize int32) ([]*mutator.LogMessage, error) {
+	directoryID string, chunkSize int32, incFn IncMetricFn) ([]*mutator.LogMessage, error) {
 	outs := make([]*mutator.LogMessage, 0, len(slices))
 	for _, s := range slices {
+		incFn("ReadSliceFn")
 		if err := fn(ctx, s, directoryID, chunkSize,
 			func(msg *mutator.LogMessage) { outs = append(outs, msg) },
 		); err != nil {
@@ -94,9 +101,11 @@ type MapLogItemFn func(logItem *mutator.LogMessage,
 	emit func(index []byte, mutation *pb.EntryUpdate), emitErr func(error))
 
 // DoMapLogItemsFn runs the MapLogItemsFn on each element of msgs.
-func DoMapLogItemsFn(fn MapLogItemFn, msgs []*mutator.LogMessage, emitErr func(error)) []*entry.IndexedValue {
+func DoMapLogItemsFn(fn MapLogItemFn, msgs []*mutator.LogMessage,
+	emitErr func(error), incFn IncMetricFn) []*entry.IndexedValue {
 	outs := make([]*entry.IndexedValue, 0, len(msgs))
 	for _, m := range msgs {
+		incFn("MapLogItemFn")
 		fn(m,
 			func(index []byte, value *pb.EntryUpdate) {
 				outs = append(outs, &entry.IndexedValue{Index: index, Value: value})
@@ -110,9 +119,10 @@ func DoMapLogItemsFn(fn MapLogItemFn, msgs []*mutator.LogMessage, emitErr func(e
 // MapMapLeafFn converts an update into an IndexedValue.
 type MapMapLeafFn func(*tpb.MapLeaf) (*entry.IndexedValue, error)
 
-func DoMapMapLeafFn(fn MapMapLeafFn, leaves []*tpb.MapLeaf) ([]*entry.IndexedValue, error) {
+func DoMapMapLeafFn(fn MapMapLeafFn, leaves []*tpb.MapLeaf, incFn IncMetricFn) ([]*entry.IndexedValue, error) {
 	outs := make([]*entry.IndexedValue, 0, len(leaves))
 	for _, m := range leaves {
+		incFn("MapMapLeafFn")
 		out, err := fn(m)
 		if err != nil {
 			return nil, err
@@ -132,9 +142,11 @@ type ReduceMutationFn func(msgs []*pb.EntryUpdate, leaves []*pb.EntryUpdate,
 
 // DoReduceFn takes the set of mutations and applies them to given leaves.
 // Returns a list of key value pairs that should be written to the map.
-func DoReduceFn(reduceFn ReduceMutationFn, joined []*Joined, emitErr func(error)) []*entry.IndexedValue {
+func DoReduceFn(reduceFn ReduceMutationFn, joined []*Joined, emitErr func(error),
+	incFn IncMetricFn) []*entry.IndexedValue {
 	ret := make([]*entry.IndexedValue, 0, len(joined))
 	for _, j := range joined {
+		incFn("ReduceFn")
 		reduceFn(j.Values1, j.Values2,
 			func(e *pb.EntryUpdate) {
 				ret = append(ret, &entry.IndexedValue{Index: j.Index, Value: e})
@@ -147,9 +159,10 @@ func DoReduceFn(reduceFn ReduceMutationFn, joined []*Joined, emitErr func(error)
 
 // DoMarshalIndexedValues executes Marshal on each IndexedValue
 // If marshal fails, it will emit an error and continue with a subset of ivs.
-func DoMarshalIndexedValues(ivs []*entry.IndexedValue, emitErr func(error)) []*tpb.MapLeaf {
+func DoMarshalIndexedValues(ivs []*entry.IndexedValue, emitErr func(error), incFn IncMetricFn) []*tpb.MapLeaf {
 	ret := make([]*tpb.MapLeaf, 0, len(ivs))
 	for _, iv := range ivs {
+		incFn("MarshalIndexedValue")
 		mapLeaf, err := iv.Marshal()
 		if err != nil {
 			emitErr(err)

--- a/core/sequencer/runner/native_test.go
+++ b/core/sequencer/runner/native_test.go
@@ -23,6 +23,8 @@ import (
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
+func fakeMetricFn(label string) {}
+
 func TestJoin(t *testing.T) {
 	for _, tc := range []struct {
 		desc   string
@@ -42,7 +44,7 @@ func TestJoin(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			got := Join(tc.leaves, tc.msgs)
+			got := Join(tc.leaves, tc.msgs, fakeMetricFn)
 			if !cmp.Equal(got, tc.want) {
 				t.Errorf("Join(): %v, want %v\n diff: %v",
 					got, tc.want, cmp.Diff(got, tc.want))

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -349,7 +349,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 			in.DirectoryId, fmt.Sprintf("%v", s.LogId))
 	}
 	mapLeafCount.Add(float64(len(newLeaves)), in.DirectoryId)
-	mapRevisionCount.Add(1, in.DirectoryId)
+	mapRevisionCount.Inc(in.DirectoryId)
 	glog.Infof("ApplyRevision(): dir: %v, rev: %v, root: %x, mutations: %v, indexes: %v, newleaves: %v",
 		in.DirectoryId, mapRoot.Revision, mapRoot.RootHash, len(logItems), len(indexes), len(newLeaves))
 	return &spb.ApplyRevisionResponse{

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -41,6 +41,7 @@ const (
 	directoryIDLabel = "directoryid"
 	logIDLabel       = "logid"
 	reasonLabel      = "reason"
+	fnLabel          = "fn"
 )
 
 var (
@@ -48,6 +49,7 @@ var (
 	knownDirectories monitoring.Gauge
 	logEntryCount    monitoring.Counter
 	mapLeafCount     monitoring.Counter
+	fnCount          monitoring.Counter
 	mapRevisionCount monitoring.Counter
 	watermarkDefined monitoring.Gauge
 	watermarkApplied monitoring.Gauge
@@ -67,6 +69,10 @@ func createMetrics(mf monitoring.MetricFactory) {
 		"map_leaf_count",
 		"Total number of map leaves written since process start. Duplicates are not removed.",
 		directoryIDLabel)
+	fnCount = mf.NewCounter(
+		"fn_count",
+		"Total number of mapping operations that have run since process start",
+		directoryIDLabel, fnLabel)
 	mapRevisionCount = mf.NewCounter(
 		"map_revision_count",
 		"Total number of map revisions written since process start.",
@@ -284,8 +290,10 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	}
 	glog.Infof("ApplyRevision(): dir: %v, rev: %v, sources: %v", in.DirectoryId, in.Revision, meta)
 
-	logSlices := runner.DoMapMetaFn(mapper.MapMetaFn, meta)
-	logItems, err := runner.DoReadFn(ctx, s.readMessages, logSlices, in.DirectoryId, s.BatchSize)
+	incMetricFn := func(label string) { fnCount.Inc(in.DirectoryId, label) }
+
+	logSlices := runner.DoMapMetaFn(mapper.MapMetaFn, meta, incMetricFn)
+	logItems, err := runner.DoReadFn(ctx, s.readMessages, logSlices, in.DirectoryId, s.BatchSize, incMetricFn)
 	if err != nil {
 		mutationFailures.Inc(err.Error())
 		return nil, err
@@ -293,7 +301,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 
 	emitErrFn := func(err error) { glog.Warning(err); mutationFailures.Inc(in.DirectoryId, err.Error()) }
 	// Map Log Items
-	indexedValues := runner.DoMapLogItemsFn(entry.MapLogItemFn, logItems, emitErrFn)
+	indexedValues := runner.DoMapLogItemsFn(entry.MapLogItemFn, logItems, emitErrFn, incMetricFn)
 
 	// Collect Indexes.
 	groupByIndex := make(map[string]bool)
@@ -316,20 +324,20 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	}
 
 	// Convert Trillian map leaves into indexed KT updates.
-	indexedLeaves, err := runner.DoMapMapLeafFn(mapper.MapMapLeafFn, leaves)
+	indexedLeaves, err := runner.DoMapMapLeafFn(mapper.MapMapLeafFn, leaves, incMetricFn)
 	if err != nil {
 		return nil, err
 	}
 
 	// GroupByIndex.
-	joined := runner.Join(indexedLeaves, indexedValues)
+	joined := runner.Join(indexedLeaves, indexedValues, incMetricFn)
 
 	// Apply mutations to values.
-	newIndexedLeaves := runner.DoReduceFn(entry.ReduceFn, joined, emitErrFn)
+	newIndexedLeaves := runner.DoReduceFn(entry.ReduceFn, joined, emitErrFn, incMetricFn)
 	glog.V(2).Infof("DoReduceFn reduced %v values on %v indexes", len(indexedValues), len(joined))
 
 	// Marshal new indexed values back into Trillian Map leaves.
-	newLeaves := runner.DoMarshalIndexedValues(newIndexedLeaves, emitErrFn)
+	newLeaves := runner.DoMarshalIndexedValues(newIndexedLeaves, emitErrFn, incMetricFn)
 
 	// Serialize metadata
 	metadata, err := proto.Marshal(meta)
@@ -345,8 +353,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	glog.V(2).Infof("CreateRevision: SetLeaves:{Revision: %v}", mapRoot.Revision)
 
 	for _, s := range meta.Sources {
-		watermarkApplied.Set(float64(s.HighestExclusive),
-			in.DirectoryId, fmt.Sprintf("%v", s.LogId))
+		watermarkApplied.Set(float64(s.HighestExclusive), in.DirectoryId, fmt.Sprintf("%v", s.LogId))
 	}
 	mapLeafCount.Add(float64(len(newLeaves)), in.DirectoryId)
 	mapRevisionCount.Inc(in.DirectoryId)

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -43,6 +43,8 @@ import (
 
 const directoryID = "directoryID"
 
+func fakeMetric(_ string) {}
+
 type fakeLogs map[int64][]mutator.LogMessage
 
 func (l fakeLogs) ReadLog(ctx context.Context, directoryID string, logID, low, high int64,
@@ -200,8 +202,8 @@ func TestReadMessages(t *testing.T) {
 			{LogId: 1, LowestInclusive: 1, HighestExclusive: 11},
 		}}},
 	} {
-		logSlices := runner.DoMapMetaFn(mapper.MapMetaFn, tc.meta)
-		logItems, err := runner.DoReadFn(ctx, s.readMessages, logSlices, directoryID, tc.batchSize)
+		logSlices := runner.DoMapMetaFn(mapper.MapMetaFn, tc.meta, fakeMetric)
+		logItems, err := runner.DoReadFn(ctx, s.readMessages, logSlices, directoryID, tc.batchSize, fakeMetric)
 		if err != nil {
 			t.Errorf("readMessages(): %v", err)
 		}


### PR DESCRIPTION
This PR adds metrics at each stage of the sequencing pipeline to help identify issues when things get stuck in the middle of the pipeline. 

