### PR TITLE
Use and test the same MySQL connection that main.go uses 

### DIFF
--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"flag"
 	"net/http"
 
@@ -37,11 +36,11 @@ import (
 	"github.com/google/keytransparency/impl/sql/mutationstorage"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+	ktsql "github.com/google/keytransparency/impl/sql"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 
-	_ "github.com/go-sql-driver/mysql" // Set database engine.
 	_ "github.com/google/trillian/crypto/keys/der/proto"
 )
 
@@ -58,23 +57,15 @@ var (
 	revisionPageSize = flag.Int("revision-page-size", 10, "Max number of revisions to return at once")
 )
 
-func openDB() *sql.DB {
-	db, err := sql.Open("mysql", *serverDBPath)
-	if err != nil {
-		glog.Exitf("sql.Open(): %v", err)
-	}
-	if err := db.Ping(); err != nil {
-		glog.Exitf("db.Ping(): %v", err)
-	}
-	return db
-}
-
 func main() {
 	flag.Parse()
 	ctx := context.Background()
 
 	// Open Resources.
-	sqldb := openDB()
+	sqldb, err := ktsql.Open(*serverDBPath)
+	if err != nil {
+		glog.Exit(err)
+	}
 	defer sqldb.Close()
 
 	creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)

--- a/core/integration/storagetest/batch.go
+++ b/core/integration/storagetest/batch.go
@@ -27,7 +27,7 @@ import (
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 )
 
-// batchStorageFactory   returns a new database object, and a function for cleaning it up.
+// batchStorageFactory returns a new database object, and a function for cleaning it up.
 type batchStorageFactory func(ctx context.Context, t *testing.T, dirID string) (sequencer.Batcher, func(context.Context))
 
 type BatchStorageTest func(ctx context.Context, t *testing.T, f batchStorageFactory)

--- a/core/integration/storagetest/batch.go
+++ b/core/integration/storagetest/batch.go
@@ -27,12 +27,13 @@ import (
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 )
 
-type BatchStorageFactory func(ctx context.Context, t *testing.T, dirID string) (sequencer.Batcher, func(context.Context))
+// batchStorageFactory   returns a new database object, and a function for cleaning it up.
+type batchStorageFactory func(ctx context.Context, t *testing.T, dirID string) (sequencer.Batcher, func(context.Context))
 
-type BatchStorageTest func(ctx context.Context, t *testing.T, f BatchStorageFactory)
+type BatchStorageTest func(ctx context.Context, t *testing.T, f batchStorageFactory)
 
 // RunBatchStorageTests runs all the batch storage tests against the provided map storage implementation.
