### PR TITLE
storagetest factory now takes domainID

### DIFF
--- a/core/integration/storagetest/batch.go
+++ b/core/integration/storagetest/batch.go
@@ -39,8 +39,9 @@ func RunBatchStorageTests(t *testing.T, factory BatchStorageFactory) {
 type BatchTests struct{}
 
 func (*BatchTests) TestNotFound(ctx context.Context, t *testing.T, f BatchStorageFactory) {
-	b := f(ctx, t, "testnotfounddir")
-	_, err := b.ReadBatch(ctx, "nodir", 0)
+	domainID := "testnotfounddir"
+	b := f(ctx, t, domainID)
+	_, err := b.ReadBatch(ctx, domainID, 0)
 	st := status.Convert(err)
 	if got, want := st.Code(), codes.NotFound; got != want {
 		t.Errorf("ReadBatch(): %v, want %v", err, want)

--- a/impl/sql/mutationstorage/mutations_test.go
+++ b/impl/sql/mutationstorage/mutations_test.go
@@ -32,7 +32,7 @@ func newDB(t testing.TB) *sql.DB {
 }
 
 func TestBatchIntegration(t *testing.T) {
-	storageFactory := func(context.Context, *testing.T) storagetest.Batcher {
+	storageFactory := func(context.Context, *testing.T, string) storagetest.Batcher {
 		m, err := New(newDB(t))
 		if err != nil {
 			t.Fatalf("Failed to create mutations: %v", err)

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -23,4 +23,5 @@ go run ./cmd/keytransparency-client post foo@bar.com \
 	--password=${PASSWORD} \
 	--kt-url=localhost:443 \
 	--verbose \
+	--timeout=2m \
 	--logtostderr


### PR DESCRIPTION
Some storage implementations require a domain setup step
This switch allows the storage factory to do the nessesary
setup for the test.