### PR TITLE
Use ProtoEqual for gomock reflection equality

### DIFF
--- a/core/keyserver/keyserver_test.go
+++ b/core/keyserver/keyserver_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/keytransparency/core/directory"
 	"github.com/google/keytransparency/core/fake"
 	"github.com/google/trillian/testonly"
+	"github.com/google/trillian/testonly/matchers"
 	"github.com/google/trillian/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -123,11 +124,12 @@ func TestLatestRevision(t *testing.T) {
 				}, err)
 			if tc.wantErr == codes.OK {
 				e.s.Map.EXPECT().GetLeafByRevision(gomock.Any(),
-					&tpb.GetMapLeafByRevisionRequest{
-						MapId:    mapID,
-						Index:    make([]byte, 32),
-						Revision: tc.treeSize - 1,
-					}).
+					matchers.ProtoEqual(
+						&tpb.GetMapLeafByRevisionRequest{
+							MapId:    mapID,
+							Index:    make([]byte, 32),
+							Revision: tc.treeSize - 1,
+						})).
 					Return(&tpb.GetMapLeafResponse{
 						MapLeafInclusion: &tpb.MapLeafInclusion{
 							Leaf: &tpb.MapLeaf{
@@ -156,11 +158,11 @@ func TestLatestRevision(t *testing.T) {
 				}, err).Times(2)
 			for i := int64(0); i < tc.treeSize; i++ {
 				e.s.Map.EXPECT().GetLeafByRevision(gomock.Any(),
-					&tpb.GetMapLeafByRevisionRequest{
+					matchers.ProtoEqual(&tpb.GetMapLeafByRevisionRequest{
 						MapId:    mapID,
 						Index:    make([]byte, 32),
 						Revision: i,
-					}).
+					})).
 					Return(&tpb.GetMapLeafResponse{
 						MapLeafInclusion: &tpb.MapLeafInclusion{
 							Leaf: &tpb.MapLeaf{

--- a/core/keyserver/revisions_test.go
+++ b/core/keyserver/revisions_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/keytransparency/impl/memory"
+	"github.com/google/trillian/testonly/matchers"
 
 	protopb "github.com/golang/protobuf/ptypes/timestamp"
 	pb "github.com/google/keytransparency/core/api/v1/keytransparency_go_proto"
@@ -171,10 +172,11 @@ func TestListMutations(t *testing.T) {
 
 			if !tc.wantErr {
 				e.s.Map.EXPECT().GetLeavesByRevision(gomock.Any(),
-					&tpb.GetMapLeavesByRevisionRequest{
-						MapId: mapID,
-						Index: genIndexes(tc.start, tc.end),
-					}).Return(&tpb.GetMapLeavesResponse{
+					matchers.ProtoEqual(
+						&tpb.GetMapLeavesByRevisionRequest{
+							MapId: mapID,
+							Index: genIndexes(tc.start, tc.end),
+						})).Return(&tpb.GetMapLeavesResponse{
 					MapLeafInclusion: genInclusions(tc.start, tc.end),
 				}, nil)
 			}


### PR DESCRIPTION
Protobufs should not be compared with `reflection.DeepEqual` which is that the `gomock` matchers do by default.