### PR TITLE
Fix deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,8 @@ jobs:
       if: branch = master AND type != pull_request
       install:
       - curl -LO "https://storage.googleapis.com/kubernetes-release/release/v1.16.3/bin/linux/amd64/kubectl" && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - kubectl version
       - openssl aes-256-cbc -K $encrypted_555d9b2948d2_key -iv $encrypted_555d9b2948d2_iv
-        -in client_secrets.json.enc -d | gcloud auth activate-service-account --key-file /dev/stdin
+        -in client_secrets.json.enc -d | gcloud auth activate-ervice-account --key-file /dev/stdin
       script: ./scripts/deploy.sh
 
 before_install:


### PR DESCRIPTION
One can't ask for the kubectl version before creds to the k8 cluster have been established