### PR TITLE
Fixups for deleted test constructor in trillian repo

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -16,13 +16,14 @@ package main
 
 import (
 	"context"
+	"crypto"
 	"crypto/tls"
 	"flag"
 	"net"
 	"net/http"
 
 	"github.com/golang/glog"
-	"github.com/google/trillian/crypto"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -75,7 +76,7 @@ func main() {
 	if err != nil {
 		glog.Exitf("Could not create signer from %v: %v", *signingKey, err)
 	}
-	signer := crypto.NewSHA256Signer(key)
+	signer := tcrypto.NewSigner(0, key, crypto.SHA256)
 	store := fake.NewMonitorStorage()
 
 	// Create monitoring background process.

--- a/core/integration/monitor_tests.go
+++ b/core/integration/monitor_tests.go
@@ -16,6 +16,7 @@ package integration
 
 import (
 	"context"
+	"crypto"
 	"sync"
 	"testing"
 	"time"
@@ -28,7 +29,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/google/trillian/crypto"
+	tcrypto "github.com/google/trillian/crypto"
 	"github.com/google/trillian/crypto/keys/pem"
 
 	tpb "github.com/google/keytransparency/core/testdata/transcript_go_proto"
@@ -49,7 +50,7 @@ func TestMonitor(ctx context.Context, env *Env, t *testing.T) []*tpb.Action {
 	if err != nil {
 		t.Fatalf("Couldn't create signer: %v", err)
 	}
-	signer := crypto.NewSHA256Signer(privKey)
+	signer := tcrypto.NewSigner(0, privKey, crypto.SHA256)
 	store := fake.NewMonitorStorage()
 	mon, err := monitor.NewFromDirectory(env.Cli, env.Directory, signer, store)
 	if err != nil {


### PR DESCRIPTION
Was removed in https://github.com/google/trillian/pull/1997. Sorry, wasn't aware it was in use in KT.