### PR TITLE
Library for converting time.Time to sequencer watermarks

### DIFF
--- a/core/keyserver/paginator.go
+++ b/core/keyserver/paginator.go
@@ -65,7 +65,7 @@ func (s SourceList) First() *rtpb.ReadToken {
 		// Empty struct means there is nothing else to page through.
 		return &rtpb.ReadToken{}
 	}
-	st, err := ptypes.TimestampProto(metadata.Source(s[0]).StartTime())
+	st, err := ptypes.TimestampProto(metadata.FromProto(s[0]).StartTime())
 	if err != nil {
 		panic("invalid timestamp")
 	}
@@ -97,7 +97,7 @@ func (s SourceList) Next(rt *rtpb.ReadToken, lastRow *mutator.LogMessage) *rtpb.
 		return &rtpb.ReadToken{} // Encodes to ""
 	}
 
-	st, err := ptypes.TimestampProto(metadata.Source(s[rt.SliceIndex+1]).StartTime())
+	st, err := ptypes.TimestampProto(metadata.FromProto(s[rt.SliceIndex+1]).StartTime())
 	if err != nil {
 		panic("invalid timestamp")
 	}

--- a/core/keyserver/paginator_test.go
+++ b/core/keyserver/paginator_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-
 	"github.com/google/keytransparency/core/mutator"
 
 	tpb "github.com/golang/protobuf/ptypes/timestamp"

--- a/core/keyserver/revisions.go
+++ b/core/keyserver/revisions.go
@@ -141,7 +141,7 @@ func (s *Server) ListMutations(ctx context.Context, in *pb.ListMutationsRequest)
 	}
 
 	// Read PageSize + 1 messages from the log to see if there is another page.
