### PR TITLE
Improve mutation log integration tests

### DIFF
--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -54,7 +54,7 @@ func mustMarshal(t *testing.T, p proto.Message) []byte {
 	return b
 }
 
-// The lowest common denominator for the minimum timestamp supported between all implementations.
+// The minimum timestamp supported between all implementations.
 var minWatermark = time.Unix(0, 0)
 
 // TestReadLog ensures that reads happen in atomic units of batch size.

--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -66,8 +66,12 @@ func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTe
 	// Write ten batches.
 	for i := byte(0); i < 10; i++ {
 		entry := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: mustMarshal(t, &pb.Entry{Index: []byte{i}})}}
-		if _, err := m.Send(ctx, directoryID, logID, entry, entry, entry); err != nil {
+		ts, err := m.Send(ctx, directoryID, logID, entry, entry, entry)
+		if err != nil {
 			t.Fatalf("Send(): %v", err)
+		}
+		if ts.Before(minWatermark) {
+			t.Fatalf("Send(): %v is before min watermark %v", ts, minWatermark)
 		}
 	}
 

--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -54,8 +54,8 @@ func mustMarshal(t *testing.T, p proto.Message) []byte {
 	return b
 }
 
-// https://dev.mysql.com/doc/refman/8.0/en/datetime.html
-var minWatermark = time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC)
+// The lowest common denominator for the minimum timestamp supported between all implementations.
+var minWatermark = time.Unix(0, 0)
 
 // TestReadLog ensures that reads happen in atomic units of batch size.
 func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTest mutationLogsFactory) {

--- a/impl/memory/mutation_logs.go
+++ b/impl/memory/mutation_logs.go
@@ -97,8 +97,8 @@ func (m MutationLogs) ReadLog(_ context.Context, _ string,
 	start := sort.Search(len(logShard), func(i int) bool { return !logShard[i].time.Before(low) })
 	end := sort.Search(len(logShard), func(i int) bool { return !logShard[i].time.Before(high) })
 	// If the search is unsuccessful, i will be equal to len(logShard).
-	if start == len(logShard) && logShard[start].time.Before(low) {
-		return nil, fmt.Errorf("invalid argument: low: %v, want <= max watermark: %v", low, logShard[start].time)
+	if start == len(logShard) && logShard[start-1].time.Before(low) {
+		return nil, fmt.Errorf("invalid argument: low: %v, want <= max watermark: %v", low, logShard[start-1].time)
 	}
 	out := make([]*mutator.LogMessage, 0, batchSize)
 	for i := start; i < end; i++ {


### PR DESCRIPTION
- Remove dependency on time.Now
- Check validity of insert timestamps
- Support implementations based on unix seconds