### PR TITLE
Bump docker images to go1.13

### DIFF
--- a/cmd/keytransparency-monitor/Dockerfile
+++ b/cmd/keytransparency-monitor/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.12 as build
+FROM golang:1.13 as build
 
 WORKDIR /go/src/github.com/google/keytransparency
 COPY go.mod go.sum ./
 
-ENV GO111MODULE=on
 RUN go mod download
 COPY . .
 

--- a/cmd/keytransparency-sequencer/Dockerfile
+++ b/cmd/keytransparency-sequencer/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.12 as build
+FROM golang:1.13 as build
 
 WORKDIR /go/src/github.com/google/keytransparency
 COPY go.mod go.sum ./
 
-ENV GO111MODULE=on
 RUN go mod download
 COPY . .
 

--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.12 as build
+FROM golang:1.13 as build
 
 WORKDIR /go/src/github.com/google/keytransparency
 COPY go.mod go.sum ./
 
-ENV GO111MODULE=on
 RUN go mod download
 COPY . .
 


### PR DESCRIPTION
Make things consistent. The rest of the project is using go 1.13