### PR TITLE
Interpret MapMetadata as microseconds

### DIFF
--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -108,15 +108,18 @@ func (mutationLogsTests) TestReadLogExact(ctx context.Context, t *testing.T, new
 	}
 
 	for _, tc := range []struct {
-		low, high int
+		low, high time.Time
 		want      []byte
 	}{
-		{low: 0, high: 0, want: []byte{}},
-		{low: 0, high: 1, want: []byte{0}},
-		{low: 0, high: 9, want: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8}},
-		{low: 1, high: 9, want: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		{low: idx[0], high: idx[0], want: []byte{}},
+		{low: idx[0], high: idx[1], want: []byte{0}},
+		{low: idx[0], high: idx[9], want: []byte{0, 1, 2, 3, 4, 5, 6, 7, 8}},
+		{low: idx[1], high: idx[9], want: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		// Ensure that adding 1 correctly modifies the range semantics.
+		{low: idx[0].Add(1), high: idx[9], want: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+		{low: idx[0].Add(1), high: idx[9].Add(1), want: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}},
 	} {
-		rows, err := m.ReadLog(ctx, directoryID, logID, idx[tc.low], idx[tc.high], 100)
+		rows, err := m.ReadLog(ctx, directoryID, logID, tc.low, tc.high, 100)
 		if err != nil {
 			t.Fatalf("ReadLog(): %v", err)
 		}

--- a/core/integration/storagetest/mutation_logs_reader.go
+++ b/core/integration/storagetest/mutation_logs_reader.go
@@ -79,11 +79,10 @@ func (mutationLogsReaderTests) TestHighWatermark(ctx context.Context, t *testing
 	}{
 		{desc: "log1 max", logID: 1, batchSize: 100, start: idx[0], want: idx[9].Add(1), count: 10},
 		{desc: "log2 empty", logID: 2, batchSize: 100, start: idx[0], want: idx[0]},
-		{desc: "batch0", logID: 1, batchSize: 0, start: minWatermark, want: minWatermark},
-		{desc: "batch0start55", logID: 1, start: minWatermark.Add(55 * time.Microsecond), batchSize: 0, want: minWatermark.Add(55 * time.Microsecond)},
-		{desc: "batch5", logID: 1, start: idx[0], batchSize: 5, want: idx[4].Add(1), count: 5},
-		{desc: "start1", logID: 1, start: idx[2], batchSize: 5, want: idx[6].Add(1), count: 5},
-		{desc: "start8", logID: 1, start: idx[8], batchSize: 5, want: idx[9].Add(1), count: 2},
+		{desc: "preserve start", logID: 1, batchSize: 0, start: time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC), want: time.Date(1, 2, 3, 4, 5, 6, 7, time.UTC)},
+		{desc: "batch", logID: 1, start: idx[2], batchSize: 5, want: idx[6].Add(1), count: 5},
+		// Ensure that adding 1 correctly modifies the range semantics.
+		{desc: "+1", logID: 1, start: idx[2].Add(1), batchSize: 5, want: idx[7].Add(1), count: 5},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			count, got, err := m.HighWatermark(ctx, directoryID, tc.logID, tc.start, tc.batchSize)

--- a/core/integration/storagetest/mutation_logs_reader.go
+++ b/core/integration/storagetest/mutation_logs_reader.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagetest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/keytransparency/core/sequencer"
+
+	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
+)
+
+// LogsReadWriter supports test's ability to write to and read from the mutation logs.
+type LogsReadWriter interface {
+	sequencer.LogsReader
+	// Send submits the whole group of mutations atomically to a log.
+	// TODO(gbelvin): Create a batch level object to make it clear that this a batch of updates.
+	// Returns the timestamp that the mutation batch got written at.
+	Send(ctx context.Context, directoryID string, logID int64, mutation ...*pb.EntryUpdate) (time.Time, error)
+}
+
+// logsRWFactory returns a new database object, and a function for cleaning it up.
+type logsRWFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (LogsReadWriter, func(context.Context))
+
+// RunMutationLogsReaderTests runs all the tests against the provided storage implementation.
+func RunMutationLogsReaderTests(t *testing.T, factory logsRWFactory) {
+	ctx := context.Background()
+	b := &mutationLogsReaderTests{}
+	type TestFunc func(ctx context.Context, t *testing.T, f logsRWFactory)
+	for name, f := range map[string]TestFunc{
+		// TODO(gbelvin): Discover test methods via reflection.
+		"TestHighWatermark": b.TestHighWatermark,
+	} {
+		t.Run(name, func(t *testing.T) { f(ctx, t, factory) })
+	}
+}
+
+type mutationLogsReaderTests struct{}
+
+// TestHighWatermark ensures that reads respect the low inclusive, high exclusive API.
+func (mutationLogsReaderTests) TestHighWatermark(ctx context.Context, t *testing.T, newForTest logsRWFactory) {
+	directoryID := "TestHighWatermark"
+	logIDs := []int64{1, 2}
+	m, done := newForTest(ctx, t, directoryID, logIDs...)
+	defer done(ctx)
+	update := &pb.EntryUpdate{}
+
+	idx := []time.Time{}
+	for i := 0; i < 10; i++ {
+		logID := int64(1)
+		ts, err := m.Send(ctx, directoryID, logID, update)
+		if err != nil {
+			t.Fatalf("m.send(%v): %v", logID, err)
+		}
+		idx = append(idx, ts)
+	}
+
+	for _, tc := range []struct {
+		desc      string
+		logID     int64
+		start     time.Time
+		batchSize int32
+		count     int32
+		want      time.Time
+	}{
+		{desc: "log1 max", logID: 1, batchSize: 100, start: idx[0], want: idx[9].Add(1), count: 10},
+		{desc: "log2 empty", logID: 2, batchSize: 100, start: idx[0], want: idx[0]},
+		{desc: "batch0", logID: 1, batchSize: 0, start: minWatermark, want: minWatermark},
+		{desc: "batch0start55", logID: 1, start: minWatermark.Add(55 * time.Microsecond), batchSize: 0, want: minWatermark.Add(55 * time.Microsecond)},
+		{desc: "batch5", logID: 1, start: idx[0], batchSize: 5, want: idx[4].Add(1), count: 5},
+		{desc: "start1", logID: 1, start: idx[2], batchSize: 5, want: idx[6].Add(1), count: 5},
+		{desc: "start8", logID: 1, start: idx[8], batchSize: 5, want: idx[9].Add(1), count: 2},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			count, got, err := m.HighWatermark(ctx, directoryID, tc.logID, tc.start, tc.batchSize)
+			if err != nil {
+				t.Errorf("highWatermark(): %v", err)
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("highWatermark(%v) high: %v, want %v", tc.start, got, tc.want)
+			}
+			if count != tc.count {
+				t.Errorf("highWatermark(%v) count: %v, want %v", tc.start, count, tc.count)
+			}
+		})
+	}
+}

