### PR TITLE
Define watermarks as micros

### DIFF
--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -32,6 +32,7 @@ import (
 	protopb "github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
 	rtpb "github.com/google/keytransparency/core/keyserver/readtoken_go_proto"
+	"github.com/google/keytransparency/core/sequencer/metadata"
 	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 	tpb "github.com/google/trillian"
 )
@@ -87,6 +88,15 @@ func TestGetRevisionStream(t *testing.T) {
 	}
 }
 
+func newSource(t *testing.T, logID int64, low, high time.Time) *spb.MapMetadata_SourceSlice {
+	t.Helper()
+	s, err := metadata.New(logID, low, high)
+	if err != nil {
+		t.Fatalf("Invalid source: %v", err)
+	}
+	return s.Proto()
+}
+
 type batchStorage map[int64]SourceList // Map of Revision to Sources
 
 func (b batchStorage) ReadBatch(ctx context.Context, dirID string, rev int64) (*spb.MapMetadata, error) {
@@ -127,8 +137,8 @@ func TestListMutations(t *testing.T) {
 	}
 
 	fakeBatches := batchStorage{
-		1: SourceList{{LogId: 0, LowestInclusive: idx[2].UnixNano(), HighestExclusive: idx[7].UnixNano()}},
-		2: SourceList{{LogId: 0, LowestInclusive: idx[7].UnixNano(), HighestExclusive: idx[11].UnixNano()}},
+		1: SourceList{newSource(t, 0, idx[2], idx[7])},
+		2: SourceList{newSource(t, 0, idx[7], idx[11])},
 	}
 
 	for _, tc := range []struct {

--- a/core/sequencer/metadata/sourceslice.go
+++ b/core/sequencer/metadata/sourceslice.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package metadata helps enforce a consistent standard of meaning around the map metadata object.
 package metadata
 
 import (
@@ -24,6 +25,7 @@ import (
 
 var minTime = time.Unix(0, math.MinInt64) // 1677-09-21 00:12:43.145224192
 var maxTime = time.Unix(0, math.MaxInt64) // 2262-04-11 23:47:16.854775807
+const nanosPerQuantum = int64(time.Microsecond / time.Nanosecond)
 
 // validateTime determines whether a timestamp is valid.
 // Valid timestamps can be represented by an int64 number of microseconds from the epoch.
@@ -50,8 +52,8 @@ func New(logID int64, low, high time.Time) (*SourceSlice, error) {
 	}
 	return &SourceSlice{s: &spb.MapMetadata_SourceSlice{
 		LogId:            logID,
-		LowestInclusive:  low.UnixNano(),
-		HighestExclusive: high.UnixNano(),
+		LowestInclusive:  low.UnixNano() / nanosPerQuantum,
+		HighestExclusive: high.UnixNano() / nanosPerQuantum,
 	}}, nil
 }
 
@@ -69,12 +71,12 @@ type SourceSlice struct {
 
 // StartTime returns LowestInclusive as a time.Time
 func (s SourceSlice) StartTime() time.Time {
-	return time.Unix(0, s.s.GetLowestInclusive())
+	return time.Unix(0, s.s.GetLowestInclusive()*nanosPerQuantum)
 }
 
 // EndTime returns HighestExclusive as a time.Time
 func (s SourceSlice) EndTime() time.Time {
-	return time.Unix(0, s.s.GetHighestExclusive())
+	return time.Unix(0, s.s.GetHighestExclusive()*nanosPerQuantum)
 }
 
 // Proto returns the proto representation of SourceSlice

--- a/core/sequencer/metadata/sourceslice.go
+++ b/core/sequencer/metadata/sourceslice.go
@@ -25,7 +25,8 @@ import (
 
 var minTime = time.Unix(0, math.MinInt64) // 1677-09-21 00:12:43.145224192
 var maxTime = time.Unix(0, math.MaxInt64) // 2262-04-11 23:47:16.854775807
-const nanosPerQuantum = int64(time.Microsecond / time.Nanosecond)
+const quantum = time.Microsecond
+const nanosPerQuantum = int64(quantum / time.Nanosecond)
 
 // validateTime determines whether a timestamp is valid.
 // Valid timestamps can be represented by an int64 number of microseconds from the epoch.
@@ -52,8 +53,8 @@ func New(logID int64, low, high time.Time) (*SourceSlice, error) {
 	}
 	return &SourceSlice{s: &spb.MapMetadata_SourceSlice{
 		LogId:            logID,
-		LowestInclusive:  low.UnixNano() / nanosPerQuantum,
-		HighestExclusive: high.UnixNano() / nanosPerQuantum,
+		LowestInclusive:  low.Add(quantum-1).Truncate(quantum).UnixNano() / nanosPerQuantum,
+		HighestExclusive: high.Add(quantum-1).Truncate(quantum).UnixNano() / nanosPerQuantum,
 	}}, nil
 }
 

--- a/core/sequencer/metadata/sourceslice_test.go
+++ b/core/sequencer/metadata/sourceslice_test.go
@@ -16,6 +16,10 @@ package metadata
 import (
 	"testing"
 	"time"
+
+	"github.com/golang/protobuf/proto"
+
+	spb "github.com/google/keytransparency/core/sequencer/sequencer_go_proto"
 )
 
 func TestValidateTime(t *testing.T) {
@@ -32,6 +36,25 @@ func TestValidateTime(t *testing.T) {
 		err := validateTime(tc.ts)
 		if got := err == nil; got != tc.valid {
 			t.Errorf("validateTime(%v): %v, want valid: %v", tc.ts, err, tc.valid)
+		}
+	}
+}
+
+func TestTimeToProto(t *testing.T) {
+	logID := int64(1)
+	for _, tc := range []struct {
+		low, high time.Time
+		want      *spb.MapMetadata_SourceSlice
+	}{
+		{low: time.Unix(0, 0), high: time.Unix(1, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 0, HighestExclusive: 1000000}},
+		{low: time.Unix(0, 1), high: time.Unix(1, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 1, HighestExclusive: 1000000}},
+	} {
+		ss, err := New(logID, tc.low, tc.high)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := ss.Proto(); !proto.Equal(got, tc.want) {
+			t.Errorf("New().Proto(): %v, want %v", got, tc.want)
 		}
 	}
 }

--- a/core/sequencer/metadata/sourceslice_test.go
+++ b/core/sequencer/metadata/sourceslice_test.go
@@ -46,8 +46,11 @@ func TestTimeToProto(t *testing.T) {
 		low, high time.Time
 		want      *spb.MapMetadata_SourceSlice
 	}{
-		{low: time.Unix(0, 0), high: time.Unix(1, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 0, HighestExclusive: 1000000}},
-		{low: time.Unix(0, 1), high: time.Unix(1, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 1, HighestExclusive: 1000000}},
+		{low: time.Unix(0, 0), high: time.Unix(0, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 0}},
+		{low: time.Unix(0, 1), high: time.Unix(0, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 1}},
+		{low: time.Unix(0, 1000), high: time.Unix(0, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 1}},
+		{low: time.Unix(1, 0), high: time.Unix(0, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 1000000}},
+		{low: time.Unix(1, 0), high: time.Unix(1, 0), want: &spb.MapMetadata_SourceSlice{LogId: logID, LowestInclusive: 1000000, HighestExclusive: 1000000}},
 	} {
 		ss, err := New(logID, tc.low, tc.high)
 		if err != nil {

--- a/core/sequencer/sequencer_api.proto
+++ b/core/sequencer/sequencer_api.proto
@@ -31,10 +31,12 @@ message MapMetadata {
     // lowest_inclusive is the lowest primary key (inclusive) of the source
     // log that has been incorporated into this map revision. The primary
     // keys of logged items MUST be monotonically increasing.
+    // Defined in terms of microseconds from the Unix epoch.
     int64 lowest_inclusive = 1;
     // highest_exclusive is the highest primary key (exclusive) of the source
     // log that has been incorporated into this map revision. The primary keys
     // of logged items MUST be monotonically increasing.
+    // Defined in terms of microseconds from the Unix epoch.
     int64 highest_exclusive = 2;
     // log_id is the ID of the source log.
     int64 log_id = 3;

--- a/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
+++ b/core/sequencer/sequencer_go_proto/sequencer_api.pb.go
@@ -76,10 +76,12 @@ type MapMetadata_SourceSlice struct {
 	// lowest_inclusive is the lowest primary key (inclusive) of the source
 	// log that has been incorporated into this map revision. The primary
 	// keys of logged items MUST be monotonically increasing.
+	// Defined in terms of microseconds from the Unix epoch.
 	LowestInclusive int64 `protobuf:"varint,1,opt,name=lowest_inclusive,json=lowestInclusive,proto3" json:"lowest_inclusive,omitempty"`
 	// highest_exclusive is the highest primary key (exclusive) of the source
 	// log that has been incorporated into this map revision. The primary keys
 	// of logged items MUST be monotonically increasing.
+	// Defined in terms of microseconds from the Unix epoch.
 	HighestExclusive int64 `protobuf:"varint,2,opt,name=highest_exclusive,json=highestExclusive,proto3" json:"highest_exclusive,omitempty"`
 	// log_id is the ID of the source log.
 	LogId                int64    `protobuf:"varint,3,opt,name=log_id,json=logId,proto3" json:"log_id,omitempty"`


### PR DESCRIPTION
Some time ago, different instances of Key Transparency had different units / meanings for the `int64`'s stored in `MapMetadata`.   When we switched to `time.Time` based APIs in 575344f256a6ca2e5fea3a9c3025aa69d57f63e3,  the open source `MapMetadata` silently acquired a definition of unix nanos and this change nearly caused an outage. 

This PR synchronizes the open source definition of `MapMetadata` with the unix micro one we had been defacto using internally. 