### PR TITLE
Parallize VerifyBatchGetUserIndex

### DIFF
--- a/core/client/batch_get_and_verify.go
+++ b/core/client/batch_get_and_verify.go
@@ -16,8 +16,11 @@ package client
 
 import (
 	"context"
+	"runtime"
+	"sync"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+	"github.com/google/trillian/monitoring"
 )
 
 // BatchVerifyGetUserIndex fetches and verifies the indexes for a list of users.
@@ -30,13 +33,57 @@ func (c *Client) BatchVerifyGetUserIndex(ctx context.Context, userIDs []string) 
 		return nil, err
 	}
 
-	indexByUser := make(map[string][]byte)
-	for userID, proof := range resp.Proofs {
-		index, err := c.Index(proof, c.DirectoryID, userID)
-		if err != nil {
-			return nil, err
+	_, spanEnd := monitoring.StartSpan(ctx, "VerifyBatchGetUserIndex")
+	defer spanEnd()
+
+	type proof struct {
+		userID string
+		proof  []byte
+	}
+	proofs := make(chan proof)
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		defer close(proofs)
+		for UID, p := range resp.GetProofs() {
+			select {
+			case proofs <- proof{UID, p}:
+			case <-done:
+				return
+			}
 		}
-		indexByUser[userID] = index
+	}()
+	type result struct {
+		userID string
+		index  []byte
+		err    error
+	}
+	results := make(chan result)
+	go func() {
+		defer close(results)
+		var wg sync.WaitGroup
+		defer wg.Wait()
+		for w := 0; w < runtime.NumCPU(); w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for p := range proofs {
+					index, err := c.Index(p.proof, c.DirectoryID, p.userID)
+					select {
+					case results <- result{userID: p.userID, index: index, err: err}:
+					case <-done:
+						return
+					}
+				}
+			}()
+		}
+	}()
+	indexByUser := make(map[string][]byte)
+	for r := range results {
+		if r.err != nil {
+			return nil, r.err // Done will be closed by deferred call.
+		}
+		indexByUser[r.userID] = r.index
 	}
 	return indexByUser, nil
 }


### PR DESCRIPTION
This produces a 7x speedup for batches of 1000 on a 12 core computer. 
Before: 15s
After: 2s 