### PR TITLE
Read batch definitions from batch storage

### DIFF
--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -152,6 +152,8 @@ func TestDefineRevisions(t *testing.T) {
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			s.batcher = &fakeBatcher{highestRev: tc.highestRev, batches: make(map[int64]*spb.MapMetadata)}
+			s.batcher.WriteBatchSources(ctx, directoryID, tc.highestRev, new(spb.MapMetadata))
+
 			got, err := s.DefineRevisions(ctx, &spb.DefineRevisionsRequest{
 				DirectoryId: directoryID,
 				MinBatch:    1,


### PR DESCRIPTION
The latest batch definition should start from the highest defined batch, not the highest applied batch. 

Related to #1335 