--- a/core/keyserver/paginator.go
+++ b/core/keyserver/paginator.go
@@ -65,7 +65,7 @@ func (s SourceList) First() *rtpb.ReadToken {
 		// Empty struct means there is nothing else to page through.
 		return &rtpb.ReadToken{}
 	}
-	st, err := ptypes.TimestampProto(metadata.Source(s[0]).StartTime())
+	st, err := ptypes.TimestampProto(metadata.FromProto(s[0]).StartTime())
 	if err != nil {
 		panic("invalid timestamp")
 	}
@@ -97,7 +97,7 @@ func (s SourceList) Next(rt *rtpb.ReadToken, lastRow *mutator.LogMessage) *rtpb.
 		return &rtpb.ReadToken{} // Encodes to ""
 	}
 
-	st, err := ptypes.TimestampProto(metadata.Source(s[rt.SliceIndex+1]).StartTime())
+	st, err := ptypes.TimestampProto(metadata.FromProto(s[rt.SliceIndex+1]).StartTime())
 	if err != nil {
 		panic("invalid timestamp")
 	}

--- a/core/keyserver/paginator_test.go
+++ b/core/keyserver/paginator_test.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/google/keytransparency/core/mutator"
 	"github.com/google/keytransparency/core/sequencer/metadata"
-	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 
 	tpb "github.com/golang/protobuf/ptypes/timestamp"
 	rtpb "github.com/google/keytransparency/core/keyserver/readtoken_go_proto"
+	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 )
 
 func newSourceSlice(t *testing.T, logID int64, low, high time.Time) *spb.MapMetadata_SourceSlice {

--- a/core/keyserver/paginator_test.go
+++ b/core/keyserver/paginator_test.go
@@ -21,10 +21,21 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"github.com/google/keytransparency/core/mutator"
+	"github.com/google/keytransparency/core/sequencer/metadata"
+	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 
 	tpb "github.com/golang/protobuf/ptypes/timestamp"
 	rtpb "github.com/google/keytransparency/core/keyserver/readtoken_go_proto"
 )
