### PR TITLE
Break layering violation by using native types

### DIFF
--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -63,7 +63,7 @@ func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTe
 	// Write ten batches, three entries each.
 	for i := byte(0); i < 10; i++ {
 		entry := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: mustMarshal(t, &pb.Entry{Index: []byte{i}})}}
-		if _, err := m.Send(ctx, directoryID, entry, entry, entry); err != nil {
+		if _, _, err := m.Send(ctx, directoryID, entry, entry, entry); err != nil {
 			t.Fatalf("Send(): %v", err)
 		}
 	}

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -71,8 +71,8 @@ func (b batchStorage) ReadBatch(ctx context.Context, dirID string, rev int64) (*
 
 type mutations map[int64][]*mutator.LogMessage // Map of logID to Slice of LogMessages
 
-func (m *mutations) Send(ctx context.Context, dirID string, mutation ...*pb.EntryUpdate) (*WriteWatermark, error) {
-	return nil, errors.New("unimplemented")
+func (m *mutations) Send(ctx context.Context, dirID string, mutation ...*pb.EntryUpdate) (int64, time.Time, error) {
+	return 0, time.Time{}, errors.New("unimplemented")
 }
 
 func (m *mutations) ReadLog(ctx context.Context, dirID string,

--- a/impl/sql/mutationstorage/mutation_logs_test.go
+++ b/impl/sql/mutationstorage/mutation_logs_test.go
@@ -123,7 +123,7 @@ func BenchmarkSend(b *testing.B) {
 				updates = append(updates, update)
 			}
 			for n := 0; n < b.N; n++ {
-				if _, err := m.Send(ctx, directoryID, updates...); err != nil {
+				if _, _, err := m.Send(ctx, directoryID, updates...); err != nil {
 					b.Errorf("Send(): %v", err)
 				}
 			}


### PR DESCRIPTION
The storage layer should not have a dependency on the frontend library.

By breakinig this dependency, we can avoid import cycles in later PRs.