### PR TITLE
Limit the number of map revisions to return at once

### DIFF
--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -121,8 +121,9 @@ func main() {
 	tmap := trillian.NewTrillianMapClient(mconn)
 
 	// Create gRPC server.
+	var revisionPageSize int32 = 10
 	ksvr := keyserver.New(tlog, tmap, entry.IsValidEntry, directories, logs, logs,
-		prometheus.MetricFactory{})
+		prometheus.MetricFactory{}, revisionPageSize)
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(


### PR DESCRIPTION
Fetching map revisions can be quite.... slow.
Let's help clients not time out.