+
+func newSourceSlice(t *testing.T, logID int64, low, high time.Time) *spb.MapMetadata_SourceSlice {
+	t.Helper()
+	s, err := metadata.New(logID, low, high)
+	if err != nil {
+		t.Fatalf("Invalid source: %v", err)
+	}
+	return s.Proto()
+}
 
 func TestEncodeToken(t *testing.T) {
 	for _, tc := range []struct {
@@ -71,16 +82,16 @@ func TestTokenEncodeDecode(t *testing.T) {
 }
 
 func TestFirst(t *testing.T) {
+	start := time.Unix(0, 0)
 	for _, tc := range []struct {
 		s    SourceList
 		want *rtpb.ReadToken
 	}{
 		{
 			s: SourceList{
-				{LogId: 2, LowestInclusive: 2, HighestExclusive: 11},
-				{LogId: 3, LowestInclusive: 11, HighestExclusive: 21},
-			},
-			want: &rtpb.ReadToken{SliceIndex: 0, StartTime: &tpb.Timestamp{Nanos: 2}},
+				newSourceSlice(t, 2, start.Add(2*time.Microsecond), start.Add(11*time.Microsecond)),
+				newSourceSlice(t, 3, start.Add(11*time.Microsecond), start.Add(21*time.Microsecond))},
+			want: &rtpb.ReadToken{SliceIndex: 0, StartTime: timestamp(t, start.Add(2*time.Microsecond))},
 		},
 		{s: SourceList{}, want: &rtpb.ReadToken{}},
 	} {
@@ -91,9 +102,10 @@ func TestFirst(t *testing.T) {
 }
 
 func TestNext(t *testing.T) {
+	start := time.Unix(1, 0)
 	a := SourceList{
-		{LogId: 2, LowestInclusive: 2, HighestExclusive: 11},
-		{LogId: 3, LowestInclusive: 11, HighestExclusive: 21},
+		newSourceSlice(t, 2, start.Add(2*time.Microsecond), start.Add(11*time.Microsecond)),
+		newSourceSlice(t, 3, start.Add(11*time.Microsecond), start.Add(21*time.Microsecond)),
 	}
 	for _, tc := range []struct {
 		s       SourceList
@@ -105,16 +117,16 @@ func TestNext(t *testing.T) {
 		{
 			desc:    "first page",
 			s:       a,
-			rt:      &rtpb.ReadToken{SliceIndex: 0, StartTime: &tpb.Timestamp{Nanos: 2}},
-			lastRow: &mutator.LogMessage{ID: time.Unix(0, 6)},
-			want:    &rtpb.ReadToken{SliceIndex: 0, StartTime: &tpb.Timestamp{Nanos: 6}},
+			rt:      &rtpb.ReadToken{SliceIndex: 0, StartTime: timestamp(t, start.Add(2*time.Microsecond))},
+			lastRow: &mutator.LogMessage{ID: start.Add(6 * time.Microsecond)},
+			want:    &rtpb.ReadToken{SliceIndex: 0, StartTime: timestamp(t, start.Add(6*time.Microsecond))},
 		},
 		{
 			desc:    "next source",
 			s:       a,
 			rt:      &rtpb.ReadToken{},
 			lastRow: nil,
-			want:    &rtpb.ReadToken{SliceIndex: 1, StartTime: &tpb.Timestamp{Nanos: 11}},
+			want:    &rtpb.ReadToken{SliceIndex: 1, StartTime: timestamp(t, start.Add(11*time.Microsecond))},
 		},
 		{
 			desc:    "last page",
@@ -126,7 +138,7 @@ func TestNext(t *testing.T) {
 		{
 			desc:    "empty",
 			s:       SourceList{},
-			rt:      &rtpb.ReadToken{SliceIndex: 1, StartTime: &tpb.Timestamp{Nanos: 2}},
+			rt:      &rtpb.ReadToken{SliceIndex: 1, StartTime: timestamp(t, start.Add(2*time.Microsecond))},
 			lastRow: nil,
 			want:    &rtpb.ReadToken{},
 		},

--- a/core/keyserver/revisions.go
+++ b/core/keyserver/revisions.go
@@ -141,7 +141,7 @@ func (s *Server) ListMutations(ctx context.Context, in *pb.ListMutationsRequest)
 	}
 
 	// Read PageSize + 1 messages from the log to see if there is another page.
-	high := metadata.Source(meta.Sources[rt.SliceIndex]).EndTime()
+	high := metadata.FromProto(meta.Sources[rt.SliceIndex]).EndTime()
 	logID := meta.Sources[rt.SliceIndex].LogId
 	low, err := ptypes.Timestamp(rt.StartTime)
 	if err != nil {

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/impl/memory"
 
-	protopb "github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	rtpb "github.com/google/keytransparency/core/keyserver/readtoken_go_proto"
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"

--- a/core/sequencer/metadata/sourceslice.go
+++ b/core/sequencer/metadata/sourceslice.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package metadata helps enforce a consistent standard of meaning around the map metadata object.
 package metadata
 
 import (
@@ -24,6 +25,7 @@ import (
 
 var minTime = time.Unix(0, math.MinInt64) // 1677-09-21 00:12:43.145224192
 var maxTime = time.Unix(0, math.MaxInt64) // 2262-04-11 23:47:16.854775807
+const nanosPerQuantum = int64(time.Microsecond / time.Nanosecond)
 
 // validateTime determines whether a timestamp is valid.
 // Valid timestamps can be represented by an int64 number of microseconds from the epoch.
@@ -50,8 +52,8 @@ func New(logID int64, low, high time.Time) (*SourceSlice, error) {
 	}
 	return &SourceSlice{s: &spb.MapMetadata_SourceSlice{
 		LogId:            logID,
-		LowestInclusive:  low.UnixNano(),
-		HighestExclusive: high.UnixNano(),
+		LowestInclusive:  low.UnixNano() / nanosPerQuantum,
+		HighestExclusive: high.UnixNano() / nanosPerQuantum,
 	}}, nil
 }
 
@@ -69,12 +71,12 @@ type SourceSlice struct {
 
 // StartTime returns LowestInclusive as a time.Time
 func (s SourceSlice) StartTime() time.Time {
-	return time.Unix(0, s.s.GetLowestInclusive())
+	return time.Unix(0, s.s.GetLowestInclusive()*nanosPerQuantum)
 }
 
 // EndTime returns HighestExclusive as a time.Time
 func (s SourceSlice) EndTime() time.Time {
-	return time.Unix(0, s.s.GetHighestExclusive())
+	return time.Unix(0, s.s.GetHighestExclusive()*nanosPerQuantum)
 }
 
 // Proto returns the proto representation of SourceSlice

--- a/core/sequencer/metadata/sourceslice.go
+++ b/core/sequencer/metadata/sourceslice.go
@@ -15,17 +15,54 @@
 package metadata
 
 import (
+	"fmt"
+	"math"
 	"time"
 
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 )
 
-// Source returns a wrapper for SourceSlice
-func Source(s *spb.MapMetadata_SourceSlice) SourceSlice {
-	return SourceSlice{s: s}
+var minTime = time.Unix(0, math.MinInt64) // 1677-09-21 00:12:43.145224192
+var maxTime = time.Unix(0, math.MaxInt64) // 2262-04-11 23:47:16.854775807
+
+// validateTime determines whether a timestamp is valid.
+// Valid timestamps can be represented by an int64 number of microseconds from the epoch.
+//
+// Every valid timestamp can be represented by a time.Time, but the converse is not true.
+func validateTime(ts time.Time) error {
+	if ts.Before(minTime) {
+		return fmt.Errorf("timestamp %v before %v", ts, minTime)
+	}
+	if ts.After(maxTime) {
+		return fmt.Errorf("timestamp %v after %v", ts, maxTime)
+	}
+	return nil
+}
+
+// New creates a new source slice from time objects.
+// Returns an error if the time objects cannot be represented correctly.
+func New(logID int64, low, high time.Time) (*SourceSlice, error) {
+	if err := validateTime(low); err != nil {
+		return nil, err
+	}
+	if err := validateTime(high); err != nil {
+		return nil, err
+	}
+	return &SourceSlice{s: &spb.MapMetadata_SourceSlice{
+		LogId:            logID,
+		LowestInclusive:  low.UnixNano(),
+		HighestExclusive: high.UnixNano(),
+	}}, nil
+}
+
+// FromProto returns a wrapper for SourceSlice
+func FromProto(s *spb.MapMetadata_SourceSlice) *SourceSlice {
+	return &SourceSlice{s: s}
 }
 
 // SourceSlice defines accessor and conversion methods for MapMetadata_SourceSlice
+// TODO(gbelvin): fully migrate to source slices that encode time directly.
+// For now, we need to have a wrapper to do the conversions between time and int64 consistently.
 type SourceSlice struct {
 	s *spb.MapMetadata_SourceSlice
 }
@@ -38,4 +75,9 @@ func (s SourceSlice) StartTime() time.Time {
 // EndTime returns HighestExclusive as a time.Time
 func (s SourceSlice) EndTime() time.Time {
 	return time.Unix(0, s.s.GetHighestExclusive())
+}
+
+// Proto returns the proto representation of SourceSlice
+func (s *SourceSlice) Proto() *spb.MapMetadata_SourceSlice {
+	return s.s
 }

--- a/core/sequencer/metadata/sourceslice_test.go
+++ b/core/sequencer/metadata/sourceslice_test.go
@@ -27,10 +27,11 @@ func TestValidateTime(t *testing.T) {
 		{ts: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
 		{ts: time.Date(1000, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
 		{ts: time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC), valid: true},
+		{ts: time.Date(200000, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
 	} {
 		err := validateTime(tc.ts)
 		if got := err == nil; got != tc.valid {
-			t.Errorf("validateTimestamp(%v): %v, want valid: %v", tc.ts, err, tc.valid)
+			t.Errorf("validateTime(%v): %v, want valid: %v", tc.ts, err, tc.valid)
 		}
 	}
 }

--- a/core/sequencer/metadata/sourceslice_test.go
+++ b/core/sequencer/metadata/sourceslice_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package metadata
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidateTime(t *testing.T) {
+	for _, tc := range []struct {
+		ts    time.Time
+		valid bool
+	}{
+		{ts: time.Time{}, valid: false},
+		{ts: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
+		{ts: time.Date(1000, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
+		{ts: time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC), valid: true},
+	} {
+		err := validateTime(tc.ts)
+		if got := err == nil; got != tc.valid {
+			t.Errorf("validateTimestamp(%v): %v, want valid: %v", tc.ts, err, tc.valid)
+		}
+	}
+}

--- a/core/sequencer/sequencer_api.proto
+++ b/core/sequencer/sequencer_api.proto
@@ -31,10 +31,12 @@ message MapMetadata {
     // lowest_inclusive is the lowest primary key (inclusive) of the source
     // log that has been incorporated into this map revision. The primary
     // keys of logged items MUST be monotonically increasing.
+    // Defined in terms of microseconds from the Unix epoch.
     int64 lowest_inclusive = 1;
     // highest_exclusive is the highest primary key (exclusive) of the source
     // log that has been incorporated into this map revision. The primary keys
     // of logged items MUST be monotonically increasing.
+    // Defined in terms of microseconds from the Unix epoch.
     int64 highest_exclusive = 2;
     // log_id is the ID of the source log.
     int64 log_id = 3;

--- a/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
+++ b/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
@@ -76,10 +76,12 @@ type MapMetadata_SourceSlice struct {
 	// lowest_inclusive is the lowest primary key (inclusive) of the source
 	// log that has been incorporated into this map revision. The primary
 	// keys of logged items MUST be monotonically increasing.
+	// Defined in terms of microseconds from the Unix epoch.
 	LowestInclusive int64 `protobuf:"varint,1,opt,name=lowest_inclusive,json=lowestInclusive,proto3" json:"lowest_inclusive,omitempty"`
 	// highest_exclusive is the highest primary key (exclusive) of the source
 	// log that has been incorporated into this map revision. The primary keys
 	// of logged items MUST be monotonically increasing.
+	// Defined in terms of microseconds from the Unix epoch.
 	HighestExclusive int64 `protobuf:"varint,2,opt,name=highest_exclusive,json=highestExclusive,proto3" json:"highest_exclusive,omitempty"`
 	// log_id is the ID of the source log.
 	LogId                int64    `protobuf:"varint,3,opt,name=log_id,json=logId,proto3" json:"log_id,omitempty"`

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -338,7 +338,7 @@ func (s *Server) ApplyRevisions(ctx context.Context, in *spb.ApplyRevisionsReque
 func (s *Server) readMessages(ctx context.Context, source *spb.MapMetadata_SourceSlice,
 	directoryID string, chunkSize int32,
 	emit func(*mutator.LogMessage)) error {
-	ss := metadata.Source(source)
+	ss := metadata.FromProto(source)
 	low := ss.StartTime()
 	high := ss.EndTime()
 	for moreToRead := true; moreToRead; {
@@ -531,6 +531,7 @@ func (s *Server) HighWatermarks(ctx context.Context, directoryID string, lastMet
 	ends := make(map[int64]int64)
 	starts := make(map[int64]int64)
 	for _, source := range lastMeta.GetSources() {
+		// Save the highest watermark if the same LogId appears multiple times.
 		if ends[source.LogId] < source.HighestExclusive {
 			ends[source.LogId] = source.HighestExclusive
 			starts[source.LogId] = source.HighestExclusive

--- a/core/sequencer/server_test.go
+++ b/core/sequencer/server_test.go
@@ -26,11 +26,12 @@ import (
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc"
 
+	"github.com/google/keytransparency/core/sequencer/mapper"
+	"github.com/google/keytransparency/core/sequencer/metadata"
+	"github.com/google/keytransparency/core/sequencer/runner"
 	"github.com/google/keytransparency/impl/memory"
 
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
-	"github.com/google/keytransparency/core/sequencer/mapper"
-	"github.com/google/keytransparency/core/sequencer/runner"
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 	tpb "github.com/google/trillian"
 )
@@ -143,14 +144,14 @@ func TestDefiningRevisions(t *testing.T) {
 		{desc: "skewed", highestRev: mapRev - 1, wantNew: mapRev - 1},
 		{desc: "almost_drained", highestRev: mapRev,
 			meta: spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 0, LowestInclusive: 0, HighestExclusive: 9},
-				{LogId: 1, LowestInclusive: 0, HighestExclusive: 20},
+				newSource(t, 0, zero.Add(0*time.Microsecond), zero.Add(9*time.Microsecond)),
+				newSource(t, 1, zero.Add(0*time.Microsecond), zero.Add(20*time.Microsecond)),
 			}},
 			wantNew: mapRev + 1},
 		{desc: "drained", highestRev: mapRev,
 			meta: spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 0, LowestInclusive: 0, HighestExclusive: idx[0][9].Add(1).UnixNano()},
-				{LogId: 1, LowestInclusive: 0, HighestExclusive: idx[1][19].Add(1).UnixNano()},
+				newSource(t, 0, zero, idx[0][9].Add(1)),
+				newSource(t, 1, zero, idx[1][19].Add(1)),
 			}},
 			wantNew: mapRev},
 	} {
@@ -190,6 +191,15 @@ func TestDefiningRevisions(t *testing.T) {
 	}
 }
 
+func newSource(t *testing.T, logID int64, low, high time.Time) *spb.MapMetadata_SourceSlice {
+	t.Helper()
+	s, err := metadata.New(logID, low, high)
+	if err != nil {
+		t.Fatalf("Invalid source: %v", err)
+	}
+	return s.Proto()
+}
+
 func TestReadMessages(t *testing.T) {
 	ctx := context.Background()
 	dirID := "TestReadMessages"
@@ -202,14 +212,14 @@ func TestReadMessages(t *testing.T) {
 		want      int
 	}{
 		{batchSize: 1, want: 9, meta: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-			{LogId: 0, LowestInclusive: idx[0][1].UnixNano(), HighestExclusive: idx[0][9].Add(1).UnixNano()},
+			newSource(t, 0, idx[0][1], idx[0][9].Add(1)),
 		}}},
 		{batchSize: 10000, want: 9, meta: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-			{LogId: 0, LowestInclusive: idx[0][1].UnixNano(), HighestExclusive: idx[0][9].Add(1).UnixNano()},
+			newSource(t, 0, idx[0][1], idx[0][9].Add(1)),
 		}}},
 		{batchSize: 1, want: 19, meta: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-			{LogId: 0, LowestInclusive: idx[0][1].UnixNano(), HighestExclusive: idx[0][9].Add(1).UnixNano()},
-			{LogId: 1, LowestInclusive: idx[1][1].UnixNano(), HighestExclusive: idx[1][10].Add(1).UnixNano()},
+			newSource(t, 0, idx[0][1], idx[0][9].Add(1)),
+			newSource(t, 1, idx[1][1], idx[1][10].Add(1)),
 		}}},
 	} {
 		logSlices := runner.DoMapMetaFn(mapper.MapMetaFn, tc.meta, fakeMetric)
@@ -238,34 +248,42 @@ func TestHighWatermarks(t *testing.T) {
 	}{
 		{desc: "nobatch", batchSize: 30, count: 30,
 			next: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 0, HighestExclusive: idx[0][9].Add(1).UnixNano()},
-				{LogId: 1, HighestExclusive: idx[1][19].Add(1).UnixNano()}}}},
+				NewTestSource(t, 0, zero, idx[0][9].Add(1)),
+				NewTestSource(t, 1, zero, idx[1][19].Add(1)),
+			}}},
 		{desc: "exactbatch", batchSize: 20, count: 20,
 			next: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 0, HighestExclusive: idx[0][9].Add(1).UnixNano()},
-				{LogId: 1, HighestExclusive: idx[1][9].Add(1).UnixNano()}}}},
+				NewTestSource(t, 0, zero, idx[0][9].Add(1)),
+				NewTestSource(t, 1, zero, idx[1][9].Add(1)),
+			}}},
 		{desc: "batchwprev", batchSize: 20, count: 20,
 			last: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 0, HighestExclusive: idx[0][9].Add(2).UnixNano()}}},
+				newSource(t, 0, zero, idx[0][9].Add(2)),
+			}},
 			next: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
 				// Nothing to read from log 1, preserve watermark of log 1.
