### PR TITLE
Fix generic comparisons on protobuf messages

### DIFF
--- a/core/sequencer/runner/native_test.go
+++ b/core/sequencer/runner/native_test.go
@@ -17,6 +17,7 @@ package runner
 import (
 	"testing"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/core/mutator/entry"
 
@@ -52,7 +53,7 @@ func TestJoin(t *testing.T) {
 			for g := range Join(tc.leaves, tc.msgs, func(label string) { metrics[label]++ }) {
 				got = append(got, g)
 			}
-			if !cmp.Equal(got, tc.want) {
+			if !cmp.Equal(got, tc.want, cmp.Comparer(proto.Equal)) {
 				t.Errorf("Join(): %v, want %v\n diff: %v",
 					got, tc.want, cmp.Diff(got, tc.want))
 			}


### PR DESCRIPTION
Generated protobuf messages contain internal data structures
that general purpose comparison functions (e.g., reflect.DeepEqual,
pretty.Compare, etc) do not properly compare. It is already the case
today that these functions may report a difference when two messages
are actually semantically equivalent.

Fix all usages by either calling proto.Equal directly if
the top-level types are themselves proto.Message, or by calling
cmp.Equal with the cmp.Comparer(proto.Equal) option specified.
This option teaches cmp to use proto.Equal anytime it encounters
proto.Message types.