### PR TITLE
Parallize functions in the BatchCreateUser flow

### DIFF
--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -108,7 +108,7 @@ func (c *Client) BatchCreateMutation(ctx context.Context, users []*User) ([]*ent
 		defer close(rChan)
 		var wg sync.WaitGroup
 		defer wg.Wait() // Wait before closing rChan
-		for w := 1; w < runtime.NumCPU(); w++ {
+		for w := 0; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func(uChan <-chan *User, rChan chan<- result) {
 				defer wg.Done()

--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -109,13 +109,13 @@ func (c *Client) BatchCreateMutation(ctx context.Context, users []*User) ([]*ent
 		var wg sync.WaitGroup
 		for w := 1; w < (runtime.NumCPU() - 1); w++ {
 			wg.Add(1)
-			go func(id int, uChan <-chan *User, rChan chan<- result) {
+			go func(uChan <-chan *User, rChan chan<- result) {
 				defer wg.Done()
 				for u := range uChan {
 					m, err := c.createMutation(u, leavesByUserID[u.UserID])
 					rChan <- result{m: m, err: err}
 				}
-			}(w, uChan, rChan)
+			}(uChan, rChan)
 		}
 		wg.Wait()
 	}()

--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -107,6 +107,7 @@ func (c *Client) BatchCreateMutation(ctx context.Context, users []*User) ([]*ent
 	go func() {
 		defer close(rChan)
 		var wg sync.WaitGroup
+		defer wg.Wait() // Wait before closing rChan
 		for w := 1; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func(uChan <-chan *User, rChan chan<- result) {
@@ -117,7 +118,6 @@ func (c *Client) BatchCreateMutation(ctx context.Context, users []*User) ([]*ent
 				}
 			}(uChan, rChan)
 		}
-		wg.Wait()
 	}()
 	// Collect
 	mutations := make([]*entry.Mutation, 0, len(users))

--- a/core/client/batch_client.go
+++ b/core/client/batch_client.go
@@ -107,7 +107,7 @@ func (c *Client) BatchCreateMutation(ctx context.Context, users []*User) ([]*ent
 	go func() {
 		defer close(rChan)
 		var wg sync.WaitGroup
-		for w := 1; w < (runtime.NumCPU() - 1); w++ {
+		for w := 1; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func(uChan <-chan *User, rChan chan<- result) {
 				defer wg.Done()

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -262,7 +262,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) []testda
 			// Check profile.
 			e, newslr, err := CheckProfile(ctx, env, tc.userID, tc.wantProfile, slr)
 			if err != nil {
-				t.Errorf("%v", err)
+				t.Fatalf("%v", err)
 			}
 
 			// Update the trusted root on the first revision, then let it fall behind

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -349,6 +349,7 @@ func (s *Server) batchGetUserIndex(ctx context.Context, d *directory.Directory,
 	go func() {
 		defer close(results)
 		var wg sync.WaitGroup
+		defer wg.Wait() // Wait before closing results
 		for w := 1; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func() {
@@ -359,7 +360,6 @@ func (s *Server) batchGetUserIndex(ctx context.Context, d *directory.Directory,
 				}
 			}()
 		}
-		wg.Wait()
 	}()
 	proofsByUser = make(map[string][]byte)
 	usersByIndex = make(map[string]string)
@@ -620,6 +620,7 @@ func (s *Server) BatchQueueUserUpdate(ctx context.Context, in *pb.BatchQueueUser
 	go func() {
 		defer close(results)
 		var wg sync.WaitGroup
+		defer wg.Wait() // Wait before closing results
 		for w := 1; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func() {
@@ -636,7 +637,6 @@ func (s *Server) BatchQueueUserUpdate(ctx context.Context, in *pb.BatchQueueUser
 				}
 			}()
 		}
-		wg.Wait()
 	}()
 	for e := range results {
 		return nil, e

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -349,7 +349,7 @@ func (s *Server) batchGetUserIndex(ctx context.Context, d *directory.Directory,
 	go func() {
 		defer close(results)
 		var wg sync.WaitGroup
-		for w := 1; w < (runtime.NumCPU() - 1); w++ {
+		for w := 1; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -620,7 +620,7 @@ func (s *Server) BatchQueueUserUpdate(ctx context.Context, in *pb.BatchQueueUser
 	go func() {
 		defer close(results)
 		var wg sync.WaitGroup
-		for w := 1; w < (runtime.NumCPU() - 1); w++ {
+		for w := 1; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -350,7 +350,7 @@ func (s *Server) batchGetUserIndex(ctx context.Context, d *directory.Directory,
 		defer close(results)
 		var wg sync.WaitGroup
 		defer wg.Wait() // Wait before closing results
-		for w := 1; w < runtime.NumCPU(); w++ {
+		for w := 0; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -621,7 +621,7 @@ func (s *Server) BatchQueueUserUpdate(ctx context.Context, in *pb.BatchQueueUser
 		defer close(errors)
 		var wg sync.WaitGroup
 		defer wg.Wait() // Wait before closing errors
-		for w := 1; w < runtime.NumCPU(); w++ {
+		for w := 0; w < runtime.NumCPU(); w++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()


### PR DESCRIPTION
This will help us create more fake traffic for load testing.

Profiling these functions has revealed a significant amount of time being spent in running the VRF functions. 