-				{LogId: 0, LowestInclusive: idx[0][9].Add(2).UnixNano(), HighestExclusive: idx[0][9].Add(2).UnixNano()},
-				{LogId: 1, HighestExclusive: idx[1][19].Add(1).UnixNano()}}}},
+				NewTestSource(0, idx[0][9].Add(2), idx[0][9].Add(2)),
+				NewTestSource(1, zero, idx[1][19].Add(1)),
+			}}},
 		// Don't drop existing watermarks.
 		{desc: "keep existing", batchSize: 1, count: 1,
 			last: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 1, HighestExclusive: 10}}},
+				newSource(t, 1, zero, zero.Add(10)),
+			}},
 			next: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 0, HighestExclusive: idx[0][0].Add(1).UnixNano()},
+				NewTestSource(t, 0, zero, idx[0][0].Add(1)),
 				// No reads from log 1, but don't drop the watermark.
-				{LogId: 1, LowestInclusive: 10, HighestExclusive: 10}}}},
+				newSource(t, 1, zero.Add(10), zero.Add(10)),
+			}}},
 		{desc: "logs that dont move", batchSize: 0, count: 0,
 			last: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 3, HighestExclusive: 10}}},
+				newSource(t, 3, zero, zero.Add(10*time.Microsecond)),
+			}},
 			next: &spb.MapMetadata{Sources: []*spb.MapMetadata_SourceSlice{
-				{LogId: 0},
-				{LogId: 1},
-				{LogId: 3, LowestInclusive: 10, HighestExclusive: 10}}}},
+				newSource(t, 0, zero, zero),
+				newSource(t, 1, zero, zero),
+				newSource(t, 3, zero.Add(10*time.Microsecond), zero.Add(10*time.Microsecond)),
+			}}},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			count, next, err := s.HighWatermarks(ctx, directoryID, tc.last, tc.batchSize)

