### PR TITLE
Set default code reviewer to @google/keytransparency

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,4 +5,5 @@
 # https://git-scm.com/docs/gitignore#_pattern_format
 
 # Default
-*				@gdbelvin
+*				@google/keytransparency
+core/crypto			@gdbelvin @thaidn @benbenoy


### PR DESCRIPTION
CODEOWNERS automatically assigns reviewers but it also requires an LGTM from
one of those reviewers, regardless of other LGTMs.

Remove single point of failure by expanding code ownership to include the whole
team.