### PR TITLE
Move the responsibility to pick an input log from storage to the frontend

### DIFF
--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -63,7 +63,7 @@ func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTe
 	// Write ten batches, three entries each.
 	for i := byte(0); i < 10; i++ {
 		entry := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: mustMarshal(t, &pb.Entry{Index: []byte{i}})}}
-		if _, _, err := m.Send(ctx, directoryID, entry, entry, entry); err != nil {
+		if _, _, err := m.Send(ctx, directoryID, logID, entry, entry, entry); err != nil {
 			t.Fatalf("Send(): %v", err)
 		}
 	}

--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -63,7 +63,7 @@ func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTe
 	// Write ten batches, three entries each.
 	for i := byte(0); i < 10; i++ {
 		entry := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: mustMarshal(t, &pb.Entry{Index: []byte{i}})}}
-		if _, _, err := m.Send(ctx, directoryID, logID, entry, entry, entry); err != nil {
+		if _, err := m.Send(ctx, directoryID, logID, entry, entry, entry); err != nil {
 			t.Fatalf("Send(): %v", err)
 		}
 	}

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -658,7 +658,8 @@ func (s *Server) BatchQueueUserUpdate(ctx context.Context, in *pb.BatchQueueUser
 	}
 	tdone()
 
-	// Save mutation to the database.
+	// Pick a random logID.  Note, this effectively picks a random QoS. See issue #1377.
+	// TODO(gbelvin): Define an explicit QoS / Load ballancing API.
 	wmLogID, err := s.randLog(ctx, directory.DirectoryID)
 	if st := status.Convert(err); st.Code() != codes.OK {
 		return nil, status.Errorf(st.Code(), "Could not pick a log to write to: %v", err)

--- a/core/keyserver/keyserver.go
+++ b/core/keyserver/keyserver.go
@@ -67,10 +67,10 @@ func createMetrics(mf monitoring.MetricFactory) {
 
 // MutationLogs provides sets of time ordered message logs.
 type MutationLogs interface {
-	// Send submits the whole group of mutations atomically to a random log.
+	// Send submits the whole group of mutations atomically to a given log.
 	// TODO(gbelvin): Create a batch level object to make it clear that this a batch of updates.
-	// Returns the logID and timestamp that the mutation batch got written at.
-	Send(ctx context.Context, directoryID string, logID int64, mutation ...*pb.EntryUpdate) (int64, time.Time, error)
+	// Returns the timestamp that the mutation batch got written at.
+	Send(ctx context.Context, directoryID string, logID int64, mutation ...*pb.EntryUpdate) (time.Time, error)
 	// ReadLog returns the messages in the (low, high] range stored in the
 	// specified log. ReadLog always returns complete units of the original
 	// batches sent via Send, and will return  more items than limit if
@@ -657,7 +657,8 @@ func (s *Server) BatchQueueUserUpdate(ctx context.Context, in *pb.BatchQueueUser
 	tdone()
 
 	// Save mutation to the database.
-	wmLogID, wmTime, err := s.logs.Send(ctx, directory.DirectoryID, in.GetLogId(), in.Updates...)
+	wmLogID := in.GetLogId()
+	wmTime, err := s.logs.Send(ctx, directory.DirectoryID, wmLogID, in.Updates...)
 	if st := status.Convert(err); st.Code() != codes.OK {
 		glog.Errorf("mutations.Write failed: %v", err)
 		return nil, status.Errorf(st.Code(), "Mutation write error")

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -71,8 +71,8 @@ func (b batchStorage) ReadBatch(ctx context.Context, dirID string, rev int64) (*
 
 type mutations map[int64][]*mutator.LogMessage // Map of logID to Slice of LogMessages
 
-func (m *mutations) Send(ctx context.Context, dirID string, _ int64, mutation ...*pb.EntryUpdate) (int64, time.Time, error) {
-	return 0, time.Time{}, errors.New("unimplemented")
+func (m *mutations) Send(ctx context.Context, dirID string, _ int64, mutation ...*pb.EntryUpdate) (time.Time, error) {
+	return time.Time{}, errors.New("unimplemented")
 }
 
 func (m *mutations) ReadLog(ctx context.Context, dirID string,

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -71,7 +71,7 @@ func (b batchStorage) ReadBatch(ctx context.Context, dirID string, rev int64) (*
 
 type mutations map[int64][]*mutator.LogMessage // Map of logID to Slice of LogMessages
 
-func (m *mutations) Send(ctx context.Context, dirID string, mutation ...*pb.EntryUpdate) (int64, time.Time, error) {
+func (m *mutations) Send(ctx context.Context, dirID string, _ int64, mutation ...*pb.EntryUpdate) (int64, time.Time, error) {
 	return 0, time.Time{}, errors.New("unimplemented")
 }
 

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -75,6 +75,14 @@ func (m *mutations) Send(ctx context.Context, dirID string, _ int64, mutation ..
 	return time.Time{}, errors.New("unimplemented")
 }
 
+func (m *mutations) ListLogs(ctx context.Context, dirID string, _ bool) ([]int64, error) {
+	logIDs := []int64{}
+	for id := range *m {
+		logIDs = append(logIDs, id)
+	}
+	return logIDs, nil
+}
+
 func (m *mutations) ReadLog(ctx context.Context, dirID string,
 	logID int64, low, high time.Time, batchSize int32) ([]*mutator.LogMessage, error) {
 	logShard := (*m)[logID]

--- a/impl/sql/mutationstorage/mutation_logs.go
+++ b/impl/sql/mutationstorage/mutation_logs.go
@@ -65,16 +65,16 @@ func (m *Mutations) AddLogs(ctx context.Context, directoryID string, logIDs ...i
 // Send writes mutations to the leading edge (by sequence number) of the mutations table.
 // Returns the logID/watermark pair that was written, or nil if nothing was written.
 // TODO(gbelvin): Make updates a slice.
-func (m *Mutations) Send(ctx context.Context, directoryID string, logID int64, updates ...*pb.EntryUpdate) (int64, time.Time, error) {
+func (m *Mutations) Send(ctx context.Context, directoryID string, logID int64, updates ...*pb.EntryUpdate) (time.Time, error) {
 	glog.Infof("mutationstorage: Send(%v, <mutation>)", directoryID)
 	if len(updates) == 0 {
-		return 0, time.Time{}, nil
+		return time.Time{}, nil
 	}
 	updateData := make([][]byte, 0, len(updates))
 	for _, u := range updates {
 		data, err := proto.Marshal(u)
 		if err != nil {
-			return 0, time.Time{}, err
+			return time.Time{}, err
 		}
 		updateData = append(updateData, data)
 	}
@@ -82,9 +82,9 @@ func (m *Mutations) Send(ctx context.Context, directoryID string, logID int64, u
 	// we get timestamp contention.
 	ts := time.Now()
 	if err := m.send(ctx, ts, directoryID, logID, updateData...); err != nil {
-		return 0, time.Time{}, err
+		return time.Time{}, err
 	}
-	return logID, ts, nil
+	return ts, nil
 }
 
 // ListLogs returns a list of all logs for directoryID, optionally filtered for writable logs.

--- a/impl/sql/mutationstorage/mutation_logs_test.go
+++ b/impl/sql/mutationstorage/mutation_logs_test.go
@@ -83,7 +83,7 @@ func BenchmarkSend(b *testing.B) {
 				updates = append(updates, update)
 			}
 			for n := 0; n < b.N; n++ {
-				if _, _, err := m.Send(ctx, directoryID, logID, updates...); err != nil {
+				if _, err := m.Send(ctx, directoryID, logID, updates...); err != nil {
 					b.Errorf("Send(): %v", err)
 				}
 			}

--- a/impl/sql/mutationstorage/mutation_logs_test.go
+++ b/impl/sql/mutationstorage/mutation_logs_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/core/adminserver"
 	"github.com/google/keytransparency/core/integration/storagetest"
 	"github.com/google/keytransparency/core/keyserver"
@@ -57,45 +56,6 @@ func TestLogsAdminIntegration(t *testing.T) {
 		})
 }
 
-func TestRandLog(t *testing.T) {
-	ctx := context.Background()
-	directoryID := "TestRandLog"
-
-	for _, tc := range []struct {
-		desc     string
-		send     []int64
-		wantCode codes.Code
-		wantLogs map[int64]bool
-	}{
-		{desc: "no rows", wantCode: codes.NotFound, wantLogs: map[int64]bool{}},
-		{desc: "one row", send: []int64{10}, wantLogs: map[int64]bool{10: true}},
-		{desc: "second", send: []int64{1, 2, 3}, wantLogs: map[int64]bool{
-			1: true,
-			2: true,
-			3: true,
-		}},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			m, done := newForTest(ctx, t, directoryID, tc.send...)
-			defer done(ctx)
-			logs := make(map[int64]bool)
-			for i := 0; i < 10*len(tc.wantLogs); i++ {
-				logID, err := m.randLog(ctx, directoryID)
-				if got, want := status.Code(err), tc.wantCode; got != want {
-					t.Errorf("randLog(): %v, want %v", got, want)
-				}
-				if err != nil {
-					break
-				}
-				logs[logID] = true
-			}
-			if got, want := logs, tc.wantLogs; !cmp.Equal(got, want) {
-				t.Errorf("logs: %v, want %v", got, want)
-			}
-		})
-	}
-}
-
 func BenchmarkSend(b *testing.B) {
 	ctx := context.Background()
 	directoryID := "BenchmarkSend"
@@ -123,7 +83,7 @@ func BenchmarkSend(b *testing.B) {
 				updates = append(updates, update)
 			}
 			for n := 0; n < b.N; n++ {
-				if _, _, err := m.Send(ctx, directoryID, updates...); err != nil {
+				if _, _, err := m.Send(ctx, directoryID, logID, updates...); err != nil {
 					b.Errorf("Send(): %v", err)
 				}
 			}


### PR DESCRIPTION
Allow clients to specify the mutation input log
This permits quality of service prioritization because
input logs are processed in low to high order.