### PR TITLE
Add Canonical Err Codes

### DIFF
--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -90,7 +90,7 @@ func ReduceFn(leaves []*pb.EntryUpdate, msgs []*pb.EntryUpdate,
 		newValue, err := MutateFn(oldValue, msg.GetMutation())
 		if err != nil {
 			s := status.Convert(err)
-			emitErr(status.Errorf(s.Code(), "entry: ReduceFn(msg %d/%d): %v", i, len(msgs)-1, s.Message()))
+			emitErr(status.Errorf(s.Code(), "entry: ReduceFn(msg %d/%d): %v", i+1, len(msgs), s.Message()))
 			continue
 		}
 		newEntries = append(newEntries, &pb.EntryUpdate{

--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -71,7 +71,7 @@ func IsValidEntry(signedEntry *pb.SignedEntry) error {
 func ReduceFn(leaves []*pb.EntryUpdate, msgs []*pb.EntryUpdate,
 	emit func(*pb.EntryUpdate), emitErr func(error)) {
 	if got := len(leaves); got > 1 {
-		emitErr(status.Errorf(codes.Internal, "expected 0 or 1 map leaf for got %v", got))
+		emitErr(status.Errorf(codes.Internal, "got %v map leaves, want 0 or 1", got))
 		return // A bad index should not cause the whole batch to fail.
 	}
 	var oldValue *pb.SignedEntry // If no map leaf was found, oldValue will be nil.

--- a/core/sequencer/runner/native.go
+++ b/core/sequencer/runner/native.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/keytransparency/core/mutator"
 	"github.com/google/keytransparency/core/mutator/entry"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"

--- a/core/sequencer/runner/native.go
+++ b/core/sequencer/runner/native.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/keytransparency/core/mutator"
 	"github.com/google/keytransparency/core/mutator/entry"
+	"google.golang.org/grpc/status"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
@@ -35,6 +36,13 @@ type Joined struct {
 	Index   []byte
 	Values1 []*pb.EntryUpdate
 	Values2 []*pb.EntryUpdate
+}
+
+func wrapErrFn(emitErr func(error), msg string) func(error) {
+	return func(err error) {
+		s := status.Convert(err)
+		emitErr(status.Errorf(s.Code(), "%v: %v", msg, s.Message()))
+	}
 }
 
 // Join pairs up MapLeaves and IndexedValue by index.
@@ -110,7 +118,7 @@ func DoMapLogItemsFn(fn MapLogItemFn, msgs []*mutator.LogMessage,
 			func(index []byte, value *pb.EntryUpdate) {
 				outs = append(outs, &entry.IndexedValue{Index: index, Value: value})
 			},
-			func(err error) { emitErr(fmt.Errorf("mapLogItemFn: %v", err)) },
+			wrapErrFn(emitErr, "mapLogItemFn"),
 		)
 	}
 	return outs
@@ -152,7 +160,7 @@ func DoReduceFn(reduceFn ReduceMutationFn, joined []*Joined, emitErr func(error)
 			func(e *pb.EntryUpdate) {
 				ret = append(ret, &entry.IndexedValue{Index: j.Index, Value: e})
 			},
-			func(err error) { emitErr(fmt.Errorf("reduceFn on index %x: %v", j.Index, err)) },
+			wrapErrFn(emitErr, fmt.Sprintf("reduceFn on index %x", j.Index)),
 		)
 	}
 	return ret
@@ -166,7 +174,7 @@ func DoMarshalIndexedValues(ivs []*entry.IndexedValue, emitErr func(error), incF
 		incFn("MarshalIndexedValue")
 		mapLeaf, err := iv.Marshal()
 		if err != nil {
-			emitErr(err)
+			emitErr(status.Errorf(codes.Internal, "MarshalIndexedValue(): %v", err))
 			continue
 		}
 		ret = append(ret, mapLeaf)


### PR DESCRIPTION
Add canonical error codes to the errors that may occur during sequencing.

The main purpose of this is to expose a metric that can export the numbers of sequencing errors that are:
- InvalidArgument - various kinds of data corruption or user error.
- Internal - conditions that we expect to never happen.