### PR TITLE
Remove VerifySignedMapRoot from VerifierInterface

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/google/keytransparency/core/client/verifier"
 	"github.com/google/keytransparency/core/mutator/entry"
-	"github.com/google/trillian"
 
 	"github.com/google/trillian/client/backoff"
 	"github.com/google/trillian/types"
@@ -77,8 +76,6 @@ type VerifierInterface interface {
 	// VerifyRevision verifies that revision is correctly signed and included in the append only log.
 	// VerifyRevision also verifies that revision.LogRoot is consistent with the last trusted SignedLogRoot.
 	VerifyRevision(revision *pb.Revision, trusted types.LogRootV1) (*types.LogRootV1, *types.MapRootV1, error)
-	// VerifySignedMapRoot verifies the signature on the SignedMapRoot.
-	VerifySignedMapRoot(smr *trillian.SignedMapRoot) (*types.MapRootV1, error)
 }
 
 // ReduceMutationFn takes all the mutations for an index and an auxiliary input

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -133,7 +133,7 @@ func (m *Monitor) ProcessLoop(ctx context.Context, directoryID string, trusted t
 			return err
 		}
 
-		mutations, err := m.cli.RevisionMutations(ctx, pair.B)
+		mutations, err := m.cli.RevisionMutations(ctx, mapRootB)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
All verifications should be rooted in the last verified log root.

Pass already verified `mapRoot` to `RevisionMutations`.  There's no need to re-verify it without the context of a last verified log root. 