### PR TITLE
Improve integration script reliability

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -12,7 +12,7 @@ trap "docker-compose down" INT EXIT
 wget -T 60 --spider --retry-connrefused --waitretry=1 http://localhost:8081/metrics
 wget -T 60 -O /dev/null --no-check-certificate  \
 	--retry-connrefused --waitretry=1 \
-	--retry-on-http-error=405,404 \
+	--retry-on-http-error=405,404,503 \
 	https://localhost/v1/directories/default
 
 PASSWORD="foobar"


### PR DESCRIPTION
Add UNAVAILABLE to the list of HTTP codes the integration test retries on