--- a/impl/memory/mutation_logs_test.go
+++ b/impl/memory/mutation_logs_test.go
@@ -33,3 +33,14 @@ func TestMutationLogsIntegration(t *testing.T) {
 			return m, func(context.Context) {}
 		})
 }
+
+func TestMutationLogsReaderIntegration(t *testing.T) {
+	storagetest.RunMutationLogsReaderTests(t,
+		func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (storagetest.LogsReadWriter, func(context.Context)) {
+			m := NewMutationLogs()
+			if err := m.AddLogs(ctx, dirID, logIDs...); err != nil {
+				t.Fatal(err)
+			}
+			return m, func(context.Context) {}
+		})
+}

--- a/impl/sql/mutationstorage/mutation_logs.go
+++ b/impl/sql/mutationstorage/mutation_logs.go
@@ -165,6 +165,7 @@ func (m *Mutations) send(ctx context.Context, ts time.Time, directoryID string,
 // equal to batchSize items greater than start.
 func (m *Mutations) HighWatermark(ctx context.Context, directoryID string, logID int64,
 	start time.Time, batchSize int32) (int32, time.Time, error) {
+	startQuery := start.Add(quantum - 1).Truncate(quantum)
 	var count int32
 	var high sql.NullTime
 	if err := m.db.QueryRowContext(ctx,
@@ -175,7 +176,7 @@ func (m *Mutations) HighWatermark(ctx context.Context, directoryID string, logID
 			ORDER BY Q.Time ASC
 			LIMIT ?
 		) AS T1`,
-		directoryID, logID, start, batchSize).
+		directoryID, logID, startQuery, batchSize).
 		Scan(&count, &high); err != nil {
 		return 0, start, err
 	}

--- a/impl/sql/mutationstorage/mutation_logs.go
+++ b/impl/sql/mutationstorage/mutation_logs.go
@@ -181,7 +181,7 @@ func (m *Mutations) HighWatermark(ctx context.Context, directoryID string, logID
 		// When there are no rows, return the start time as the highest timestamp.
 		return 0, start, nil
 	}
-	return count, high.Time.Add(1 * time.Microsecond), nil
+	return count, high.Time.Add(1), nil
 }
 
 // ReadLog reads all mutations in logID between [low, high).

--- a/impl/sql/mutationstorage/mutation_logs_test.go
+++ b/impl/sql/mutationstorage/mutation_logs_test.go
@@ -56,6 +56,13 @@ func TestLogsAdminIntegration(t *testing.T) {
 		})
 }
 
+func TestMutationLogsReaderIntegration(t *testing.T) {
+	storagetest.RunMutationLogsReaderTests(t,
+		func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (storagetest.LogsReadWriter, func(context.Context)) {
+			return newForTest(ctx, t, dirID, logIDs...)
+		})
+}
+
 func BenchmarkSend(b *testing.B) {
 	ctx := context.Background()
 	directoryID := "BenchmarkSend"
@@ -119,55 +126,5 @@ func TestSend(t *testing.T) {
 		if got, want := status.Code(err), tc.wantCode; got != want {
 			t.Errorf("%v: send(): %v, got: %v, want %v", tc.desc, err, got, want)
 		}
-	}
-}
-
-// https://dev.mysql.com/doc/refman/8.0/en/datetime.html
-var minWatermark = time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC)
-
-func TestWatermark(t *testing.T) {
-	ctx := context.Background()
-	directoryID := "TestWatermark"
-	logIDs := []int64{1, 2}
-	m, done := newForTest(ctx, t, directoryID, logIDs...)
-	defer done(ctx)
-	update := []byte("bar")
-
-	start := time.Now().Truncate(time.Microsecond)
-	for ts := start; ts.Before(start.Add(10 * time.Microsecond)); ts = ts.Add(1 * time.Microsecond) {
-		logID := int64(1)
-		if err := m.send(ctx, ts, directoryID, logID, update); err != nil {
-			t.Fatalf("m.send(%v): %v", logID, err)
-		}
-	}
-
-	for _, tc := range []struct {
-		desc      string
-		logID     int64
-		start     time.Time
-		batchSize int32
-		count     int32
-		want      time.Time
-	}{
-		{desc: "log1 max", logID: 1, batchSize: 100, start: start, want: start.Add(10 * time.Microsecond), count: 10},
-		{desc: "log2 empty", logID: 2, batchSize: 100, start: start, want: start},
-		{desc: "batch0", logID: 1, batchSize: 0, start: minWatermark, want: minWatermark},
-		{desc: "batch0start55", logID: 1, start: minWatermark.Add(55 * time.Microsecond), batchSize: 0, want: minWatermark.Add(55 * time.Microsecond)},
-		{desc: "batch5", logID: 1, start: start, batchSize: 5, want: start.Add(5 * time.Microsecond), count: 5},
-		{desc: "start1", logID: 1, start: start.Add(2 * time.Microsecond), batchSize: 5, want: start.Add(7 * time.Microsecond), count: 5},
-		{desc: "start8", logID: 1, start: start.Add(8 * time.Microsecond), batchSize: 5, want: start.Add(10 * time.Microsecond), count: 2},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			count, got, err := m.HighWatermark(ctx, directoryID, tc.logID, tc.start, tc.batchSize)
-			if err != nil {
-				t.Errorf("highWatermark(): %v", err)
-			}
-			if !got.Equal(tc.want) {
-				t.Errorf("highWatermark(%v) high: %v, want %v", tc.start, got, tc.want)
-			}
-			if count != tc.count {
-				t.Errorf("highWatermark(%v) count: %v, want %v", tc.start, count, tc.count)
-			}
-		})
 	}
 }


### PR DESCRIPTION
The MapMetadata struct contains a plain int64, which causes confusion.
We are migrating to make this an explicit time struct, but unfortunately we
can't do this directly due to existing deployments. 

This PR provides a metadata helper library to convert time.Time objects
into these metadata structs.