### PR TITLE
Update some error cases in BatchGetUser

### DIFF
--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -269,7 +269,7 @@ func (s *Server) BatchGetUser(ctx context.Context, in *pb.BatchGetUserRequest) (
 	d, err := s.directories.Read(ctx, in.DirectoryId, false)
 	if err != nil {
 		glog.Errorf("adminstorage.Read(%v): %v", in.DirectoryId, err)
-		return nil, status.Errorf(codes.Internal, "Cannot fetch directory info")
+		return nil, err
 	}
 
 	// Fetch latest revision.

--- a/core/keyserver/revisions.go
+++ b/core/keyserver/revisions.go
@@ -247,6 +247,9 @@ func (s *Server) latestLogRootProof(ctx context.Context, d *directory.Directory,
 	}
 	// Consistency proof.
 	secondTreeSize := int64(root.TreeSize)
+	if secondTreeSize < firstTreeSize {
+          return nil, nil, status.Errorf(codes.InvalidArgument, "latestLogRootProof: latest log root is smaller than firstTreeSize")
+	}
 	var logConsistency *tpb.GetConsistencyProofResponse
 	if firstTreeSize != 0 {
 		logConsistency, err = s.tlog.GetConsistencyProof(ctx,

--- a/core/keyserver/revisions.go
+++ b/core/keyserver/revisions.go
@@ -248,7 +248,7 @@ func (s *Server) latestLogRootProof(ctx context.Context, d *directory.Directory,
 	// Consistency proof.
 	secondTreeSize := int64(root.TreeSize)
 	if secondTreeSize < firstTreeSize {
-          return nil, nil, status.Errorf(codes.InvalidArgument, "latestLogRootProof: latest log root is smaller than firstTreeSize")
+		return nil, nil, status.Errorf(codes.InvalidArgument, "latestLogRootProof: latest log root is smaller than firstTreeSize")
 	}
 	var logConsistency *tpb.GetConsistencyProofResponse
 	if firstTreeSize != 0 {


### PR DESCRIPTION
Update some error cases in BatchGetUser to properly return client errors for invalid input.