### PR TITLE
Don't double count errors

### DIFF
--- a/core/mutator/entry/mutator.go
+++ b/core/mutator/entry/mutator.go
@@ -99,7 +99,6 @@ func ReduceFn(leaves []*pb.EntryUpdate, msgs []*pb.EntryUpdate,
 		})
 	}
 	if len(newEntries) == 0 {
-		emitErr(errors.New("entry: no valid mutations"))
 		return // No valid mutations for one index should not cause the whole batch to fail.
 	}
 	// Choose the mutation deterministically, regardless of the messages order.


### PR DESCRIPTION
When a mutation for a single entry is invalid it will produce both an
InvalidArgument error because of an invalid hash, and this Unknown error
because there are no mutations to apply. This double counting is
confusing.