### PR TITLE
Verify Revisions in StreamRevisions

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
-	"github.com/google/trillian/types"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -85,10 +84,8 @@ func main() {
 		glog.Exitf("Failed to initialize monitor: %v", err)
 	}
 
-	// TODO(gbelvin): persist trusted roots
-	trusted := types.LogRootV1{}
 	go func() {
-		if err := mon.ProcessLoop(ctx, trusted); err != nil {
+		if err := mon.ProcessLoop(ctx, 0); err != nil {
 			glog.Errorf("ProcessLoop: %v", err)
 		}
 	}()

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -88,7 +88,7 @@ func main() {
 	// TODO(gbelvin): persist trusted roots
 	trusted := types.LogRootV1{}
 	go func() {
-		if err := mon.ProcessLoop(ctx, *directoryID, trusted); err != nil {
+		if err := mon.ProcessLoop(ctx, trusted); err != nil {
 			glog.Errorf("ProcessLoop: %v", err)
 		}
 	}()

--- a/core/client/get_and_verify.go
+++ b/core/client/get_and_verify.go
@@ -94,7 +94,7 @@ func (c *Client) VerifiedGetLatestRevision(ctx context.Context) (*types.LogRootV
 
 // VerifiedGetRevision fetches the requested revision from the key server.
 // It also verifies the consistency of the latest log root against the last seen log root.
-// Returns the latest log root and the requested map root.
+// Returns the requested map root.
 func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*types.MapRootV1, error) {
 	// Only one method should attempt to update the trusted root at time.
 	c.trustedLock.Lock()

--- a/core/client/get_and_verify.go
+++ b/core/client/get_and_verify.go
@@ -94,7 +94,7 @@ func (c *Client) VerifiedGetLatestRevision(ctx context.Context) (*types.LogRootV
 // VerifiedGetRevision fetches the requested revision from the key server.
 // It also verifies the consistency of the latest log root against the last seen log root.
 // Returns the latest log root and the requested map root.
-func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*types.LogRootV1, *types.MapRootV1, error) {
+func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*types.MapRootV1, error) {
 	// Only one method should attempt to update the trusted root at time.
 	c.trustedLock.Lock()
 	defer c.trustedLock.Unlock()
@@ -105,20 +105,20 @@ func (c *Client) VerifiedGetRevision(ctx context.Context, revision int64) (*type
 		LastVerifiedTreeSize: int64(c.trusted.TreeSize),
 	})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	lr, err := c.VerifyLogRoot(c.trusted, resp.GetLatestLogRoot())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	c.updateTrusted(lr)
 	mr, err := c.VerifyMapRevision(lr, resp.GetMapRoot())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return lr, mr, nil
+	return mr, nil
 }
 
 // VerifiedListHistory performs one list history operation, verifies and returns the results.

--- a/core/client/mutations.go
+++ b/core/client/mutations.go
@@ -39,13 +39,13 @@ type RevisionMutations struct {
 // StreamRevisions repeatedly fetches revisions and sends them to out until GetRevision
 // returns an error other than NotFound or until ctx.Done is closed.  When
 // GetRevision returns NotFound, it waits one pollPeriod before trying again.
-func (c *Client) StreamRevisions(ctx context.Context, directoryID string, startRevision int64, out chan<- *pb.Revision) error {
+func (c *Client) StreamRevisions(ctx context.Context, startRevision int64, out chan<- *pb.Revision) error {
 	defer close(out)
 	wait := time.NewTicker(c.RetryDelay).C
 	for i := startRevision; ; {
 		// time out if we exceed the poll period:
 		revision, err := c.cli.GetRevision(ctx, &pb.GetRevisionRequest{
-			DirectoryId:          directoryID,
+			DirectoryId:          c.DirectoryID,
 			Revision:             i,
 			LastVerifiedTreeSize: startRevision,
 		})
@@ -59,7 +59,7 @@ func (c *Client) StreamRevisions(ctx context.Context, directoryID string, startR
 				continue
 			}
 		} else if err != nil {
-			glog.Warningf("GetRevision(%v,%v): %v", directoryID, i, err)
+			glog.Warningf("GetRevision(%v): %v", err)
 			return err
 		}
 

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
-	"github.com/google/trillian/types"
 
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 	tpb "github.com/google/keytransparency/core/testdata/transcript_go_proto"
@@ -124,13 +123,12 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) []*tpb.Action {
 		}
 	}
 
-	trusted := types.LogRootV1{}
 	cctx, cancel := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err = mon.ProcessLoop(cctx, env.Directory.DirectoryId, trusted)
+		err = mon.ProcessLoop(cctx, 0)
 	}()
 	time.Sleep(env.Timeout)
 	cancel()

--- a/core/monitor/monitor.go
+++ b/core/monitor/monitor.go
@@ -108,15 +108,15 @@ func RevisionPairs(ctx context.Context, revisions <-chan *pb.Revision, pairs cha
 }
 
 // ProcessLoop continuously fetches mutations and processes them.
-func (m *Monitor) ProcessLoop(ctx context.Context, directoryID string, trusted types.LogRootV1) error {
+func (m *Monitor) ProcessLoop(ctx context.Context, trusted types.LogRootV1) error {
 	cctx, cancel := context.WithCancel(ctx)
 	errc := make(chan error)
 	revisions := make(chan *pb.Revision)
 	pairs := make(chan RevisionPair)
 
 	go func(ctx context.Context) {
-		err := m.cli.StreamRevisions(ctx, directoryID, int64(trusted.TreeSize), revisions)
-		glog.Errorf("StreamRevisions(%v): %v", directoryID, err)
+		err := m.cli.StreamRevisions(ctx, int64(trusted.TreeSize), revisions)
+		glog.Errorf("StreamRevisions(%v): %v", err)
 		errc <- err
 	}(cctx)
 	go func(ctx context.Context) {

--- a/core/monitor/verify.go
+++ b/core/monitor/verify.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/keytransparency/core/mutator/entry"
-	"github.com/google/trillian"
 	"github.com/google/trillian/merkle"
 	"github.com/google/trillian/storage"
 	"github.com/google/trillian/types"
@@ -89,7 +88,7 @@ func (e *ErrList) Proto() []*statuspb.Status {
 	return errs
 }
 
-func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot *trillian.SignedMapRoot, expectedNewRoot *types.MapRootV1) []error {
+func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot, expectedNewRoot *types.MapRootV1) []error {
 	errs := ErrList{}
 	oldProofNodes := make(map[string][]byte)
 	newLeaves := make([]*merkle.HStar2LeafHash, 0, len(muts))
@@ -103,7 +102,7 @@ func (m *Monitor) verifyMutations(muts []*pb.MutationProof, oldRoot *trillian.Si
 
 		// verify that the provided leaf’s inclusion proof goes to revision e-1:
 		index := mut.GetLeafProof().GetLeaf().GetIndex()
-		if err := m.mapVerifier.VerifyMapLeafInclusion(oldRoot, mut.GetLeafProof()); err != nil {
+		if err := m.mapVerifier.VerifyMapLeafInclusionHash(oldRoot.RootHash, mut.GetLeafProof()); err != nil {
 			glog.Infof("VerifyMapInclusionProof(%x): %v", index, err)
 			errs.AppendStatus(status.Newf(codes.DataLoss, "invalid  map inclusion proof: %v", err).WithDetails(mut.GetLeafProof()))
 		}


### PR DESCRIPTION
By verifying revisions inside of StreamRevisions, 
we can reuse VerifyGetRevision and have better control
over the updating of LogRoot