-func RunBatchStorageTests(t *testing.T, factory BatchStorageFactory) {
+func RunBatchStorageTests(t *testing.T, factory batchStorageFactory) {
 	ctx := context.Background()
 	b := &BatchTests{}
 	for name, f := range map[string]BatchStorageTest{
@@ -49,7 +50,7 @@ func RunBatchStorageTests(t *testing.T, factory BatchStorageFactory) {
 // BatchTests is a suite of tests to run against
 type BatchTests struct{}
 
-func (*BatchTests) TestNotFound(ctx context.Context, t *testing.T, f BatchStorageFactory) {
+func (*BatchTests) TestNotFound(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "testnotfounddir"
 	b, done := f(ctx, t, domainID)
 	defer done(ctx)
@@ -60,7 +61,7 @@ func (*BatchTests) TestNotFound(ctx context.Context, t *testing.T, f BatchStorag
 	}
 }
 
-func (*BatchTests) TestWriteBatch(ctx context.Context, t *testing.T, f BatchStorageFactory) {
+func (*BatchTests) TestWriteBatch(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "writebatchtest"
 	b, done := f(ctx, t, domainID)
 	defer done(ctx)
@@ -85,7 +86,7 @@ func (*BatchTests) TestWriteBatch(ctx context.Context, t *testing.T, f BatchStor
 	}
 }
 
-func (*BatchTests) TestReadBatch(ctx context.Context, t *testing.T, f BatchStorageFactory) {
+func (*BatchTests) TestReadBatch(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "readbatchtest"
 	b, done := f(ctx, t, domainID)
 	defer done(ctx)
@@ -115,7 +116,7 @@ func (*BatchTests) TestReadBatch(ctx context.Context, t *testing.T, f BatchStora
 	}
 }
 
-func (*BatchTests) TestHighestRev(ctx context.Context, t *testing.T, f BatchStorageFactory) {
+func (*BatchTests) TestHighestRev(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "writebatchtest"
 	b, done := f(ctx, t, domainID)
 	defer done(ctx)

--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -25,7 +25,7 @@ import (
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
-// mutationLogsFactory  returns a new database object, and a function for cleaning it up.
+// mutationLogsFactory returns a new database object, and a function for cleaning it up.
 type mutationLogsFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (keyserver.MutationLogs, func(context.Context))
 
 // RunMutationLogsTests runs all the tests against the provided storage implementation.

--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -25,7 +25,7 @@ import (
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
-type MutationLogsFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) keyserver.MutationLogs
+type MutationLogsFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (keyserver.MutationLogs, func(context.Context))
 
 // RunMutationLogsTests runs all the tests against the provided storage implementation.
 func RunMutationLogsTests(t *testing.T, factory MutationLogsFactory) {
@@ -54,7 +54,8 @@ func mustMarshal(t *testing.T, p proto.Message) []byte {
 func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTest MutationLogsFactory) {
 	directoryID := "TestReadLog"
 	logID := int64(5) // Any log ID.
-	m := newForTest(ctx, t, directoryID, logID)
+	m, done := newForTest(ctx, t, directoryID, logID)
+	defer done(ctx)
 	// Write ten batches, three entries each.
 	for i := byte(0); i < 10; i++ {
 		entry := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: mustMarshal(t, &pb.Entry{Index: []byte{i}})}}

--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -25,13 +25,14 @@ import (
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 )
 
-type MutationLogsFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (keyserver.MutationLogs, func(context.Context))
+// mutationLogsFactory  returns a new database object, and a function for cleaning it up.
+type mutationLogsFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (keyserver.MutationLogs, func(context.Context))
 
 // RunMutationLogsTests runs all the tests against the provided storage implementation.
-func RunMutationLogsTests(t *testing.T, factory MutationLogsFactory) {
+func RunMutationLogsTests(t *testing.T, factory mutationLogsFactory) {
 	ctx := context.Background()
 	b := &mutationLogsTests{}
-	for name, f := range map[string]func(ctx context.Context, t *testing.T, f MutationLogsFactory){
+	for name, f := range map[string]func(ctx context.Context, t *testing.T, f mutationLogsFactory){
 		// TODO(gbelvin): Discover test methods via reflection.
 		"TestReadLog": b.TestReadLog,
 	} {
@@ -51,7 +52,7 @@ func mustMarshal(t *testing.T, p proto.Message) []byte {
 }
 
 // TestReadLog ensures that reads happen in atomic units of batch size.
-func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTest MutationLogsFactory) {
+func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTest mutationLogsFactory) {
 	directoryID := "TestReadLog"
 	logID := int64(5) // Any log ID.
 	m, done := newForTest(ctx, t, directoryID, logID)

--- a/core/integration/storagetest/mutation_logs_admin.go
+++ b/core/integration/storagetest/mutation_logs_admin.go
@@ -24,13 +24,14 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type LogsAdminFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (adminserver.LogsAdmin, func(context.Context))
+// logAdminFactory returns a new database object, and a function for cleaning it up.
+type logAdminFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (adminserver.LogsAdmin, func(context.Context))
 
 // RunLogsAdminTests runs all the admin tests against the provided storage implementation.
-func RunLogsAdminTests(t *testing.T, factory LogsAdminFactory) {
+func RunLogsAdminTests(t *testing.T, factory logAdminFactory) {
 	ctx := context.Background()
 	b := &logsAdminTests{}
-	for name, f := range map[string]func(ctx context.Context, t *testing.T, f LogsAdminFactory){
+	for name, f := range map[string]func(ctx context.Context, t *testing.T, f logAdminFactory){
 		// TODO(gbelvin): Discover test methods via reflection.
 		"TestSetWritable": b.TestSetWritable,
 		"TestListLogs":    b.TestListLogs,
@@ -41,7 +42,7 @@ func RunLogsAdminTests(t *testing.T, factory LogsAdminFactory) {
 
 type logsAdminTests struct{}
 
-func (logsAdminTests) TestSetWritable(ctx context.Context, t *testing.T, f LogsAdminFactory) {
+func (logsAdminTests) TestSetWritable(ctx context.Context, t *testing.T, f logAdminFactory) {
 	directoryID := "TestSetWritable"
 	m, done := f(ctx, t, directoryID, 1)
 	defer done(ctx)
@@ -50,7 +51,7 @@ func (logsAdminTests) TestSetWritable(ctx context.Context, t *testing.T, f LogsA
 	}
 }
 
-func (logsAdminTests) TestListLogs(ctx context.Context, t *testing.T, f LogsAdminFactory) {
+func (logsAdminTests) TestListLogs(ctx context.Context, t *testing.T, f logAdminFactory) {
 	directoryID := "TestListLogs"
 	for _, tc := range []struct {
 		desc        string

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/kylelemons/godebug v1.1.0
 	github.com/lyft/protoc-gen-validate v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.9 // indirect
-	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/mwitkow/go-proto-validators v0.1.0 // indirect
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -53,7 +53,6 @@ import (
 
 	_ "github.com/google/trillian/merkle/coniks"  // Register hasher
 	_ "github.com/google/trillian/merkle/rfc6962" // Register hasher
-	_ "github.com/mattn/go-sqlite3"               // Use sqlite database for testing.
 )
 
 var (

--- a/impl/sql/directory/storage_test.go
+++ b/impl/sql/directory/storage_test.go
@@ -43,8 +43,8 @@ func newStorage(ctx context.Context, t *testing.T) (directory.Storage, func(cont
 
 func TestList(t *testing.T) {
 	ctx := context.Background()
-	s, closeF := newStorage(ctx, t)
-	defer closeF(ctx)
+	s, done := newStorage(ctx, t)
+	defer done(ctx)
 	for _, tc := range []struct {
 		directories []*directory.Directory
 		readDeleted bool
@@ -100,8 +100,8 @@ func TestList(t *testing.T) {
 
 func TestWriteReadDelete(t *testing.T) {
 	ctx := context.Background()
-	s, closeF := newStorage(ctx, t)
-	defer closeF(ctx)
+	s, done := newStorage(ctx, t)
+	defer done(ctx)
 	for _, tc := range []struct {
 		desc                 string
 		d                    directory.Directory
@@ -244,8 +244,8 @@ func TestWriteReadDelete(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
-	s, closeF := newStorage(ctx, t)
-	defer closeF(ctx)
+	s, done := newStorage(ctx, t)
+	defer done(ctx)
 	for _, tc := range []struct {
 		directoryID string
 	}{

--- a/impl/sql/mutationstorage/mutation_logs_test.go
+++ b/impl/sql/mutationstorage/mutation_logs_test.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 func newForTest(ctx context.Context, t testing.TB, dirID string, logIDs ...int64) (*Mutations, func(context.Context)) {

--- a/impl/sql/open.go
+++ b/impl/sql/open.go
@@ -1,0 +1,21 @@
+package sql
+
+import (
+	"database/sql"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// Open the mysql database specified by the dsn string.
+func Open(dsn string) (*sql.DB, error) {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("mysql", cfg.FormatDSN())
+	if err != nil {
+		return nil, err
+	}
+	return db, db.Ping()
+}

--- a/impl/sql/open.go
+++ b/impl/sql/open.go
@@ -1,3 +1,18 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sql provides functions for interacting with MySQL.
 package sql
 
 import (
@@ -6,7 +21,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 )
 
-// Open the mysql database specified by the dsn string.
+// Open the MySQL database specified by the dsn string.
 func Open(dsn string) (*sql.DB, error) {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
@@ -14,7 +29,7 @@ func Open(dsn string) (*sql.DB, error) {
 	}
 
 	// MySQL flags that affect storage logic.
-	cfg.ClientFoundRows = true // Return number of matching rows instead of rows changed
+	cfg.ClientFoundRows = true // Return number of matching rows instead of rows changed.
 
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {

--- a/impl/sql/open.go
+++ b/impl/sql/open.go
@@ -13,6 +13,9 @@ func Open(dsn string) (*sql.DB, error) {
 		return nil, err
 	}
 
+	// MySQL flags that affect storage logic.
+	cfg.ClientFoundRows = true // Return number of matching rows instead of rows changed
+
 	db, err := sql.Open("mysql", cfg.FormatDSN())
 	if err != nil {
 		return nil, err

--- a/impl/sql/testdb/testdb.go
+++ b/impl/sql/testdb/testdb.go
@@ -1,0 +1,59 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testdb
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/go-sql-driver/mysql" // mysql driver
+)
+
+func NewForTest(ctx context.Context, t testing.TB) (*sql.DB, func(context.Context)) {
+	config := mysql.NewConfig()
+	config.User = "root"
+	config.Net = "tcp"
+	config.Addr = "127.0.0.1"
+
+	db, err := sql.Open("mysql", config.FormatDSN())
+	if err != nil {
+		t.Fatalf("sql.Open(): %v", err)
+	}
+
+	dbName := fmt.Sprintf("test_%v", time.Now().UnixNano())
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE `%s`", dbName)); err != nil {
+		t.Fatalf("Failed to create test database: %v", err)
+	}
+
+	// Open test database
+	db.Close()
+	config.DBName = dbName
+	db, err = sql.Open("mysql", config.FormatDSN())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := func(ctx context.Context) {
+		defer db.Close()
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP DATABASE `%s`", dbName)); err != nil {
+			log.Printf("Failed to drop test database %q: %v", dbName, err)
+		}
+	}
+	return db, done
+}

--- a/impl/sql/testdb/testdb.go
+++ b/impl/sql/testdb/testdb.go
@@ -26,9 +26,10 @@ import (
 	ktsql "github.com/google/keytransparency/impl/sql"
 )
 
-var dataSourceURI = flag.String("test_mysql_uri", "root@tcp(127.0.0.1)/", "The MySQL uri to use when running tests")
+var dataSourceURI = flag.String("test_mysql_uri", "root@tcp(127.0.0.1)/", "The MySQL URI to use when running tests")
 
-// NewForTest creates a temporary database for testing, and deletes it in the close function.
+// NewForTest creates a temporary database.
+// Returns a function for deleting the database.
 func NewForTest(ctx context.Context, t testing.TB) (*sql.DB, func(context.Context)) {
 	db, err := ktsql.Open(*dataSourceURI)
 	if err != nil {

--- a/impl/sql/testdb/testdb.go
+++ b/impl/sql/testdb/testdb.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package testdb supports opening ephemeral databases for testing.
 package testdb
 
 import (

--- a/impl/sql/testdb/testdb_test.go
+++ b/impl/sql/testdb/testdb_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2019 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/impl/sql/testdb/testdb_test.go
+++ b/impl/sql/testdb/testdb_test.go
@@ -11,26 +11,19 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package mutationstorage
+
+package testdb
 
 import (
 	"context"
 	"testing"
-
-	"github.com/google/keytransparency/core/integration/storagetest"
-	"github.com/google/keytransparency/core/sequencer"
-	"github.com/google/keytransparency/impl/sql/testdb"
 )
 
-func TestBatchIntegration(t *testing.T) {
-	storageFactory := func(ctx context.Context, t *testing.T, _ string) (sequencer.Batcher, func(context.Context)) {
-		db, done := testdb.NewForTest(ctx, t)
-		m, err := New(db)
-		if err != nil {
-			t.Fatalf("Failed to create mutations: %v", err)
-		}
-		return m, done
+func TestNewForTest(t *testing.T) {
+	ctx := context.Background()
+	db, done := NewForTest(ctx, t)
+	defer done(ctx)
+	if err := db.Ping(); err != nil {
+		t.Error(err)
 	}
-
-	storagetest.RunBatchStorageTests(t, storageFactory)
 }

--- a/impl/sql/testdb/testdb_test.go
+++ b/impl/sql/testdb/testdb_test.go
@@ -22,8 +22,11 @@ import (
 func TestNewForTest(t *testing.T) {
 	ctx := context.Background()
 	db, done := NewForTest(ctx, t)
-	defer done(ctx)
 	if err := db.Ping(); err != nil {
 		t.Error(err)
 	}
+	done(ctx)
+	// Verify that the databse was really closed by looking for the
+	// error in the logs when running the test with -v
+	done(ctx)
 }


### PR DESCRIPTION
"Test what we use" 

By testing against a real MySQL database instead of SQLite, I discovered a subtle implementation difference in the behavior of `AffectedRows`, requiring a MySQL driver flag `ClientFoundRows` to be set to achieve the desired behavior 