-	high := metadata.Source(meta.Sources[rt.SliceIndex]).EndTime()
+	high := metadata.FromProto(meta.Sources[rt.SliceIndex]).EndTime()
 	logID := meta.Sources[rt.SliceIndex].LogId
 	low, err := ptypes.Timestamp(rt.StartTime)
 	if err != nil {

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/impl/memory"
 
-	protopb "github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	rtpb "github.com/google/keytransparency/core/keyserver/readtoken_go_proto"
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/impl/memory"
 
+	protopb "github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	rtpb "github.com/google/keytransparency/core/keyserver/readtoken_go_proto"
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"

--- a/core/sequencer/metadata/sourceslice.go
+++ b/core/sequencer/metadata/sourceslice.go
@@ -15,17 +15,54 @@
 package metadata
 
 import (
+	"fmt"
+	"math"
 	"time"
 
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 )
 
-// Source returns a wrapper for SourceSlice
-func Source(s *spb.MapMetadata_SourceSlice) SourceSlice {
-	return SourceSlice{s: s}
+var minTime = time.Unix(0, math.MinInt64) // 1677-09-21 00:12:43.145224192
+var maxTime = time.Unix(0, math.MaxInt64) // 2262-04-11 23:47:16.854775807
+
+// validateTime determines whether a timestamp is valid.
+// Valid timestamps can be represented by an int64 number of microseconds from the epoch.
+//
+// Every valid timestamp can be represented by a time.Time, but the converse is not true.
+func validateTime(ts time.Time) error {
+	if ts.Before(minTime) {
+		return fmt.Errorf("timestamp %v before %v", ts, minTime)
+	}
+	if ts.After(maxTime) {
+		return fmt.Errorf("timestamp %v after %v", ts, maxTime)
+	}
+	return nil
+}
+
+// New creates a new source slice from time objects.
+// Returns an error if the time objects cannot be represented correctly.
+func New(logID int64, low, high time.Time) (*SourceSlice, error) {
+	if err := validateTime(low); err != nil {
+		return nil, err
+	}
+	if err := validateTime(high); err != nil {
+		return nil, err
+	}
+	return &SourceSlice{s: &spb.MapMetadata_SourceSlice{
+		LogId:            logID,
+		LowestInclusive:  low.UnixNano(),
+		HighestExclusive: high.UnixNano(),
+	}}, nil
+}
+
+// FromProto returns a wrapper for SourceSlice
+func FromProto(s *spb.MapMetadata_SourceSlice) *SourceSlice {
+	return &SourceSlice{s: s}
 }
 
 // SourceSlice defines accessor and conversion methods for MapMetadata_SourceSlice
+// TODO(gbelvin): fully migrate to source slices that encode time directly.
+// For now, we need to have a wrapper to do the conversions between time and int64 consistently.
 type SourceSlice struct {
 	s *spb.MapMetadata_SourceSlice
 }
@@ -38,4 +75,9 @@ func (s SourceSlice) StartTime() time.Time {
 // EndTime returns HighestExclusive as a time.Time
 func (s SourceSlice) EndTime() time.Time {
 	return time.Unix(0, s.s.GetHighestExclusive())
+}
+
+// Proto returns the proto representation of SourceSlice
+func (s *SourceSlice) Proto() *spb.MapMetadata_SourceSlice {
+	return s.s
 }

--- a/core/sequencer/metadata/sourceslice_test.go
+++ b/core/sequencer/metadata/sourceslice_test.go
@@ -27,10 +27,11 @@ func TestValidateTime(t *testing.T) {
 		{ts: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
 		{ts: time.Date(1000, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
 		{ts: time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC), valid: true},
+		{ts: time.Date(200000, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
 	} {
 		err := validateTime(tc.ts)
 		if got := err == nil; got != tc.valid {
-			t.Errorf("validateTimestamp(%v): %v, want valid: %v", tc.ts, err, tc.valid)
+			t.Errorf("validateTime(%v): %v, want valid: %v", tc.ts, err, tc.valid)
 		}
 	}
 }

--- a/core/sequencer/metadata/sourceslice_test.go
+++ b/core/sequencer/metadata/sourceslice_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package metadata
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidateTime(t *testing.T) {
+	for _, tc := range []struct {
+		ts    time.Time
+		valid bool
+	}{
+		{ts: time.Time{}, valid: false},
+		{ts: time.Date(1, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
+		{ts: time.Date(1000, 0, 0, 0, 0, 0, 0, time.UTC), valid: false},
+		{ts: time.Date(2000, 0, 0, 0, 0, 0, 0, time.UTC), valid: true},
+	} {
+		err := validateTime(tc.ts)
+		if got := err == nil; got != tc.valid {
+			t.Errorf("validateTimestamp(%v): %v, want valid: %v", tc.ts, err, tc.valid)
+		}
+	}
+}

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -338,7 +338,7 @@ func (s *Server) ApplyRevisions(ctx context.Context, in *spb.ApplyRevisionsReque
 func (s *Server) readMessages(ctx context.Context, source *spb.MapMetadata_SourceSlice,
 	directoryID string, chunkSize int32,
 	emit func(*mutator.LogMessage)) error {
-	ss := metadata.Source(source)
+	ss := metadata.FromProto(source)
 	low := ss.StartTime()
 	high := ss.EndTime()
 	for moreToRead := true; moreToRead; {
@@ -531,6 +531,7 @@ func (s *Server) HighWatermarks(ctx context.Context, directoryID string, lastMet
 	ends := make(map[int64]int64)
 	starts := make(map[int64]int64)
 	for _, source := range lastMeta.GetSources() {
+		// Save the highest watermark if the same LogId appears multiple times.
 		if ends[source.LogId] < source.HighestExclusive {
 			ends[source.LogId] = source.HighestExclusive
 			starts[source.LogId] = source.HighestExclusive


### PR DESCRIPTION
This PR effectively makes pb.Watermarks a private object.
By only accessing the watermarks proto through a helper library, we give ourselves the ability to define clear rules for what valid watermarks are. 