### PR TITLE
Use GetMapLeavesNoProof

### DIFF
--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -390,7 +390,7 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 		return nil, err
 	}
 	verifyLeafStart := time.Now()
-	leaves, err := mapClient.GetAndVerifyMapLeavesByRevision(ctx, in.Revision-1, indexes)
+	leaves, err := mapClient.GetMapLeavesByRevisionNoProof(ctx, in.Revision-1, indexes)
 	fnLatency.Observe(time.Since(verifyLeafStart).Seconds(), in.DirectoryId, "GetAndVerifyMapLeavesByRevision")
 	if err != nil {
 		return nil, err

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -126,7 +126,7 @@ type fakeMapConn struct {
 
 var errSuccess = status.Errorf(codes.Unimplemented, "Success! No Duplicates. Shortcut return")
 
-func (m *fakeMapConn) GetLeavesByRevision(_ context.Context, in *tpb.GetMapLeavesByRevisionRequest, _ ...grpc.CallOption) (*tpb.GetMapLeavesResponse, error) {
+func (m *fakeMapConn) GetLeavesByRevisionNoProof(_ context.Context, in *tpb.GetMapLeavesByRevisionRequest, _ ...grpc.CallOption) (*tpb.MapLeaves, error) {
 	set := make(map[string]bool)
 	for _, i := range in.Index {
 		if set[string(i)] {

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -18,27 +18,18 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/tink/go/keyset"
-	"github.com/google/tink/go/signature"
-	"github.com/google/tink/go/tink"
 	"github.com/google/trillian/monitoring"
 	"github.com/google/trillian/types"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/google/keytransparency/core/mutator"
-	"github.com/google/keytransparency/core/mutator/entry"
 	"github.com/google/keytransparency/core/sequencer/mapper"
 	"github.com/google/keytransparency/core/sequencer/runner"
 
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 	tpb "github.com/google/trillian"
-	tclient "github.com/google/trillian/client"
 )
 
 const directoryID = "directoryID"
@@ -118,26 +109,6 @@ func (b *fakeBatcher) ReadBatch(_ context.Context, _ string, rev int64) (*spb.Ma
 		return nil, fmt.Errorf("batch %v not found", rev)
 	}
 	return meta, nil
-}
-
-type fakeMapConn struct {
-	tpb.TrillianMapClient
-}
-
-var errSuccess = status.Errorf(codes.Unimplemented, "Success! No Duplicates. Shortcut return")
-
-func (m *fakeMapConn) GetLeavesByRevisionNoProof(_ context.Context, in *tpb.GetMapLeavesByRevisionRequest, _ ...grpc.CallOption) (*tpb.MapLeaves, error) {
-	set := make(map[string]bool)
-	for _, i := range in.Index {
-		if set[string(i)] {
-			return nil, status.Errorf(codes.InvalidArgument,
-				"map.GetLeaves(): index %x requested more than once", i)
-		}
-		set[string(i)] = true
-	}
-
-	// Return a unique error here so the test can verify success.
-	return nil, errSuccess
 }
 
 func TestDefineRevisions(t *testing.T) {
@@ -268,69 +239,5 @@ func TestHighWatermarks(t *testing.T) {
 				t.Errorf("HighWatermarks(): diff(-got, +want): %v", cmp.Diff(next, &tc.next))
 			}
 		})
-	}
-}
-
-func TestDuplicateUpdates(t *testing.T) {
-	ctx := context.Background()
-	initMetrics.Do(func() { createMetrics(monitoring.InertMetricFactory{}) })
-	ks, err := keyset.NewHandle(signature.ECDSAP256KeyTemplate())
-	if err != nil {
-		t.Fatalf("keyset.NewHandle(): %v", err)
-	}
-	signer, err := signature.NewSigner(ks)
-	if err != nil {
-		t.Fatalf("signature.NewSigner(): %v", err)
-	}
-	authorizedKeys, err := ks.Public()
-	if err != nil {
-		t.Fatalf("Failed to setup tink keyset: %v", err)
-	}
-
-	index := []byte("index")
-	userID := "userID"
-	log0 := []mutator.LogMessage{}
-	mapRev := int64(0)
-	for i, data := range []string{"data1", "data2"} {
-		m := entry.NewMutation(index, directoryID, userID)
-		if err := m.SetCommitment([]byte(data)); err != nil {
-			t.Fatalf("SetCommitment(): %v", err)
-		}
-		if err := m.ReplaceAuthorizedKeys(authorizedKeys); err != nil {
-			t.Fatalf("ReplaceAuthorizedKeys(): %v", err)
-		}
-		update, err := m.SerializeAndSign([]tink.Signer{signer})
-		if err != nil {
-			t.Fatalf("SerializeAndSign(): %v", err)
-		}
-		log0 = append(log0, mutator.LogMessage{
-			ID:        int64(i),
-			Mutation:  update.Mutation,
-			ExtraData: update.Committed},
-		)
-	}
-
-	s := Server{
-		logs: fakeLogs{0: log0},
-		batcher: &fakeBatcher{
-			highestRev: mapRev,
-			batches: map[int64]*spb.MapMetadata{
-				1: {Sources: []*spb.MapMetadata_SourceSlice{{LogId: 0, HighestExclusive: 2}}},
-			},
-		},
-		trillian: &fakeTrillianFactory{
-			tmap: &fakeMap{
-				MapClient:     MapClient{&tclient.MapClient{Conn: &fakeMapConn{}}},
-				latestMapRoot: &types.MapRootV1{Revision: uint64(mapRev)},
-			},
-		},
-	}
-
-	_, err = s.ApplyRevision(ctx, &spb.ApplyRevisionRequest{
-		DirectoryId: directoryID,
-		Revision:    1,
-	})
-	if got, want := status.Convert(err).Message(), status.Convert(errSuccess).Message(); !strings.Contains(got, want) {
-		t.Fatalf("ApplyRevision(): %v, want\n%v", got, want)
 	}
 }

--- a/core/sequencer/trillian_client.go
+++ b/core/sequencer/trillian_client.go
@@ -142,7 +142,7 @@ func (c *MapClient) GetAndVerifyMapRootByRevision(ctx context.Context,
 	return rawMapRoot, mapRoot, nil
 }
 
-// GetMapLeavesByRevisionNoProof verifies and returns the requested map leaves at a specific revision.
+// GetMapLeavesByRevisionNoProof returns the requested map leaves at a specific revision.
 // indexes may not contain duplicates.
 func (c *MapClient) GetMapLeavesByRevisionNoProof(ctx context.Context, revision int64, indexes [][]byte) ([]*tpb.MapLeaf, error) {
 	if err := hasDuplicates(indexes); err != nil {
@@ -155,7 +155,7 @@ func (c *MapClient) GetMapLeavesByRevisionNoProof(ctx context.Context, revision 
 	})
 	if err != nil {
 		s := status.Convert(err)
-		return nil, status.Errorf(s.Code(), "map.GetLeaves(): %v", s.Message())
+		return nil, status.Errorf(s.Code(), "GetLeavesByRevisionNoProof(): %v", s.Message())
 	}
 	return getResp.Leaves, nil
 }
@@ -165,8 +165,7 @@ func hasDuplicates(indexes [][]byte) error {
 	set := make(map[string]bool)
 	for _, i := range indexes {
 		if set[string(i)] {
-			return status.Errorf(codes.InvalidArgument,
-				"map.GetLeaves(): index %x requested more than once", i)
+			return status.Errorf(codes.InvalidArgument, "index %x requested more than once", i)
 		}
 		set[string(i)] = true
 	}

--- a/core/sequencer/trillian_client.go
+++ b/core/sequencer/trillian_client.go
@@ -145,9 +145,6 @@ func (c *MapClient) GetAndVerifyMapRootByRevision(ctx context.Context,
 // GetMapLeavesByRevisionNoProof returns the requested map leaves at a specific revision.
 // indexes may not contain duplicates.
 func (c *MapClient) GetMapLeavesByRevisionNoProof(ctx context.Context, revision int64, indexes [][]byte) ([]*tpb.MapLeaf, error) {
-	if err := hasDuplicates(indexes); err != nil {
-		return nil, err
-	}
 	getResp, err := c.Conn.GetLeavesByRevisionNoProof(ctx, &tpb.GetMapLeavesByRevisionRequest{
 		MapId:    c.MapID,
 		Index:    indexes,
@@ -158,16 +155,4 @@ func (c *MapClient) GetMapLeavesByRevisionNoProof(ctx context.Context, revision 
 		return nil, status.Errorf(s.Code(), "GetLeavesByRevisionNoProof(): %v", s.Message())
 	}
 	return getResp.Leaves, nil
-}
-
-// hasDuplicates returns an error if there are duplicates in indexes.
-func hasDuplicates(indexes [][]byte) error {
-	set := make(map[string]bool)
-	for _, i := range indexes {
-		if set[string(i)] {
-			return status.Errorf(codes.InvalidArgument, "index %x requested more than once", i)
-		}
-		set[string(i)] = true
-	}
-	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/certificate-transparency-go v1.0.21 // indirect
 	github.com/google/go-cmp v0.2.0
 	github.com/google/tink v1.2.1-0.20190523150020-6495d823d968
-	github.com/google/trillian v1.2.2-0.20190524132942-bbaabdb62893
+	github.com/google/trillian v1.2.2-0.20190603160524-0cfa53f919f3
 	github.com/googleapis/gax-go v2.0.2+incompatible // indirect
 	github.com/gorilla/websocket v1.4.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/google/tink v1.2.1-0.20190523150020-6495d823d968 h1:3P4TOKsvMmO5ZyE1C
 github.com/google/tink v1.2.1-0.20190523150020-6495d823d968/go.mod h1:eu7D8x3z2rMO7fyvHVhMx8yoFH+vH8EZR1uO3hjEIhQ=
 github.com/google/trillian v1.2.2-0.20190524132942-bbaabdb62893 h1:y26y8caji3DdlcenfA5E//fjrKZ4tPW5+bwoQYA882M=
 github.com/google/trillian v1.2.2-0.20190524132942-bbaabdb62893/go.mod h1:YPmUVn5NGwgnDUgqlVyFGMTgaWlnSvH7W5p+NdOG8UA=
+github.com/google/trillian v1.2.2-0.20190603160524-0cfa53f919f3 h1:/rXJK62GtZrsjz2a9W2QIUiwN+OCxtWHsXxx3v996i0=
+github.com/google/trillian v1.2.2-0.20190603160524-0cfa53f919f3/go.mod h1:YPmUVn5NGwgnDUgqlVyFGMTgaWlnSvH7W5p+NdOG8UA=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190425150028-36563e24a262 h1:qsl9y/CJx34tuA7QCPNp86JNJe4spst6Ff8MjvPUdPg=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/api v0.5.0 h1:lj9SyhMzyoa38fgFF0oO2T6pjs5IzkLPKfVtxpyCRMM=
 google.golang.org/api v0.5.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=


### PR DESCRIPTION
It's not necessary to fully verify the results from the Trillian Map inside the sequencer because 
this effort is duplicated by clients.

Depends on google/trillian#1647