### PR TITLE
Define watermarks in terms of microseconds

### DIFF
--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/keytransparency/core/keyserver"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
@@ -35,8 +33,7 @@ func RunMutationLogsTests(t *testing.T, factory MutationLogsFactory) {
 	b := &mutationLogsTests{}
 	for name, f := range map[string]func(ctx context.Context, t *testing.T, f MutationLogsFactory){
 		// TODO(gbelvin): Discover test methods via reflection.
-		"TestReadLog":              b.TestReadLog,
-		"TestReadLogHighWatermark": b.TestReadLogHighWatermark,
+		"TestReadLog": b.TestReadLog,
 	} {
 		t.Run(name, func(t *testing.T) { f(ctx, t, factory) })
 	}
@@ -51,19 +48,6 @@ func mustMarshal(t *testing.T, p proto.Message) []byte {
 		t.Fatalf("proto.Marshal(): %v", err)
 	}
 	return b
-}
-
-// TestReadLogHighWatermark ensures that erroneous values for high watermark return errors.
-func (mutationLogsTests) TestReadLogHighWatermark(ctx context.Context, t *testing.T, newForTest MutationLogsFactory) {
-	directoryID := "TestReadLogHighWatermark"
-	logID := int64(5) // Any log ID.
-	m := newForTest(ctx, t, directoryID, logID)
-	limit := int32(2)
-	_, err := m.ReadLog(ctx, directoryID, logID, 0, time.Now().UnixNano(), limit)
-	st := status.Convert(err)
-	if got, want := st.Code(), codes.InvalidArgument; got != want {
-		t.Errorf("ReadLog(high > now): %v, want %v", err, want)
-	}
 }
 
 // TestReadLog ensures that reads happen in atomic units of batch size.

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -76,7 +76,8 @@ type MutationLogs interface {
 	// TODO(gbelvin): Create a batch level object to make it clear that this a batch of updates.
 	Send(ctx context.Context, directoryID string, mutation ...*pb.EntryUpdate) (*WriteWatermark, error)
 	// ReadLog returns the messages in the (low, high] range stored in the
-	// specified log. ReadLog always returns complete units of the original
+	// specified log. Low and high are measured in milliseconds since the
+	// epoch.  ReadLog always returns complete units of the original
 	// batches sent via Send, and will return  more items than limit if
 	// needed to do so.
 	ReadLog(ctx context.Context, directoryID string, logID, low, high int64,

--- a/impl/sql/mutationstorage/mutation_logs.go
+++ b/impl/sql/mutationstorage/mutation_logs.go
@@ -206,9 +206,6 @@ func (m *Mutations) HighWatermark(ctx context.Context, directoryID string, logID
 // ReadLog may return more rows than batchSize in order to fetch all the rows at a particular timestamp.
 func (m *Mutations) ReadLog(ctx context.Context, directoryID string,
 	logID, low, high int64, batchSize int32) ([]*mutator.LogMessage, error) {
-	if high > watermark(time.Now().Add(time.Minute)) {
-		return nil, status.Errorf(codes.InvalidArgument, "high: %v, want <= (now + 1 minute)", high)
-	}
 	rows, err := m.db.QueryContext(ctx,
 		`SELECT Time, LocalID, Mutation FROM Queue
 		WHERE DirectoryID = ? AND LogID = ? AND Time >= ? AND Time < ?


### PR DESCRIPTION
This helps define a better, tested interface for the logs.

Depends on #1358 