### PR TITLE
Don't emit metric err on read err

### DIFF
--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -379,7 +379,6 @@ func (s *Server) ApplyRevision(ctx context.Context, in *spb.ApplyRevisionRequest
 	logSlices := runner.DoMapMetaFn(mapper.MapMetaFn, meta, incMetricFn)
 	logItems, err := runner.DoReadFn(ctx, s.readMessages, logSlices, in.DirectoryId, s.BatchSize, incMetricFn)
 	if err != nil {
-		mutationFailures.Inc(err.Error())
 		return nil, err
 	}
 


### PR DESCRIPTION
Emitting the wrong number of dimensions will cause an error.