### PR TITLE
Revert "Turn on GOPROXY"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
   - PATH=$PATH:${HOME}/google-cloud-sdk/bin
   - CLOUDSDK_CORE_DISABLE_PROMPTS=1
   - GO111MODULE=on
-  - GOPROXY=https://proxy.golang.org
 
 jobs:
   include:

--- a/cmd/keytransparency-monitor/Dockerfile
+++ b/cmd/keytransparency-monitor/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.12 as build
 WORKDIR /go/src/github.com/google/keytransparency
 COPY go.mod go.sum ./
 
-ENV GO111MODULE=on \
-    GOPROXY=https://proxy.golang.org
+ENV GO111MODULE=on
 RUN go mod download
 COPY . .
 

--- a/cmd/keytransparency-sequencer/Dockerfile
+++ b/cmd/keytransparency-sequencer/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.12 as build
 WORKDIR /go/src/github.com/google/keytransparency
 COPY go.mod go.sum ./
 
-ENV GO111MODULE=on \
-    GOPROXY=https://proxy.golang.org
+ENV GO111MODULE=on
 RUN go mod download
 COPY . .
 

--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -3,8 +3,7 @@ FROM golang:1.12 as build
 WORKDIR /go/src/github.com/google/keytransparency
 COPY go.mod go.sum ./
 
-ENV GO111MODULE=on \
-    GOPROXY=https://proxy.golang.org
+ENV GO111MODULE=on
 RUN go mod download
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.4.0
-	github.com/uber/prototool v1.8.1 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45

--- a/go.sum
+++ b/go.sum
@@ -452,8 +452,6 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 github.com/uber/prototool v1.8.0 h1:AByDUuTG5nphja3+APWR04YPUjp7Ac0fZp/St1RKHlY=
 github.com/uber/prototool v1.8.0/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
-github.com/uber/prototool v1.8.1 h1:wlba8JLLuyTn0a7W6AqLrecGypFkrGOb+TwciSrW/rg=
-github.com/uber/prototool v1.8.1/go.mod h1:E+xJFE/vf87XeqHbKM4uGQMrJ7NyKQb0+G7NtqHBgYs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=


### PR DESCRIPTION
Reverts google/keytransparency#1330

This worked for a while, but then GOPROXY started returning 410's for pseudo-versions deep in the dependency graph. 
cc @ FiloSottile