### PR TITLE
Make check-set mutation semantics optional

### DIFF
--- a/core/mutator/entry/mutation.go
+++ b/core/mutator/entry/mutation.go
@@ -27,8 +27,6 @@ import (
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
-var nilHash = sha256.Sum256(nil)
-
 // Mutation provides APIs for manipulating entries.
 type Mutation struct {
 	UserID      string
@@ -49,13 +47,17 @@ func NewMutation(index []byte, directoryID, userID string) *Mutation {
 	return &Mutation{
 		UserID: userID,
 		entry: &pb.Entry{
-			Index:    index,
-			Previous: nilHash[:],
+			Index: index,
 		},
 	}
 }
 
-// SetPrevious sets the previous hash.
+// SetPrevious adds a check-set constraint on the mutation which is useful when performing a get-modify-set operation.
+//
+// If Previous is set, the server will verify that the *current* value matches the Previous hash in this mutation.
+// If the hash is missmatched, the server will not apply the mutation.
+// If Previous is unset, the server will not perform this check.
+//
 // If copyPrevious is true, AuthorizedKeys and Commitment are also copied.
 // oldValueRevision is the map revision that oldValue was fetched at.
 func (m *Mutation) SetPrevious(oldValueRevision uint64, oldValue []byte, copyPrevious bool) error {


### PR DESCRIPTION
The hash chain in user entries is not currently being used.  `Entry.Previous`
was intended to help make account history verification efficient, but it did
not meet that goal.

In the meantime, `Entry.Previous` enforces quite a tight sequence of get,
modify, update.  Any delay in Key Transparency sequencing causes these updates
to fail, and continuously retrying exacerbates the issue.