### PR TITLE
 Separate Log Revision Writes from Map Writes

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -220,6 +220,9 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn,
 		}
 	})
 
+	if err := signer.AddAllDirectories(ctx); err != nil {
+		glog.Errorf("runSequencer(AddAllDirectories): %v", err)
+	}
 	go sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
 		if err := signer.AddAllDirectories(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(AddAllDirectories): %v", err)
@@ -230,9 +233,6 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn,
 	})
 
 	sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
-		if err := signer.AddAllDirectories(ctx); err != nil {
-			glog.Errorf("PeriodicallyRun(AddAllDirectories): %v", err)
-		}
 		if err := signer.PublishLogForAllMasterships(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(PublishRevisionsForAllMasterships): %v", err)
 		}

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -228,7 +228,7 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn,
 			glog.Errorf("PeriodicallyRun(RunBatchForAllMasterships): %v", err)
 		}
 	})
-	
+
 	sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
 		if err := signer.AddAllDirectories(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(AddAllDirectories): %v", err)

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -228,4 +228,13 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn,
 			glog.Errorf("PeriodicallyRun(RunBatchForAllMasterships): %v", err)
 		}
 	})
+	
+	sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
+		if err := signer.AddAllDirectories(ctx); err != nil {
+			glog.Errorf("PeriodicallyRun(AddAllDirectories): %v", err)
+		}
+		if err := signer.PublishRevisionsForAllMasterships(ctx, int32(*batchSize)); err != nil {
+			glog.Errorf("PeriodicallyRun(PublishRevisionsForAllMasterships): %v", err)
+		}
+	})
 }

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -233,7 +233,7 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn,
 		if err := signer.AddAllDirectories(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(AddAllDirectories): %v", err)
 		}
-		if err := signer.PublishRevisionsForAllMasterships(ctx); err != nil {
+		if err := signer.PublishLogForAllMasterships(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(PublishRevisionsForAllMasterships): %v", err)
 		}
 	})

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -233,7 +233,7 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn,
 		if err := signer.AddAllDirectories(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(AddAllDirectories): %v", err)
 		}
-		if err := signer.PublishRevisionsForAllMasterships(ctx, int32(*batchSize)); err != nil {
+		if err := signer.PublishRevisionsForAllMasterships(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(PublishRevisionsForAllMasterships): %v", err)
 		}
 	})

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -220,7 +220,7 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn,
 		}
 	})
 
-	sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
+	go sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
 		if err := signer.AddAllDirectories(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(AddAllDirectories): %v", err)
 		}

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -121,7 +121,7 @@ func (s *Sequencer) RunBatchForAllMasterships(ctx context.Context, batchSize int
 	return lastErr
 }
 
-func (s *Sequencer) PublishLogForAllMasterships(ctx context.Context, batchSize int32) error {
+func (s *Sequencer) PublishLogForAllMasterships(ctx context.Context) error {
 	glog.Infof("PublishLogForAllMasterships")
 	cctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -120,3 +120,24 @@ func (s *Sequencer) RunBatchForAllMasterships(ctx context.Context, batchSize int
 
 	return lastErr
 }
+
+func (s *Sequencer) PublishLogForAllMasterships(ctx context.Context, batchSize int32) error {
+	glog.Infof("PublishLogForAllMasterships")
+	cctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	masterships, err := s.tracker.Masterships(cctx)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	for dirID, whileMaster := range masterships {
+		publishReq := &spb.PublishRevisionsRequest{DirectoryId: dirID}
+		if _, err = s.sequencerClient.PublishRevisions(ctx, publishReq); err != nil {
+			lastErr = err
+			glog.Errorf("RunBatch for %v failed: %v", dirID, err)
+		}
+	}
+
+	return lastErr
+}

--- a/core/sequencer/sequencer.go
+++ b/core/sequencer/sequencer.go
@@ -133,7 +133,7 @@ func (s *Sequencer) PublishLogForAllMasterships(ctx context.Context) error {
 	var lastErr error
 	for dirID, whileMaster := range masterships {
 		publishReq := &spb.PublishRevisionsRequest{DirectoryId: dirID}
-		if _, err = s.sequencerClient.PublishRevisions(ctx, publishReq); err != nil {
+		if _, err = s.sequencerClient.PublishRevisions(whileMaster, publishReq); err != nil {
 			lastErr = err
 			glog.Errorf("RunBatch for %v failed: %v", dirID, err)
 		}

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -255,18 +255,9 @@ func (s *Server) RunBatch(ctx context.Context, in *spb.RunBatchRequest) (*empty.
 		revReq := &spb.ApplyRevisionRequest{DirectoryId: in.DirectoryId, Revision: rev}
 		_, err := s.loopback.ApplyRevision(ctx, revReq)
 		if err != nil {
-			// Log the error and continue to publish any revsisions this run may have completed.
-			// This revision will be retried on the next execution of RunBatch.
-			glog.Errorf("ApplyRevision(dir: %v, rev: %v): %v", in.DirectoryId, rev, err)
-			break
+			return nil, err
 		}
 		handledCount++
-	}
-
-	publishReq := &spb.PublishRevisionsRequest{DirectoryId: in.DirectoryId, Block: in.Block}
-	_, err = s.loopback.PublishRevisions(ctx, publishReq)
-	if err != nil {
-		return nil, err
 	}
 	return &empty.Empty{}, nil
 }


### PR DESCRIPTION
Moved PublishRevision out of RunBatch and created its own function to call periodically. Publishing to the log and writing to the map are independent actions.