### PR TITLE
 Split VerifyRevision into Verify{LogRoot,MapRevision

### DIFF
--- a/core/client/batch_get_and_verify.go
+++ b/core/client/batch_get_and_verify.go
@@ -111,11 +111,15 @@ func (c *Client) BatchVerifiedGetUser(ctx context.Context, userIDs []string) (
 		return nil, nil, err
 	}
 
-	slr, smr, err := c.VerifyRevision(resp.Revision, c.trusted)
+	lr, err := c.VerifyLogRoot(c.trusted, resp.Revision.GetLatestLogRoot())
 	if err != nil {
 		return nil, nil, err
 	}
-	c.updateTrusted(slr)
+	c.updateTrusted(lr)
+	smr, err := c.VerifyMapRevision(lr, resp.Revision.GetMapRoot())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	leavesByUserID := make(map[string]*pb.MapLeaf)
 	for userID, leaf := range resp.MapLeavesByUserId {

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -73,9 +73,10 @@ type VerifierInterface interface {
 	Index(vrfProof []byte, directoryID, userID string) ([]byte, error)
 	// VerifyMapLeaf verifies everything about a MapLeaf.
 	VerifyMapLeaf(directoryID, userID string, in *pb.MapLeaf, smr *types.MapRootV1) error
-	// VerifyRevision verifies that revision is correctly signed and included in the append only log.
-	// VerifyRevision also verifies that revision.LogRoot is consistent with the last trusted SignedLogRoot.
-	VerifyRevision(revision *pb.Revision, trusted types.LogRootV1) (*types.LogRootV1, *types.MapRootV1, error)
+	// VerifyLogRoot verifies that revision.LogRoot is consistent with the last trusted SignedLogRoot.
+	VerifyLogRoot(trusted types.LogRootV1, slr *pb.LogRoot) (*types.LogRootV1, error)
+	// VerifyMapRevision verifies that the map revision is correctly signed and included in the log.
+	VerifyMapRevision(lr *types.LogRootV1, smr *pb.MapRoot) (*types.MapRootV1, error)
 }
 
 // ReduceMutationFn takes all the mutations for an index and an auxiliary input

--- a/core/client/client_test.go
+++ b/core/client/client_test.go
@@ -312,11 +312,10 @@ func (f *fakeVerifier) VerifyMapLeaf(directoryID, userID string,
 	return nil
 }
 
-func (f *fakeVerifier) VerifyRevision(in *pb.Revision, trusted types.LogRootV1) (*types.LogRootV1, *types.MapRootV1, error) {
-	smr, err := f.VerifySignedMapRoot(in.MapRoot.MapRoot)
-	return &types.LogRootV1{}, smr, err
+func (f *fakeVerifier) VerifyLogRoot(trusted types.LogRootV1, slr *pb.LogRoot) (*types.LogRootV1, error) {
+	return &types.LogRootV1{}, nil
 }
 
-func (f *fakeVerifier) VerifySignedMapRoot(smr *trillian.SignedMapRoot) (*types.MapRootV1, error) {
-	return &types.MapRootV1{Revision: uint64(smr.MapRoot[0])}, nil
+func (f *fakeVerifier) VerifyMapRevision(logRoot *types.LogRootV1, smr *pb.MapRoot) (*types.MapRootV1, error) {
+	return &types.MapRootV1{Revision: uint64(smr.MapRoot.MapRoot[0])}, nil
 }

--- a/core/client/get_and_verify.go
+++ b/core/client/get_and_verify.go
@@ -37,17 +37,20 @@ func (c *Client) VerifiedGetUser(ctx context.Context, userID string) (*types.Map
 		return nil, nil, err
 	}
 
-	slr, smr, err := c.VerifyRevision(resp.Revision, c.trusted)
+	lr, err := c.VerifyLogRoot(c.trusted, resp.Revision.GetLatestLogRoot())
 	if err != nil {
 		return nil, nil, err
 	}
-	c.updateTrusted(slr)
-
-	if err := c.VerifyMapLeaf(c.DirectoryID, userID, resp.Leaf, smr); err != nil {
+	c.updateTrusted(lr)
+	mr, err := c.VerifyMapRevision(lr, resp.Revision.GetMapRoot())
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.VerifyMapLeaf(c.DirectoryID, userID, resp.Leaf, mr); err != nil {
 		return nil, nil, err
 	}
 
-	return smr, resp.Leaf, nil
+	return mr, resp.Leaf, nil
 }
 
 // VerifiedGetLatestRevision fetches the latest revision from the key server.
@@ -58,7 +61,7 @@ func (c *Client) VerifiedGetLatestRevision(ctx context.Context) (*types.LogRootV
 	c.trustedLock.Lock()
 	defer c.trustedLock.Unlock()
 
-	e, err := c.cli.GetLatestRevision(ctx, &pb.GetLatestRevisionRequest{
+	resp, err := c.cli.GetLatestRevision(ctx, &pb.GetLatestRevisionRequest{
 		DirectoryId:          c.DirectoryID,
 		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
 	})
@@ -66,23 +69,26 @@ func (c *Client) VerifiedGetLatestRevision(ctx context.Context) (*types.LogRootV
 		return nil, nil, err
 	}
 
-	slr, smr, err := c.VerifyRevision(e, c.trusted)
+	lr, err := c.VerifyLogRoot(c.trusted, resp.GetLatestLogRoot())
 	if err != nil {
 		return nil, nil, err
 	}
-	// At this point, the SignedLogRoot has been verified as consistent.
-	c.updateTrusted(slr)
+	c.updateTrusted(lr)
+	mr, err := c.VerifyMapRevision(lr, resp.GetMapRoot())
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Also check that the map revision returned is the latest one.
 	// TreeSize - 1 == mapRoot.Revision.
-	wantRevision, err := mapRevisionFor(slr)
+	wantRevision, err := mapRevisionFor(lr)
 	if err != nil {
 		return nil, nil, err
 	}
-	if smr.Revision != wantRevision {
-		return nil, nil, fmt.Errorf("map revision is not the most recent. smr.Revison: %v != slr.TreeSize-1: %v", smr.Revision, slr.TreeSize-1)
+	if mr.Revision != wantRevision {
+		return nil, nil, fmt.Errorf("map revision is not the most recent. smr.Revison: %v != slr.TreeSize-1: %v", mr.Revision, lr.TreeSize-1)
 	}
-	return slr, smr, nil
+	return lr, mr, nil
 }
 
 // VerifiedGetRevision fetches the requested revision from the key server.
@@ -93,7 +99,7 @@ func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*type
 	c.trustedLock.Lock()
 	defer c.trustedLock.Unlock()
 
-	e, err := c.cli.GetRevision(ctx, &pb.GetRevisionRequest{
+	resp, err := c.cli.GetRevision(ctx, &pb.GetRevisionRequest{
 		DirectoryId:          c.DirectoryID,
 		Revision:             revision,
 		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
@@ -102,13 +108,17 @@ func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*type
 		return nil, nil, err
 	}
 
-	slr, smr, err := c.VerifyRevision(e, c.trusted)
+	lr, err := c.VerifyLogRoot(c.trusted, resp.GetLatestLogRoot())
+	if err != nil {
+		return nil, nil, err
+	}
+	c.updateTrusted(lr)
+	mr, err := c.VerifyMapRevision(lr, resp.GetMapRoot())
 	if err != nil {
 		return nil, nil, err
 	}
 
-	c.updateTrusted(slr)
-	return slr, smr, nil
+	return lr, mr, nil
 }
 
 // VerifiedListHistory performs one list history operation, verifies and returns the results.
@@ -129,23 +139,26 @@ func (c *Client) VerifiedListHistory(ctx context.Context, userID string, start i
 
 	// The roots are only updated once per API call.
 	// TODO(gbelvin): Remove the redundancy inside the responses.
-	var slr *types.LogRootV1
-	var smr *types.MapRootV1
+	var lr *types.LogRootV1
 	profiles := make(map[*types.MapRootV1][]byte)
 	for _, v := range resp.GetValues() {
-		slr, smr, err = c.VerifyRevision(v.Revision, c.trusted)
+		if lr == nil {
+			lr, err = c.VerifyLogRoot(c.trusted, v.GetRevision().GetLatestLogRoot())
+			if err != nil {
+				return nil, 0, err
+			}
+			c.updateTrusted(lr)
+		}
+		mr, err := c.VerifyMapRevision(lr, v.GetRevision().GetMapRoot())
 		if err != nil {
 			return nil, 0, err
 		}
-		if err = c.VerifyMapLeaf(c.DirectoryID, userID, v.Leaf, smr); err != nil {
+		if err := c.VerifyMapLeaf(c.DirectoryID, userID, v.Leaf, mr); err != nil {
 			return nil, 0, err
 		}
-		Vlog.Printf("Processing entry for %v, revision %v", userID, smr.Revision)
-		glog.V(2).Infof("Processing entry for %v, revision %v", userID, smr.Revision)
-		profiles[smr] = v.GetLeaf().GetCommitted().GetData()
-	}
-	if slr != nil {
-		c.updateTrusted(slr)
+		Vlog.Printf("Processing entry for %v, revision %v", userID, mr.Revision)
+		glog.V(2).Infof("Processing entry for %v, revision %v", userID, mr.Revision)
+		profiles[mr] = v.GetLeaf().GetCommitted().GetData()
 	}
 	return profiles, resp.NextStart, nil
 }

--- a/core/client/verifier/verifier_test.go
+++ b/core/client/verifier/verifier_test.go
@@ -55,9 +55,13 @@ func RunTranscriptTest(t *testing.T, transcript *tpb.Transcript) {
 			}
 			switch pair := rpc.ReqRespPair.(type) {
 			case *tpb.Action_GetUser:
-				_, smr, err := v.VerifyRevision(pair.GetUser.Response.Revision, trusted)
+				lr, err := v.VerifyLogRoot(trusted, pair.GetUser.Response.Revision.GetLatestLogRoot())
 				if err != nil {
-					t.Fatalf("VerifyRevision(): %v", err)
+					t.Fatalf("VerifyLogRoot(): %v", err)
+				}
+				smr, err := v.VerifyMapRevision(lr, pair.GetUser.Response.Revision.GetMapRoot())
+				if err != nil {
+					t.Fatalf("VerifyMapRevision(): %v", err)
 				}
 				if err := v.VerifyMapLeaf(
 					transcript.Directory.DirectoryId,

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -127,9 +127,14 @@ func (m *Monitor) ProcessLoop(ctx context.Context, directoryID string, trusted t
 	defer cancel()
 
 	for pair := range pairs {
-		_, mapRootB, err := m.cli.VerifyRevision(pair.B, trusted)
+		lr, err := m.cli.VerifyLogRoot(trusted, pair.B.GetLatestLogRoot())
 		if err != nil {
-			glog.Errorf("Invalid Revision %v: %v", mapRootB.Revision, err)
+			glog.Errorf("Invalid LogRoot %v: %v", pair.B, err)
+			return err
+		}
+		mapRootB, err := m.cli.VerifyMapRevision(lr, pair.B.GetMapRoot())
+		if err != nil {
+			glog.Errorf("Invalid MapRoot %v: %v", pair.B, err)
 			return err
 		}
 


### PR DESCRIPTION
This PR establishes a nice API pattern:
`VerifyX(VerifiedDataFromPreviousStep,  UnverifiedInputData) VerifiedDataForNextStep`

It is also important because it allows us to verify a log root once, while verifying many map roots in VerifyListHistory. 

By establishing a 1:1 relationship between sending requests and verifying log roots, we setup ourselves nicely for a refactoring of the log root tracker into a separate package. 