### PR TITLE
Setup liveness and readiness k8 probes

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -50,7 +50,7 @@ var (
 
 	signingKey         = flag.String("sign-key", "genfiles/monitor_sign-key.pem", "Path to private key PEM for SMH signing")
 	signingKeyPassword = flag.String("password", "towel", "Password of the private key PEM file for SMH signing")
-	ktURL              = flag.String("kt-url", "localhost:8080", "URL of key-server.")
+	ktURL              = flag.String("kt-url", "localhost:443", "URL of key-server.")
 	insecure           = flag.Bool("insecure", false, "Skip TLS checks")
 	directoryID        = flag.String("directoryid", "", "KT Directory identifier to monitor")
 

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -138,6 +138,8 @@ func main() {
 	// Insert handlers for other http paths here.
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/healthz", serverutil.Healthz())
+	mux.Handle("/readyz", serverutil.Healthz())
 	mux.Handle("/", gwmux)
 
 	// Serve HTTP2 server over TLS.

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -140,7 +140,7 @@ func main() {
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.Handle("/healthz", serverutil.Healthz())
 	mux.Handle("/readyz", serverutil.Healthz())
-	mux.Handle("/", gwmux)
+	mux.Handle("/", serverutil.RootHealthHandler(gwmux))
 
 	// Serve HTTP2 server over TLS.
 	glog.Infof("Listening on %v", *addr)

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -80,6 +80,9 @@ func main() {
 	var config *pb.Directory
 	if err := b.Retry(cctx, func() (err error) {
 		config, err = ktClient.GetDirectory(ctx, &pb.GetDirectoryRequest{DirectoryId: *directoryID})
+		if err != nil {
+			glog.Errorf("GetDirectory(%v/%v): %v", *ktURL, *directoryID, err)
+		}
 		return
 	}, codes.Unavailable); err != nil {
 		glog.Exitf("Could not read directory info %v:", err)

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -185,7 +185,7 @@ func main() {
 	glog.Infof("Signer starting")
 
 	// Run servers
-	go serveHTTPMetric(*metricsAddr)
+	go serveHTTPMetric(*metricsAddr, sqldb)
 	go serveHTTPGateway(ctx, lis, dopts, grpcServer,
 		pb.RegisterKeyTransparencyAdminHandlerFromEndpoint,
 	)

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -185,7 +185,7 @@ func main() {
 	glog.Infof("Signer starting")
 
 	// Run servers
-	go serveHTTPMetric(*metricsAddr, sqldb)
+	go serveHTTPMetrics(*metricsAddr, sqldb)
 	go serveHTTPGateway(ctx, lis, dopts, grpcServer,
 		pb.RegisterKeyTransparencyAdminHandlerFromEndpoint,
 	)

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"net"
 	"net/http"
 
@@ -26,9 +27,11 @@ import (
 	"google.golang.org/grpc"
 )
 
-func serveHTTPMetric(addr string) {
+func serveHTTPMetric(addr string, sqldb *sql.DB) {
 	metricMux := http.NewServeMux()
 	metricMux.Handle("/metrics", promhttp.Handler())
+	metricMux.Handle("/healthz", serverutil.Healthz())
+	metricMux.Handle("/readyz", serverutil.Readyz(sqldb))
 
 	glog.Infof("Hosting metrics on %v", addr)
 	if err := http.ListenAndServe(addr, metricMux); err != nil {

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -32,6 +32,7 @@ func serveHTTPMetric(addr string, sqldb *sql.DB) {
 	metricMux.Handle("/metrics", promhttp.Handler())
 	metricMux.Handle("/healthz", serverutil.Healthz())
 	metricMux.Handle("/readyz", serverutil.Readyz(sqldb))
+	metricMux.Handle("/", serverutil.Healthz())
 
 	glog.Infof("Hosting metrics on %v", addr)
 	if err := http.ListenAndServe(addr, metricMux); err != nil {

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -27,15 +27,15 @@ import (
 	"google.golang.org/grpc"
 )
 
-func serveHTTPMetric(addr string, sqldb *sql.DB) {
-	metricMux := http.NewServeMux()
-	metricMux.Handle("/metrics", promhttp.Handler())
-	metricMux.Handle("/healthz", serverutil.Healthz())
-	metricMux.Handle("/readyz", serverutil.Readyz(sqldb))
-	metricMux.Handle("/", serverutil.Healthz())
+func serveHTTPMetrics(addr string, sqldb *sql.DB) {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/healthz", serverutil.Healthz())
+	mux.Handle("/readyz", serverutil.Readyz(sqldb))
+	mux.Handle("/", serverutil.Healthz())
 
-	glog.Infof("Hosting metrics on %v", addr)
-	if err := http.ListenAndServe(addr, metricMux); err != nil {
+	glog.Infof("Hosting server status and metrics on %v", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil {
 		glog.Fatalf("ListenAndServeTLS(%v): %v", addr, err)
 	}
 }

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -49,7 +49,7 @@ func serveHTTPGateway(ctx context.Context, lis net.Listener, dopts []grpc.DialOp
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/", gwmux)
+	mux.Handle("/", serverutil.RootHealthHandler(gwmux))
 
 	server := &http.Server{Handler: serverutil.GrpcHandlerFunc(grpcServer, mux)}
 	if err := server.ServeTLS(lis, *certFile, *keyFile); err != nil {

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -158,6 +158,7 @@ func main() {
 	metricMux.Handle("/healthz", serverutil.Healthz())
 	metricMux.Handle("/readyz", serverutil.Readyz(sqldb))
 	metricMux.Handle("/metrics", promhttp.Handler())
+	metricMux.Handle("/", serverutil.Healthz())
 	go func() {
 		glog.Infof("Hosting metrics on %v", *metricsAddr)
 		if err := http.ListenAndServe(*metricsAddr, metricMux); err != nil {

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -152,7 +152,7 @@ func main() {
 
 	// Insert handlers for other http paths here.
 	mux := http.NewServeMux()
-	mux.Handle("/", gwmux)
+	mux.Handle("/", serverutil.RootHealthHandler(gwmux))
 
 	metricMux := http.NewServeMux()
 	metricMux.Handle("/healthz", serverutil.Healthz())

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -155,6 +155,8 @@ func main() {
 	mux.Handle("/", gwmux)
 
 	metricMux := http.NewServeMux()
+	metricMux.Handle("/healthz", serverutil.Healthz())
+	metricMux.Handle("/readyz", serverutil.Readyz(sqldb))
 	metricMux.Handle("/metrics", promhttp.Handler())
 	go func() {
 		glog.Infof("Hosting metrics on %v", *metricsAddr)

--- a/cmd/serverutil/healthz.go
+++ b/cmd/serverutil/healthz.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/serverutil/healthz.go
+++ b/cmd/serverutil/healthz.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverutil
+
+import "net/http"
+
+// Healthz is a liveness probe.
+func Healthz() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/cmd/serverutil/readyz.go
+++ b/cmd/serverutil/readyz.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/serverutil/readyz.go
+++ b/cmd/serverutil/readyz.go
@@ -1,0 +1,31 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serverutil
+
+import (
+	"database/sql"
+	"net/http"
+)
+
+// Readyz is a readiness probe.
+func Readyz(db *sql.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if db == nil || db.PingContext(r.Context()) != nil {
+			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/cmd/serverutil/serverutil.go
+++ b/cmd/serverutil/serverutil.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package serverutil provides helper functions to main.go files.
 package serverutil
 
 import (

--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -31,6 +31,14 @@ spec:
         - --alsologtostderr
         - --v=3
         image: gcr.io/key-transparency/keytransparency-monitor:latest
+        livenessProbe:
+         httpGet:
+           path: /healthz
+           port: 8099
+        readinessProbe:
+         httpGet:
+           path: /readyz
+           port: 8099
         name: monitor
         ports:
         - containerPort: 8099

--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -35,10 +35,12 @@ spec:
          httpGet:
            path: /healthz
            port: 8099
+           scheme: HTTPS
         readinessProbe:
          httpGet:
            path: /readyz
            port: 8099
+           scheme: HTTPS
         name: monitor
         ports:
         - containerPort: 8099

--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       - command:
         - /keytransparency-monitor
         - --addr=0.0.0.0:8099
-        - --kt-url=server:8080
+        - --kt-url=server:443
         - --insecure
         - --directoryid=default
         - --tls-key=/run/secrets/server.key

--- a/deploy/kubernetes/base/sequencer-deployment.yaml
+++ b/deploy/kubernetes/base/sequencer-deployment.yaml
@@ -32,7 +32,11 @@ spec:
         image: gcr.io/key-transparency/keytransparency-sequencer:latest
         livenessProbe:
          httpGet:
-           path: /metrics
+           path: /healthz
+           port: 8081
+        readinessProbe:
+         httpGet:
+           path: /readyz
            port: 8081
         name: sequencer
         ports:

--- a/deploy/kubernetes/base/server-deployment.yaml
+++ b/deploy/kubernetes/base/server-deployment.yaml
@@ -32,7 +32,11 @@ spec:
         image: gcr.io/key-transparency/keytransparency-server:latest
         livenessProbe:
          httpGet:
-           path: /metrics
+           path: /healthz
+           port: 8081
+        readinessProbe:
+         httpGet:
+           path: /readyz
            port: 8081
         name: server
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
     labels:
       kompose.service.type: LoadBalancer
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/metrics"]
+      test: ["CMD", "curl", "-f", "http://localhost:8081/readyz"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -165,7 +165,7 @@ services:
       - "8080"
       - "8081"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/metrics"]
+      test: ["CMD", "curl", "-f", "http://localhost:8081/readyz"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -6,6 +6,7 @@ if [ ! -f genfiles/server.key ]; then
 	./scripts/prepare_server.sh -f
 fi
 
+docker-compose build --parallel
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 trap "docker-compose down" INT EXIT
 TIMEOUT=2m

--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -6,7 +6,6 @@ if [ ! -f genfiles/server.key ]; then
 	./scripts/prepare_server.sh -f
 fi
 
-docker-compose build --parallel
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 trap "docker-compose down" INT EXIT
 TIMEOUT=2m
@@ -18,7 +17,7 @@ timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(d
 timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q server)`" == "running" ]; do sleep 0.1; done;'
 timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q monitor)`" == "running" ]; do sleep 0.1; done;'
 
-wget -T 60 --spider --retry-connrefused --waitretry=1 http://localhost:8081/metrics
+wget -T 60 --spider --retry-connrefused --waitretry=1 http://localhost:8081/readyz
 wget -T 60 -O /dev/null --no-check-certificate  \
 	--retry-connrefused --waitretry=1 \
 	--retry-on-http-error=405,404,503 \

--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -6,7 +6,6 @@ if [ ! -f genfiles/server.key ]; then
 	./scripts/prepare_server.sh -f
 fi
 
-docker-compose build --parallel
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 trap "docker-compose down" INT EXIT
 TIMEOUT=2m

--- a/scripts/kubernetes_test.sh
+++ b/scripts/kubernetes_test.sh
@@ -42,7 +42,7 @@ timeout ${TIMEOUT} kubectl rollout status deployment/monitor
 timeout ${TIMEOUT} kubectl rollout status deployment/sequencer
 timeout ${TIMEOUT} kubectl rollout status deployment/server
 
-wget -T 60 --spider --retry-connrefused --waitretry=1 http://localhost:8081/metrics
+wget -T 60 --spider --retry-connrefused --waitretry=1 http://localhost:8081/readyz
 wget -T 60 -O /dev/null --no-check-certificate  \
 	--retry-connrefused --waitretry=1 \
 	--retry-on-http-error=405,404,503 \


### PR DESCRIPTION
As a precondition for using a GKE load ballancer, we must define readiness probes.

https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#limitations
https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/