### PR TITLE
Initialize mutations batch 0 with zero watermarks

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -181,6 +181,7 @@ func main() {
 		trillian.NewTrillianAdminClient(mconn),
 		directoryStorage,
 		mutations,
+		mutations,
 		func(ctx context.Context, spec *keyspb.Specification) (proto.Message, error) {
 			return der.NewProtoFromSpec(spec)
 		}))

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -147,7 +147,7 @@ func NewEnv(ctx context.Context) (*Env, error) {
 	if err != nil {
 		return nil, fmt.Errorf("env: Failed to create mutations object: %v", err)
 	}
-	adminSvr := adminserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin, directoryStorage, mutations, vrfKeyGen)
+	adminSvr := adminserver.New(logEnv.Log, mapEnv.Map, logEnv.Admin, mapEnv.Admin, directoryStorage, mutations, mutations, vrfKeyGen)
 	cctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	directoryPB, err := adminSvr.CreateDirectory(cctx, &pb.CreateDirectoryRequest{


### PR DESCRIPTION
This change puts batch number 0 to storage when a directory is created.