### PR TITLE
Add a prefix to keyserver metric name

### DIFF
--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -51,7 +51,7 @@ var (
 
 func createMetrics(mf monitoring.MetricFactory) {
 	watermarkWritten = mf.NewGauge(
-		"watermark_written",
+		"keyserver_watermark_written",
 		"High watermark of each input log that has been written",
 		directoryIDLabel, logIDLabel)
 }


### PR DESCRIPTION
This distinguishes it from the metric with the same name in the sequencer server.