### PR TITLE
Proposal to refine docker deployment

### DIFF
--- a/cmd/keytransparency-monitor/Dockerfile
+++ b/cmd/keytransparency-monitor/Dockerfile
@@ -1,12 +1,16 @@
-FROM golang:1
+FROM golang:1.12 as build
 
-ADD keytransparency/genfiles/* /kt/
-ADD ./keytransparency /go/src/github.com/google/keytransparency
-ADD ./trillian /go/src/github.com/google/trillian
-WORKDIR /go/src/github.com/google/keytransparency 
+WORKDIR /go/src/github.com/google/keytransparency
+COPY . .
 
+ENV GO111MODULE=on
 RUN go get -tags="mysql" ./cmd/keytransparency-monitor
 
-ENTRYPOINT ["/go/bin/keytransparency-monitor"]
+FROM gcr.io/distroless/base
+
+COPY --from=build /go/bin/keytransparency-monitor /
+ADD ./genfiles/* /kt/
+
+ENTRYPOINT ["/keytransparency-monitor"]
 
 EXPOSE 8099

--- a/cmd/keytransparency-sequencer/Dockerfile
+++ b/cmd/keytransparency-sequencer/Dockerfile
@@ -1,11 +1,14 @@
-FROM golang:1
+FROM golang:1.12 as build
 
-ADD ./keytransparency /go/src/github.com/google/keytransparency
-ADD ./trillian /go/src/github.com/google/trillian
-WORKDIR /go/src/github.com/google/keytransparency 
+WORKDIR /go/src/github.com/google/keytransparency
+COPY . .
 
+ENV GO111MODULE=on
 RUN go get -tags="mysql" ./cmd/keytransparency-sequencer
 
-# Specify mandatory flags via the docker command-line or using docker-compose.
-# See the README.md file on how to use docker-compose.
-ENTRYPOINT ["/go/bin/keytransparency-sequencer"]
+FROM gcr.io/distroless/base
+
+COPY --from=build /go/bin/keytransparency-sequencer /
+ADD ./genfiles/* /kt/
+
+ENTRYPOINT ["/keytransparency-sequencer"]

--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -1,14 +1,16 @@
-FROM golang:1
+FROM golang:1.12 as build
 
-ADD keytransparency/genfiles/* /kt/
-ADD ./keytransparency /go/src/github.com/google/keytransparency
-ADD ./trillian /go/src/github.com/google/trillian
-WORKDIR /go/src/github.com/google/keytransparency 
+WORKDIR /go/src/github.com/google/keytransparency
+COPY . .
 
+ENV GO111MODULE=on
 RUN go get -tags="mysql" ./cmd/keytransparency-server
 
-# Specify mandatory flags via the docker command-line or using docker-compose.
-# See the README.md file on how to use docker-compose.
-ENTRYPOINT ["/go/bin/keytransparency-server"]
+FROM gcr.io/distroless/base
+
+COPY --from=build /go/bin/keytransparency-server /
+ADD ./genfiles/* /kt/
+
+ENTRYPOINT ["/keytransparency-server"]
 
 EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,13 +42,10 @@ services:
       MYSQL_USER: test
       MYSQL_DATABASE: test
 
-  log-server:
+    log-server:
     depends_on:
       - db
-    image: us.gcr.io/key-transparency/log-server:${TRAVIS_COMMIT}
-    build:
-      context: ../trillian
-      dockerfile: examples/deployment/docker/log_server/Dockerfile
+    image: us.gcr.io/trillian/log-server:latest
     restart: always
     command: 
       - --mysql_uri=test:zaphod@tcp(db:3306)/test
@@ -67,10 +64,7 @@ services:
   log-signer:
     depends_on:
       - db
-    image: us.gcr.io/key-transparency/log-signer:${TRAVIS_COMMIT}
-    build:
-      context: ../trillian
-      dockerfile: examples/deployment/docker/log_signer/Dockerfile
+    image: us.gcr.io/trillian/log-signer:latest
     restart: always
     command:
       - --mysql_uri=test:zaphod@tcp(db:3306)/test
@@ -92,10 +86,7 @@ services:
   map-server:
     depends_on:
       - db
-    image: us.gcr.io/key-transparency/map-server:${TRAVIS_COMMIT}
-    build:
-      context: ../trillian
-      dockerfile: examples/deployment/docker/map_server/Dockerfile
+    image: us.gcr.io/trillian/map-server:latest
     restart: always
     command:
       - --mysql_uri=test:zaphod@tcp(db:3306)/test
@@ -118,8 +109,8 @@ services:
       - map-server
     image: us.gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
     build:
-      context: ..
-      dockerfile: ./keytransparency/cmd/keytransparency-server/Dockerfile
+      context: .
+      dockerfile: ./cmd/keytransparency-server/Dockerfile
     restart: always
     ports:
       - "443:8080" # json & grpc
@@ -149,8 +140,8 @@ services:
       - map-server
     image: us.gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}
     build:
-      context: ..
-      dockerfile: ./keytransparency/cmd/keytransparency-sequencer/Dockerfile
+      context: .
+      dockerfile: ./cmd/keytransparency-sequencer/Dockerfile
     restart: always
     command:
       - --force_master
@@ -158,6 +149,8 @@ services:
       - --addr=0.0.0.0:8080
       - --log-url=log-server:8090
       - --map-url=map-server:8090
+      - --tls-key=/kt/server.key
+      - --tls-cert=/kt/server.crt
       - --alsologtostderr
       - --v=5
     ports:
@@ -188,8 +181,8 @@ services:
       - sequencer
     image: us.gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
     build:
-      context: ..
-      dockerfile: ./keytransparency/cmd/keytransparency-monitor/Dockerfile
+      context: .
+      dockerfile: ./cmd/keytransparency-monitor/Dockerfile
     command:
       - --addr=0.0.0.0:8099
       - --kt-url=server:8080


### PR DESCRIPTION
Triggered by my challenges using KeyTransparency's (KT's) docker-compose (#1300)

This is a proposal to streamline the use of docker-compose and the container images.

It will *not* (yet) work as-is.

### 0. CI|CD Key Transparency Server often unavailable

The CI|CD deployment rarely works and the KT server (`35.202.56.9:443`) is generally inaccessible. This makes the need for a user-deployable mechanism more important. The solution for docker-compose exists and is the easiest solution.

### 1. Go Modules

The use of Go Modules (appears to) cause problems with the docker-compose builds. The Dockerfiles were being referenced from `github.com/google` and this directory contains no `go.mod` files. This resulted in issues for the `docker build` commands. Splitting KT and Trillian (see #2) allows the build context to be more appropriately set to `github.com/google/keytransparency` and this does contain a `go.mod` and the issue goes away.

### 2. Disconnect KT and Trillian

Currently KT's docker-compose will rebuild Trillian images as-needed. I think this is too strong a dependency and that -- ideally -- KT should reference "golden" images for the Trillian components through a repository, e.g. `us.gcr.io/trillian/log-server`.

### 3. Switch to [Distroless](https://github.com/GoogleContainerTools/distroless)

Trillian's images are built using Distroless. Recommend switching KT's. This reduces the resulting image sizes and -- as a consequence -- reduces the scope of vulnerabilities.

There is one downside to this. The `distroless/base` image does not include `curl`. The docker-compose healthchecks use `curl` to check endpoints. These no longer work with distroless. An alternative is to add a simple Golang healthcheck that can be included in the Dockerfile and referenced from the Dockerfile and|or docker-compose.

### 4. Sequencer configuration issue

The `sequencer` service configuration did not explicitly `--tls-key` and `--tls-cert` to point to the genfiles mapped to `/kt/` in the container.
