### PR TITLE
Extract log tracking into separate package 

### DIFF
--- a/core/client/batch_get_and_verify.go
+++ b/core/client/batch_get_and_verify.go
@@ -100,22 +100,19 @@ func (c *Client) BatchVerifyGetUserIndex(ctx context.Context, userIDs []string) 
 // TODO(gbelvin): Verify that the returned map root is indeed the latest map root.
 func (c *Client) BatchVerifiedGetUser(ctx context.Context, userIDs []string) (
 	*types.MapRootV1, map[string]*pb.MapLeaf, error) {
-	c.trustedLock.Lock()
-	defer c.trustedLock.Unlock()
 	resp, err := c.cli.BatchGetUser(ctx, &pb.BatchGetUserRequest{
 		DirectoryId:          c.DirectoryID,
 		UserIds:              userIDs,
-		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
+		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	lr, err := c.VerifyLogRoot(c.trusted, resp.Revision.GetLatestLogRoot())
+	lr, err := c.VerifyLogRoot(resp.Revision.GetLatestLogRoot())
 	if err != nil {
 		return nil, nil, err
 	}
-	c.updateTrusted(lr)
 	smr, err := c.VerifyMapRevision(lr, resp.Revision.GetMapRoot())
 	if err != nil {
 		return nil, nil, err

--- a/core/client/batch_get_and_verify.go
+++ b/core/client/batch_get_and_verify.go
@@ -100,16 +100,17 @@ func (c *Client) BatchVerifyGetUserIndex(ctx context.Context, userIDs []string) 
 // TODO(gbelvin): Verify that the returned map root is indeed the latest map root.
 func (c *Client) BatchVerifiedGetUser(ctx context.Context, userIDs []string) (
 	*types.MapRootV1, map[string]*pb.MapLeaf, error) {
+	logReq := c.LastVerifiedLogRoot()
 	resp, err := c.cli.BatchGetUser(ctx, &pb.BatchGetUserRequest{
 		DirectoryId:          c.DirectoryID,
 		UserIds:              userIDs,
-		LastVerifiedTreeSize: c.LastVerifiedLogRoot().TreeSize,
+		LastVerifiedTreeSize: logReq.TreeSize,
 	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	lr, err := c.VerifyLogRoot(resp.Revision.GetLatestLogRoot())
+	lr, err := c.VerifyLogRoot(logReq, resp.Revision.GetLatestLogRoot())
 	if err != nil {
 		return nil, nil, err
 	}

--- a/core/client/batch_get_and_verify.go
+++ b/core/client/batch_get_and_verify.go
@@ -103,7 +103,7 @@ func (c *Client) BatchVerifiedGetUser(ctx context.Context, userIDs []string) (
 	resp, err := c.cli.BatchGetUser(ctx, &pb.BatchGetUserRequest{
 		DirectoryId:          c.DirectoryID,
 		UserIds:              userIDs,
-		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
+		LastVerifiedTreeSize: c.LastVerifiedLogRoot().TreeSize,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"log"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/google/keytransparency/core/client/verifier"
@@ -71,12 +70,14 @@ var (
 type VerifierInterface interface {
 	// Index computes the index of a userID from a VRF proof, obtained from the server.
 	Index(vrfProof []byte, directoryID, userID string) ([]byte, error)
-	// VerifyMapLeaf verifies everything about a MapLeaf.
-	VerifyMapLeaf(directoryID, userID string, in *pb.MapLeaf, smr *types.MapRootV1) error
+	// LastVerifiedTreeSize retrieves the tree size of the latest verified log root
+	LastVerifiedTreeSize() int64
 	// VerifyLogRoot verifies that revision.LogRoot is consistent with the last trusted SignedLogRoot.
-	VerifyLogRoot(trusted types.LogRootV1, slr *pb.LogRoot) (*types.LogRootV1, error)
+	VerifyLogRoot(slr *pb.LogRoot) (*types.LogRootV1, error)
 	// VerifyMapRevision verifies that the map revision is correctly signed and included in the log.
 	VerifyMapRevision(lr *types.LogRootV1, smr *pb.MapRoot) (*types.MapRootV1, error)
+	// VerifyMapLeaf verifies everything about a MapLeaf.
+	VerifyMapLeaf(directoryID, userID string, in *pb.MapLeaf, smr *types.MapRootV1) error
 	//
 	// Pair Verifiers
 	//
@@ -113,8 +114,6 @@ type Client struct {
 	DirectoryID string
 	reduce      ReduceMutationFn
 	RetryDelay  time.Duration
-	trusted     types.LogRootV1
-	trustedLock sync.Mutex
 }
 
 // NewFromConfig creates a new client from a config
@@ -143,20 +142,6 @@ func New(ktClient pb.KeyTransparencyClient,
 		reduce:            entry.ReduceFn,
 		RetryDelay:        retryDelay,
 	}
-}
-
-// updateTrusted sets the local reference for the latest SignedLogRoot if
-// newTrusted is correctly signed and newer than the current stored root.
-// updateTrusted should be called while c.trustedLock has been acquired.
-func (c *Client) updateTrusted(newTrusted *types.LogRootV1) {
-	if newTrusted.TimestampNanos <= c.trusted.TimestampNanos ||
-		newTrusted.TreeSize < c.trusted.TreeSize {
-		// Valid root, but it's older than the one we currently have.
-		return
-	}
-	c.trusted = *newTrusted
-	glog.Infof("Trusted root updated to TreeSize %v", c.trusted.TreeSize)
-	Vlog.Printf("✓ Log root updated.")
 }
 
 // GetUser returns an entry if it exists, and nil if it does not.

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -68,12 +68,9 @@ var (
 
 // VerifierInterface is used to verify specific outputs from Key Transparency.
 type VerifierInterface interface {
+	verifier.LogTracker
 	// Index computes the index of a userID from a VRF proof, obtained from the server.
 	Index(vrfProof []byte, directoryID, userID string) ([]byte, error)
-	// LastVerifiedTreeSize retrieves the tree size of the latest verified log root
-	LastVerifiedTreeSize() int64
-	// VerifyLogRoot verifies that revision.LogRoot is consistent with the last trusted SignedLogRoot.
-	VerifyLogRoot(slr *pb.LogRoot) (*types.LogRootV1, error)
 	// VerifyMapRevision verifies that the map revision is correctly signed and included in the log.
 	VerifyMapRevision(lr *types.LogRootV1, smr *pb.MapRoot) (*types.MapRootV1, error)
 	// VerifyMapLeaf verifies everything about a MapLeaf.

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -80,9 +80,9 @@ type VerifierInterface interface {
 	//
 
 	// VerifyGetUser verifies the request and response to the GetUser API.
-	VerifyGetUser(trusted types.LogRootV1, req *pb.GetUserRequest, resp *pb.GetUserResponse) error
+	VerifyGetUser(logReq *pb.LogRootRequest, req *pb.GetUserRequest, resp *pb.GetUserResponse) error
 	// VerifyBatchGetUser verifies the request and response to the BatchGetUser API.
-	VerifyBatchGetUser(trusted types.LogRootV1, req *pb.BatchGetUserRequest, resp *pb.BatchGetUserResponse) error
+	VerifyBatchGetUser(logReq *pb.LogRootRequest, req *pb.BatchGetUserRequest, resp *pb.BatchGetUserResponse) error
 }
 
 // ReduceMutationFn takes all the mutations for an index and an auxiliary input

--- a/core/client/client_test.go
+++ b/core/client/client_test.go
@@ -307,8 +307,8 @@ func (f *fakeVerifier) Index(vrfProof []byte, directoryID, userID string) ([]byt
 	return make([]byte, 32), nil
 }
 
-func (f *fakeVerifier) LastVerifiedTreeSize() int64 {
-	return 0
+func (f *fakeVerifier) LastVerifiedLogRoot() *pb.LogRootRequest {
+	return &pb.LogRootRequest{}
 }
 
 func (f *fakeVerifier) VerifyLogRoot(slr *pb.LogRoot) (*types.LogRootV1, error) {

--- a/core/client/client_test.go
+++ b/core/client/client_test.go
@@ -311,7 +311,7 @@ func (f *fakeVerifier) LastVerifiedLogRoot() *pb.LogRootRequest {
 	return &pb.LogRootRequest{}
 }
 
-func (f *fakeVerifier) VerifyLogRoot(slr *pb.LogRoot) (*types.LogRootV1, error) {
+func (f *fakeVerifier) VerifyLogRoot(req *pb.LogRootRequest, slr *pb.LogRoot) (*types.LogRootV1, error) {
 	return &types.LogRootV1{}, nil
 }
 

--- a/core/client/client_test.go
+++ b/core/client/client_test.go
@@ -307,17 +307,21 @@ func (f *fakeVerifier) Index(vrfProof []byte, directoryID, userID string) ([]byt
 	return make([]byte, 32), nil
 }
 
-func (f *fakeVerifier) VerifyMapLeaf(directoryID, userID string,
-	in *pb.MapLeaf, smr *types.MapRootV1) error {
-	return nil
+func (f *fakeVerifier) LastVerifiedTreeSize() int64 {
+	return 0
 }
 
-func (f *fakeVerifier) VerifyLogRoot(trusted types.LogRootV1, slr *pb.LogRoot) (*types.LogRootV1, error) {
+func (f *fakeVerifier) VerifyLogRoot(slr *pb.LogRoot) (*types.LogRootV1, error) {
 	return &types.LogRootV1{}, nil
 }
 
 func (f *fakeVerifier) VerifyMapRevision(logRoot *types.LogRootV1, smr *pb.MapRoot) (*types.MapRootV1, error) {
 	return &types.MapRootV1{Revision: uint64(smr.MapRoot.MapRoot[0])}, nil
+}
+
+func (f *fakeVerifier) VerifyMapLeaf(directoryID, userID string,
+	in *pb.MapLeaf, smr *types.MapRootV1) error {
+	return nil
 }
 
 func (f *fakeVerifier) VerifyGetUser(trusted types.LogRootV1, req *pb.GetUserRequest, resp *pb.GetUserResponse) error {

--- a/core/client/client_test.go
+++ b/core/client/client_test.go
@@ -324,10 +324,10 @@ func (f *fakeVerifier) VerifyMapLeaf(directoryID, userID string,
 	return nil
 }
 
-func (f *fakeVerifier) VerifyGetUser(trusted types.LogRootV1, req *pb.GetUserRequest, resp *pb.GetUserResponse) error {
+func (f *fakeVerifier) VerifyGetUser(logReq *pb.LogRootRequest, req *pb.GetUserRequest, resp *pb.GetUserResponse) error {
 	return nil
 }
 
-func (f *fakeVerifier) VerifyBatchGetUser(trusted types.LogRootV1, req *pb.BatchGetUserRequest, resp *pb.BatchGetUserResponse) error {
+func (f *fakeVerifier) VerifyBatchGetUser(logReq *pb.LogRootRequest, req *pb.BatchGetUserRequest, resp *pb.BatchGetUserResponse) error {
 	return nil
 }

--- a/core/client/get_and_verify.go
+++ b/core/client/get_and_verify.go
@@ -29,7 +29,7 @@ func (c *Client) VerifiedGetUser(ctx context.Context, userID string) (*types.Map
 	req := &pb.GetUserRequest{
 		DirectoryId:          c.DirectoryID,
 		UserId:               userID,
-		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
+		LastVerifiedTreeSize: c.LastVerifiedLogRoot().TreeSize,
 	}
 	resp, err := c.cli.GetUser(ctx, req)
 	if err != nil {
@@ -57,7 +57,7 @@ func (c *Client) VerifiedGetUser(ctx context.Context, userID string) (*types.Map
 func (c *Client) VerifiedGetLatestRevision(ctx context.Context) (*types.LogRootV1, *types.MapRootV1, error) {
 	resp, err := c.cli.GetLatestRevision(ctx, &pb.GetLatestRevisionRequest{
 		DirectoryId:          c.DirectoryID,
-		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
+		LastVerifiedTreeSize: c.LastVerifiedLogRoot().TreeSize,
 	})
 	if err != nil {
 		return nil, nil, err
@@ -91,7 +91,7 @@ func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*type
 	req := &pb.GetRevisionRequest{
 		DirectoryId:          c.DirectoryID,
 		Revision:             revision,
-		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
+		LastVerifiedTreeSize: c.LastVerifiedLogRoot().TreeSize,
 	}
 	resp, err := c.cli.GetRevision(ctx, req)
 	if err != nil {
@@ -116,7 +116,7 @@ func (c *Client) VerifiedListHistory(ctx context.Context, userID string, start i
 	resp, err := c.cli.ListEntryHistory(ctx, &pb.ListEntryHistoryRequest{
 		DirectoryId:          c.DirectoryID,
 		UserId:               userID,
-		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
+		LastVerifiedTreeSize: c.LastVerifiedLogRoot().TreeSize,
 		Start:                start,
 		PageSize:             count,
 	})

--- a/core/client/get_and_verify.go
+++ b/core/client/get_and_verify.go
@@ -26,23 +26,20 @@ import (
 
 // VerifiedGetUser fetches and verifies the results of GetUser.
 func (c *Client) VerifiedGetUser(ctx context.Context, userID string) (*types.MapRootV1, *pb.MapLeaf, error) {
-	c.trustedLock.Lock()
-	defer c.trustedLock.Unlock()
 	req := &pb.GetUserRequest{
 		DirectoryId:          c.DirectoryID,
 		UserId:               userID,
-		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
+		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
 	}
 	resp, err := c.cli.GetUser(ctx, req)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	lr, err := c.VerifyLogRoot(c.trusted, resp.Revision.GetLatestLogRoot())
+	lr, err := c.VerifyLogRoot(resp.Revision.GetLatestLogRoot())
 	if err != nil {
 		return nil, nil, err
 	}
-	c.updateTrusted(lr)
 	mr, err := c.VerifyMapRevision(lr, resp.Revision.GetMapRoot())
 	if err != nil {
 		return nil, nil, err
@@ -58,23 +55,18 @@ func (c *Client) VerifiedGetUser(ctx context.Context, userID string) (*types.Map
 // It also verifies the consistency from the last seen revision.
 // Returns the latest log root and the latest map root.
 func (c *Client) VerifiedGetLatestRevision(ctx context.Context) (*types.LogRootV1, *types.MapRootV1, error) {
-	// Only one method should attempt to update the trusted root at time.
-	c.trustedLock.Lock()
-	defer c.trustedLock.Unlock()
-
 	resp, err := c.cli.GetLatestRevision(ctx, &pb.GetLatestRevisionRequest{
 		DirectoryId:          c.DirectoryID,
-		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
+		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
 	})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	lr, err := c.VerifyLogRoot(c.trusted, resp.GetLatestLogRoot())
+	lr, err := c.VerifyLogRoot(resp.GetLatestLogRoot())
 	if err != nil {
 		return nil, nil, err
 	}
-	c.updateTrusted(lr)
 	mr, err := c.VerifyMapRevision(lr, resp.GetMapRoot())
 	if err != nil {
 		return nil, nil, err
@@ -96,24 +88,20 @@ func (c *Client) VerifiedGetLatestRevision(ctx context.Context) (*types.LogRootV
 // It also verifies the consistency of the latest log root against the last seen log root.
 // Returns the requested map root.
 func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*types.MapRootV1, error) {
-	// Only one method should attempt to update the trusted root at time.
-	c.trustedLock.Lock()
-	defer c.trustedLock.Unlock()
-
-	resp, err := c.cli.GetRevision(ctx, &pb.GetRevisionRequest{
+	req := &pb.GetRevisionRequest{
 		DirectoryId:          c.DirectoryID,
 		Revision:             revision,
-		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
-	})
+		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
+	}
+	resp, err := c.cli.GetRevision(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
-	lr, err := c.VerifyLogRoot(c.trusted, resp.GetLatestLogRoot())
+	lr, err := c.VerifyLogRoot(resp.GetLatestLogRoot())
 	if err != nil {
 		return nil, err
 	}
-	c.updateTrusted(lr)
 	mr, err := c.VerifyMapRevision(lr, resp.GetMapRoot())
 	if err != nil {
 		return nil, err
@@ -125,12 +113,10 @@ func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*type
 // VerifiedListHistory performs one list history operation, verifies and returns the results.
 func (c *Client) VerifiedListHistory(ctx context.Context, userID string, start int64, count int32) (
 	map[*types.MapRootV1][]byte, int64, error) {
-	c.trustedLock.Lock()
-	defer c.trustedLock.Unlock()
 	resp, err := c.cli.ListEntryHistory(ctx, &pb.ListEntryHistoryRequest{
 		DirectoryId:          c.DirectoryID,
 		UserId:               userID,
-		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
+		LastVerifiedTreeSize: c.LastVerifiedTreeSize(),
 		Start:                start,
 		PageSize:             count,
 	})
@@ -144,11 +130,10 @@ func (c *Client) VerifiedListHistory(ctx context.Context, userID string, start i
 	profiles := make(map[*types.MapRootV1][]byte)
 	for _, v := range resp.GetValues() {
 		if lr == nil {
-			lr, err = c.VerifyLogRoot(c.trusted, v.GetRevision().GetLatestLogRoot())
+			lr, err = c.VerifyLogRoot(v.GetRevision().GetLatestLogRoot())
 			if err != nil {
 				return nil, 0, err
 			}
-			c.updateTrusted(lr)
 		}
 		mr, err := c.VerifyMapRevision(lr, v.GetRevision().GetMapRoot())
 		if err != nil {

--- a/core/client/tracker/tracker.go
+++ b/core/client/tracker/tracker.go
@@ -32,8 +32,14 @@ type LogTracker struct {
 	v       *tclient.LogVerifier
 }
 
+// New creates a log tracker from no trusted root.
 func New(lv *tclient.LogVerifier) *LogTracker {
 	return &LogTracker{v: lv}
+}
+
+// NewFromSaved creates a log tracker from a previously saved trusted root.
+func NewFromSaved(lv *tclient.LogVerifier, lr types.LogRootV1) *LogTracker {
+	return &LogTracker{v: lv, trusted: lr}
 }
 
 // LastVerifiedTreeSize retrieves the tree size of the latest log root

--- a/core/client/tracker/tracker.go
+++ b/core/client/tracker/tracker.go
@@ -42,11 +42,14 @@ func NewFromSaved(lv *tclient.LogVerifier, lr types.LogRootV1) *LogTracker {
 	return &LogTracker{v: lv, trusted: lr}
 }
 
-// LastVerifiedTreeSize retrieves the tree size of the latest log root
+// LastVerifiedLogRoot retrieves the tree size of the latest log root
 // and it blocks further requests until VerifyRoot is called.
-func (l *LogTracker) LastVerifiedTreeSize() int64 {
+func (l *LogTracker) LastVerifiedLogRoot() *pb.LogRootRequest {
 	l.mu.Lock()
-	return int64(l.trusted.TreeSize)
+	return &pb.LogRootRequest{
+		TreeSize: int64(l.trusted.TreeSize),
+		RootHash: l.trusted.RootHash,
+	}
 }
 
 // VerifyLogRoot verifies root and updates the trusted root if it is newer.

--- a/core/client/tracker/tracker.go
+++ b/core/client/tracker/tracker.go
@@ -49,10 +49,10 @@ func (l *LogTracker) LastVerifiedTreeSize() int64 {
 	return int64(l.trusted.TreeSize)
 }
 
-// VerifyRoot verifies root and updates the trusted root if it is newer.
-// VerifyRoot unblocks the next call to LastVerifiedTreeSize.
+// VerifyLogRoot verifies root and updates the trusted root if it is newer.
+// VerifyLogRoot unblocks the next call to LastVerifiedTreeSize.
 // It is a run-time error if LastVerifiedTreeSize has not previously been called.
-func (l *LogTracker) VerifyRoot(root *pb.LogRoot) (*types.LogRootV1, error) {
+func (l *LogTracker) VerifyLogRoot(root *pb.LogRoot) (*types.LogRootV1, error) {
 	defer l.mu.Unlock()
 	logRoot, err := l.v.VerifyRoot(&l.trusted,
 		root.GetLogRoot(),

--- a/core/client/tracker/tracker.go
+++ b/core/client/tracker/tracker.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package tracker tracks log roots verifies consistency proofs between them.
+// Package tracker tracks log roots and verifies consistency proofs between them.
 package tracker
 
 import (

--- a/core/client/tracker/tracker.go
+++ b/core/client/tracker/tracker.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tracker verifies consistency proofs
+package tracker
+
+import (
+	"sync"
+
+	"github.com/golang/glog"
+	"github.com/google/trillian/types"
+
+	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+	tclient "github.com/google/trillian/client"
+)
+
+// LogTracker keeps a continuous series of consistent log roots.
+type LogTracker struct {
+	trusted types.LogRootV1
+	mu      sync.Mutex
+	v       *tclient.LogVerifier
+}
+
+func New(lv *tclient.LogVerifier) *LogTracker {
+	return &LogTracker{v: lv}
+}
+
+// LastVerifiedTreeSize retrieves the tree size of the latest log root
+// and it blocks further requests until VerifyRoot is called.
+func (l *LogTracker) LastVerifiedTreeSize() int64 {
+	l.mu.Lock()
+	return int64(l.trusted.TreeSize)
+}
+
+// VerifyRoot verifies root and updates the trusted root if it is newer.
+// VerifyRoot unblocks the next call to LastVerifiedTreeSize.
+// It is a run-time error if LastVerifiedTreeSize has not previously been called.
+func (l *LogTracker) VerifyRoot(root *pb.LogRoot) (*types.LogRootV1, error) {
+	defer l.mu.Unlock()
+	logRoot, err := l.v.VerifyRoot(&l.trusted,
+		root.GetLogRoot(),
+		root.GetLogConsistency())
+	if err != nil {
+		return nil, err
+	}
+	l.updateTrusted(logRoot)
+	return logRoot, nil
+}
+
+// updateTrusted sets the local reference for the latest SignedLogRoot
+// if newTrusted is newer than the current stored root.
+func (l *LogTracker) updateTrusted(newRoot *types.LogRootV1) bool {
+	if newRoot.TimestampNanos <= l.trusted.TimestampNanos ||
+		newRoot.TreeSize < l.trusted.TreeSize {
+		// The new root is older than the one we currently have.
+		return false
+	}
+	l.trusted = *newRoot
+	glog.Infof("Trusted root updated to TreeSize %v", l.trusted.TreeSize)
+	return true
+}

--- a/core/client/tracker/tracker.go
+++ b/core/client/tracker/tracker.go
@@ -23,27 +23,32 @@ import (
 	"github.com/google/trillian/types"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
-	tclient "github.com/google/trillian/client"
+	tpb "github.com/google/trillian"
 )
 
 // UpdateTrustedPredicate return a bool indicating whether the local reference
 // for the latest SignedLogRoot should be updated.
 type UpdateTrustedPredicate func(cntRoot, newRoot types.LogRootV1) bool
 
+// LogRootVerifier verifies trillian Log Root.
+type LogRootVerifier interface {
+	VerifyRoot(trusted *types.LogRootV1, newRoot *tpb.SignedLogRoot, consistency [][]byte) (*types.LogRootV1, error)
+}
+
 // LogTracker keeps a continuous series of consistent log roots.
 type LogTracker struct {
 	trusted       types.LogRootV1
-	v             *tclient.LogVerifier
+	v             LogRootVerifier
 	updateTrusted UpdateTrustedPredicate
 }
 
 // New creates a log tracker from no trusted root.
-func New(lv *tclient.LogVerifier) *LogTracker {
+func New(lv LogRootVerifier) *LogTracker {
 	return NewFromSaved(lv, types.LogRootV1{})
 }
 
 // NewFromSaved creates a log tracker from a previously saved trusted root.
-func NewFromSaved(lv *tclient.LogVerifier, lr types.LogRootV1) *LogTracker {
+func NewFromSaved(lv LogRootVerifier, lr types.LogRootV1) *LogTracker {
 	return &LogTracker{v: lv, trusted: lr, updateTrusted: isNewer}
 }
 

--- a/core/client/tracker/tracker_test.go
+++ b/core/client/tracker/tracker_test.go
@@ -17,20 +17,68 @@ package tracker
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/trillian/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	tpb "github.com/google/trillian"
 )
 
 func TestVerifyLogRoot(t *testing.T) {
+	type rpc struct {
+		req      *pb.LogRootRequest
+		resp     *pb.LogRoot
+		want     types.LogRootV1
+		wantCode codes.Code
+	}
+
 	for _, tc := range []struct {
-		desc string
+		desc  string
+		saved types.LogRootV1
+		rpcs  []rpc
 	}{
-		{desc: "Simple"},
+		{desc: "nil req", rpcs: []rpc{{wantCode: codes.InvalidArgument}}},
+		{desc: "empty root", rpcs: []rpc{{req: &pb.LogRootRequest{}, resp: mustSignLogRoot(t, types.LogRootV1{})}}},
+		{desc: "1 rpc", rpcs: []rpc{{req: &pb.LogRootRequest{}, resp: mustSignLogRoot(t, types.LogRootV1{TreeSize: 1})}}},
+		{desc: "2 rpc invalid", rpcs: []rpc{
+			{req: &pb.LogRootRequest{}, resp: mustSignLogRoot(t, types.LogRootV1{TreeSize: 1})},
+			{req: &pb.LogRootRequest{}, resp: mustSignLogRoot(t, types.LogRootV1{TreeSize: 2}), wantCode: codes.InvalidArgument},
+		}},
+		{desc: "2 rpc", rpcs: []rpc{
+			{req: &pb.LogRootRequest{}, resp: mustSignLogRoot(t, types.LogRootV1{TreeSize: 1})},
+			{req: &pb.LogRootRequest{TreeSize: 1}, resp: mustSignLogRoot(t, types.LogRootV1{TreeSize: 2})},
+		}},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			lt := New(&fakeLogVerifier{})
+			lt := NewFromSaved(&fakeLogVerifier{}, tc.saved)
+			for _, r := range tc.rpcs {
+				got, err := lt.VerifyLogRoot(r.req, r.resp)
+				if got := status.Code(err); got != r.wantCode {
+					t.Errorf("VerifyLogRoot(): %v (%v), want %v", err, got, r.wantCode)
+				}
+				if err != nil {
+					continue
+				}
+				if cmp.Equal(*got, r.want) {
+					t.Errorf("VerifyLogRoot(): %v, want %v", got, r.want)
+				}
+			}
 		})
+	}
+}
+
+func mustSignLogRoot(t *testing.T, lr types.LogRootV1) *pb.LogRoot {
+	t.Helper()
+	logRoot, err := lr.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &pb.LogRoot{
+		LogRoot: &tpb.SignedLogRoot{
+			LogRoot: logRoot,
+		},
 	}
 }
 
@@ -38,7 +86,7 @@ type fakeLogVerifier struct{}
 
 func (*fakeLogVerifier) VerifyRoot(trusted *types.LogRootV1, r *tpb.SignedLogRoot, consistency [][]byte) (*types.LogRootV1, error) {
 	var logRoot types.LogRootV1
-	if err := logRoot.UnmarshalBinary(r.LogRoot); err != nil {
+	if err := logRoot.UnmarshalBinary(r.GetLogRoot()); err != nil {
 		return nil, err
 	}
 	return &logRoot, nil

--- a/core/client/tracker/tracker_test.go
+++ b/core/client/tracker/tracker_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tracker
+
+import (
+	"testing"
+
+	"github.com/google/trillian/types"
+
+	tpb "github.com/google/trillian"
+)
+
+func TestVerifyLogRoot(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+	}{
+		{desc: "Simple"},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			lt := New(&fakeLogVerifier{})
+		})
+	}
+}
+
+type fakeLogVerifier struct{}
+
+func (*fakeLogVerifier) VerifyRoot(trusted *types.LogRootV1, r *tpb.SignedLogRoot, consistency [][]byte) (*types.LogRootV1, error) {
+	var logRoot types.LogRootV1
+	if err := logRoot.UnmarshalBinary(r.LogRoot); err != nil {
+		return nil, err
+	}
+	return &logRoot, nil
+}

--- a/core/client/verifier/pairs.go
+++ b/core/client/verifier/pairs.go
@@ -15,14 +15,12 @@
 package verifier
 
 import (
-	"github.com/google/trillian/types"
-
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
 // VerifyGetUser verifies that the retrieved profile of userID is correct.
-func (v *Verifier) VerifyGetUser(trusted types.LogRootV1, req *pb.GetUserRequest, resp *pb.GetUserResponse) error {
-	lr, err := v.VerifyLogRoot(trusted, resp.Revision.GetLatestLogRoot())
+func (v *Verifier) VerifyGetUser(logReq *pb.LogRootRequest, req *pb.GetUserRequest, resp *pb.GetUserResponse) error {
+	lr, err := v.VerifyLogRoot(logReq, resp.Revision.GetLatestLogRoot())
 	if err != nil {
 		return err
 	}
@@ -34,8 +32,8 @@ func (v *Verifier) VerifyGetUser(trusted types.LogRootV1, req *pb.GetUserRequest
 }
 
 // VerifyBatchGetUser verifies that the retrieved profiles are correct.
-func (v *Verifier) VerifyBatchGetUser(trusted types.LogRootV1, req *pb.BatchGetUserRequest, resp *pb.BatchGetUserResponse) error {
-	lr, err := v.VerifyLogRoot(trusted, resp.Revision.GetLatestLogRoot())
+func (v *Verifier) VerifyBatchGetUser(logReq *pb.LogRootRequest, req *pb.BatchGetUserRequest, resp *pb.BatchGetUserResponse) error {
+	lr, err := v.VerifyLogRoot(logReq, resp.Revision.GetLatestLogRoot())
 	if err != nil {
 		return err
 	}

--- a/core/client/verifier/verifier.go
+++ b/core/client/verifier/verifier.go
@@ -47,7 +47,7 @@ var (
 
 type LogTracker interface {
 	LastVerifiedLogRoot() *pb.LogRootRequest
-	VerifyLogRoot(root *pb.LogRoot) (*types.LogRootV1, error)
+	VerifyLogRoot(req *pb.LogRootRequest, root *pb.LogRoot) (*types.LogRootV1, error)
 }
 
 // Verifier is a client helper library for verifying request and responses.
@@ -168,10 +168,10 @@ func (v *Verifier) LastVerifiedLogRoot() *pb.LogRootRequest {
 }
 
 // VerifyLogRoot verifies that revision.LogRoot is consistent with the last trusted SignedLogRoot.
-func (v *Verifier) VerifyLogRoot(slr *pb.LogRoot) (*types.LogRootV1, error) {
+func (v *Verifier) VerifyLogRoot(req *pb.LogRootRequest, slr *pb.LogRoot) (*types.LogRootV1, error) {
 	// Verify consistency proof between root and newroot.
 	// TODO(gdbelvin): Gossip root.
-	return v.lt.VerifyLogRoot(slr)
+	return v.lt.VerifyLogRoot(req, slr)
 }
 
 // VerifyMapRevision verifies that the map revision is correctly signed and included in the append only log.

--- a/core/client/verifier/verifier.go
+++ b/core/client/verifier/verifier.go
@@ -25,6 +25,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/google/trillian/types"
 	"github.com/kr/pretty"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/google/keytransparency/core/client/tracker"
 	"github.com/google/keytransparency/core/crypto/commitments"
@@ -106,6 +108,9 @@ func (v *Verifier) Index(vrfProof []byte, directoryID, userID string) ([]byte, e
 //  - Verify map inclusion proof.
 func (v *Verifier) VerifyMapLeaf(directoryID, userID string,
 	in *pb.MapLeaf, mapRoot *types.MapRootV1) error {
+	if mapRoot == nil {
+		return status.Errorf(codes.Internal, "nil MapRoot")
+	}
 	glog.V(5).Infof("VerifyMapLeaf(%v/%v): %# v", directoryID, userID, pretty.Formatter(in))
 
 	// Unpack the merkle tree leaf value.

--- a/core/client/verifier/verifier.go
+++ b/core/client/verifier/verifier.go
@@ -46,7 +46,7 @@ var (
 )
 
 type LogTracker interface {
-	LastVerifiedTreeSize() int64
+	LastVerifiedLogRoot() *pb.LogRootRequest
 	VerifyLogRoot(root *pb.LogRoot) (*types.LogRootV1, error)
 }
 
@@ -163,8 +163,8 @@ func (v *Verifier) VerifyMapLeaf(directoryID, userID string,
 	return nil
 }
 
-func (v *Verifier) LastVerifiedTreeSize() int64 {
-	return v.lt.LastVerifiedTreeSize()
+func (v *Verifier) LastVerifiedLogRoot() *pb.LogRootRequest {
+	return v.lt.LastVerifiedLogRoot()
 }
 
 // VerifyLogRoot verifies that revision.LogRoot is consistent with the last trusted SignedLogRoot.

--- a/core/client/verifier/verifier.go
+++ b/core/client/verifier/verifier.go
@@ -47,7 +47,7 @@ var (
 
 type LogTracker interface {
 	LastVerifiedTreeSize() int64
-	VerifyRoot(root *pb.LogRoot) (*types.LogRootV1, error)
+	VerifyLogRoot(root *pb.LogRoot) (*types.LogRootV1, error)
 }
 
 // Verifier is a client helper library for verifying request and responses.
@@ -171,7 +171,7 @@ func (v *Verifier) LastVerifiedTreeSize() int64 {
 func (v *Verifier) VerifyLogRoot(slr *pb.LogRoot) (*types.LogRootV1, error) {
 	// Verify consistency proof between root and newroot.
 	// TODO(gdbelvin): Gossip root.
-	return v.lt.VerifyRoot(slr)
+	return v.lt.VerifyLogRoot(slr)
 }
 
 // VerifyMapRevision verifies that the map revision is correctly signed and included in the append only log.

--- a/core/client/verifier/verifier.go
+++ b/core/client/verifier/verifier.go
@@ -45,12 +45,15 @@ var (
 	ErrNilProof = errors.New("nil proof")
 )
 
+// LogTracker tracks a series of consistent log roots.
 type LogTracker interface {
+	// LastVerifiedLogRoot retrieves the tree size of the latest log root.
 	LastVerifiedLogRoot() *pb.LogRootRequest
+	// VerifyLogRoot verifies root and updates the trusted root if it is newer.
 	VerifyLogRoot(req *pb.LogRootRequest, root *pb.LogRoot) (*types.LogRootV1, error)
 }
 
-// Verifier is a client helper library for verifying request and responses.
+// Verifier is a client helper library for verifying requests and responses.
 type Verifier struct {
 	vrf     vrf.PublicKey
 	mv      *tclient.MapVerifier

--- a/core/client/verifier/verifier.go
+++ b/core/client/verifier/verifier.go
@@ -50,7 +50,7 @@ type LogTracker interface {
 	// LastVerifiedLogRoot retrieves the tree size of the latest log root.
 	LastVerifiedLogRoot() *pb.LogRootRequest
 	// VerifyLogRoot verifies root and updates the trusted root if it is newer.
-	VerifyLogRoot(req *pb.LogRootRequest, root *pb.LogRoot) (*types.LogRootV1, error)
+	VerifyLogRoot(state *pb.LogRootRequest, newRoot *pb.LogRoot) (*types.LogRootV1, error)
 }
 
 // Verifier is a client helper library for verifying requests and responses.

--- a/core/client/verifier/verifier_test.go
+++ b/core/client/verifier/verifier_test.go
@@ -17,6 +17,7 @@ package verifier
 import (
 	"testing"
 
+	"github.com/google/keytransparency/core/client/tracker"
 	"github.com/google/keytransparency/core/testdata"
 	"github.com/google/trillian/types"
 
@@ -49,12 +50,13 @@ func RunTranscriptTest(t *testing.T, transcript *tpb.Transcript) {
 
 	for _, rpc := range transcript.Actions {
 		t.Run(rpc.Desc, func(t *testing.T) {
-			trusted := types.LogRootV1{
+			v.lt = tracker.NewFromSaved(v.lv, types.LogRootV1{
 				TreeSize: uint64(rpc.LastVerifiedLogRoot.GetTreeSize()),
 				RootHash: rpc.LastVerifiedLogRoot.GetRootHash(),
-			}
+			})
 			switch pair := rpc.ReqRespPair.(type) {
 			case *tpb.Action_GetUser:
+				v.LastVerifiedTreeSize()
 				if err := v.VerifyGetUser(trusted, pair.GetUser.Request, pair.GetUser.Response); err != nil {
 					t.Errorf("VerifyGetUser(): %v", err)
 				}

--- a/core/client/verifier/verifier_test.go
+++ b/core/client/verifier/verifier_test.go
@@ -56,7 +56,7 @@ func RunTranscriptTest(t *testing.T, transcript *tpb.Transcript) {
 			})
 			switch pair := rpc.ReqRespPair.(type) {
 			case *tpb.Action_GetUser:
-				v.LastVerifiedTreeSize()
+				v.LastVerifiedLogRoot()
 				if err := v.VerifyGetUser(trusted, pair.GetUser.Request, pair.GetUser.Response); err != nil {
 					t.Errorf("VerifyGetUser(): %v", err)
 				}

--- a/core/client/verifier/verifier_test.go
+++ b/core/client/verifier/verifier_test.go
@@ -56,8 +56,8 @@ func RunTranscriptTest(t *testing.T, transcript *tpb.Transcript) {
 			})
 			switch pair := rpc.ReqRespPair.(type) {
 			case *tpb.Action_GetUser:
-				v.LastVerifiedLogRoot()
-				if err := v.VerifyGetUser(trusted, pair.GetUser.Request, pair.GetUser.Response); err != nil {
+				logReq := v.LastVerifiedLogRoot()
+				if err := v.VerifyGetUser(logReq, pair.GetUser.Request, pair.GetUser.Response); err != nil {
 					t.Errorf("VerifyGetUser(): %v", err)
 				}
 

--- a/core/integration/client_tests.go
+++ b/core/integration/client_tests.go
@@ -210,6 +210,7 @@ func TestEmptyGetAndUpdate(ctx context.Context, env *Env, t *testing.T) []*tpb.A
 
 	cli, logTracker := NewClientWithTracker(t, env)
 	logTracker.SetUpdatePredicate(func(_, newRoot types.LogRootV1) bool {
+		// Only update occasionally in order to produce interesting consistency proofs.
 		return newRoot.TreeSize%5 == 1
 	})
 
@@ -354,6 +355,7 @@ func TestBatchGetUser(ctx context.Context, env *Env, t *testing.T) []*tpb.Action
 
 	cli, logTracker := NewClientWithTracker(t, env)
 	logTracker.SetUpdatePredicate(func(_, newRoot types.LogRootV1) bool {
+		// Only update occasionally in order to produce interesting consistency proofs.
 		return newRoot.TreeSize%5 == 1
 	})
 

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -19,13 +19,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/google/keytransparency/core/client"
 	"github.com/google/keytransparency/core/monitorstorage"
 	"github.com/google/trillian"
-
 	"github.com/google/trillian/types"
-
-	"github.com/golang/glog"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	tclient "github.com/google/trillian/client"


### PR DESCRIPTION
This PR isolates root tracking inside a new `tracker` package. 
By putting all root tracking behind an interface, we can implement alternate, multi-threaded root trackers.  #1311 
