### PR TITLE
Fix client_tests.go now that RunBatch and PublishRevisions are split

### DIFF
--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -414,7 +414,7 @@ func (env *Env) setupHistory(ctx context.Context, directory *pb.Directory, userI
 			}); err != nil {
 				return fmt.Errorf("sequencer.RunBatch(%v): %v", i, err)
 			}
-			_, err = env.Sequencer.PublishRevisions(ctx, &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId})
+			_, err = env.Sequencer.PublishRevisions(ctx, &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId, Block: true})
 			if err != nil {
 				return fmt.Errorf("sequencer.PublishRevisions(%v): %v", i, err)
 			}
@@ -529,7 +529,8 @@ func (env *Env) setupHistoryMultipleUsers(ctx context.Context, directory *pb.Dir
 		}); err != nil {
 			return fmt.Errorf("sequencer.RunBatch(%v): %v", i, err)
 		}
-		_, err = env.Sequencer.PublishRevisions(ctx, &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId})
+		pubRevReq := &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId, Block:true}
+		_, err = env.Sequencer.PublishRevisions(ctx, pubRevReq)
 		if err != nil {
 			return fmt.Errorf("sequencer.PublishRevisions(%v): %v", i, err)
 		}

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -414,6 +414,10 @@ func (env *Env) setupHistory(ctx context.Context, directory *pb.Directory, userI
 			}); err != nil {
 				return fmt.Errorf("sequencer.RunBatch(%v): %v", i, err)
 			}
+			_, err = env.Sequencer.PublishRevisions(ctx, &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId})
+			if err != nil {
+				return fmt.Errorf("sequencer.PublishRevisions(%v): %v", i, err)
+			}
 		} else if _, err := env.Sequencer.RunBatch(ctx, &spb.RunBatchRequest{
 			DirectoryId: directory.DirectoryId,
 			// Create an empty revision.
@@ -524,6 +528,10 @@ func (env *Env) setupHistoryMultipleUsers(ctx context.Context, directory *pb.Dir
 			Block:       true,
 		}); err != nil {
 			return fmt.Errorf("sequencer.RunBatch(%v): %v", i, err)
+		}
+		_, err = env.Sequencer.PublishRevisions(ctx, &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId})
+		if err != nil {
+			return fmt.Errorf("sequencer.PublishRevisions(%v): %v", i, err)
 		}
 	}
 	return nil

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -529,7 +529,7 @@ func (env *Env) setupHistoryMultipleUsers(ctx context.Context, directory *pb.Dir
 		}); err != nil {
 			return fmt.Errorf("sequencer.RunBatch(%v): %v", i, err)
 		}
-		pubRevReq := &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId, Block:true}
+		pubRevReq := &spb.PublishRevisionsRequest{DirectoryId: directory.DirectoryId, Block: true}
 		_, err = env.Sequencer.PublishRevisions(ctx, pubRevReq)
 		if err != nil {
 			return fmt.Errorf("sequencer.PublishRevisions(%v): %v", i, err)


### PR DESCRIPTION
One more fix to client_tests.go to add explicit calls to PublishRevisions.