### PR TITLE
Transition off of deprecated gAPI.New

### DIFF
--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -89,7 +89,7 @@ func main() {
 		authFunc = authentication.FakeAuthFunc
 	case "google":
 		var err error
-		gauth, err := authentication.NewGoogleAuth()
+		gauth, err := authentication.NewGoogleAuth(ctx)
 		if err != nil {
 			glog.Exitf("Failed to create authentication library instance: %v", err)
 		}

--- a/impl/authentication/google.go
+++ b/impl/authentication/google.go
@@ -17,7 +17,6 @@ package authentication
 import (
 	"context"
 	"log"
-	"net/http"
 	"strings"
 
 	"golang.org/x/oauth2"
@@ -43,8 +42,8 @@ type GAuth struct {
 }
 
 // NewGoogleAuth creates a new authenticator for Google users.
-func NewGoogleAuth() (*GAuth, error) {
-	googleService, err := gAPI.New(http.DefaultClient)
+func NewGoogleAuth(ctx context.Context) (*GAuth, error) {
+	googleService, err := gAPI.NewService(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/impl/authentication/google_test.go
+++ b/impl/authentication/google_test.go
@@ -46,7 +46,8 @@ func TestGoogleAuthn(t *testing.T) {
 	if *accessToken == "" {
 		t.Skip()
 	}
-	a, err := NewGoogleAuth()
+	ctx := context.Background()
+	a, err := NewGoogleAuth(ctx)
 	if err != nil {
 		t.Fatalf("Failed to create GoogleAuth: %v", err)
 	}
@@ -62,7 +63,6 @@ func TestGoogleAuthn(t *testing.T) {
 	token.SetAuthHeader(r)
 
 	// Convert http request into grpc header.
-	ctx := context.Background()
 	ctx, err = runtime.AnnotateContext(ctx, mux, r)
 	if err != nil {
 		t.Errorf("Error annotating context: %v", err)


### PR DESCRIPTION
gAPI.New was deprecated and replaced with gAPI.NewService in
googleapis/google-api-go-client#d827405e6070b8f323fa8681174e93f0195b7961