### PR TITLE
Remove kompose k8 cruft

### DIFF
--- a/deploy/kubernetes/base/db-deployment.yaml
+++ b/deploy/kubernetes/base/db-deployment.yaml
@@ -1,10 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db

--- a/deploy/kubernetes/base/db-service.yaml
+++ b/deploy/kubernetes/base/db-service.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: db
   name: db

--- a/deploy/kubernetes/base/init-pod.yaml
+++ b/deploy/kubernetes/base/init-pod.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     io.kompose.service: init
   name: init

--- a/deploy/kubernetes/base/log-server-deployment.yaml
+++ b/deploy/kubernetes/base/log-server-deployment.yaml
@@ -1,10 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: log-server
   name: log-server

--- a/deploy/kubernetes/base/log-server-service.yaml
+++ b/deploy/kubernetes/base/log-server-service.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: log-server
   name: log-server

--- a/deploy/kubernetes/base/log-signer-deployment.yaml
+++ b/deploy/kubernetes/base/log-signer-deployment.yaml
@@ -1,10 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: log-signer
   name: log-signer

--- a/deploy/kubernetes/base/log-signer-service.yaml
+++ b/deploy/kubernetes/base/log-signer-service.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: log-signer
   name: log-signer

--- a/deploy/kubernetes/base/map-server-deployment.yaml
+++ b/deploy/kubernetes/base/map-server-deployment.yaml
@@ -1,10 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: map-server
   name: map-server

--- a/deploy/kubernetes/base/map-server-service.yaml
+++ b/deploy/kubernetes/base/map-server-service.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: map-server
   name: map-server

--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -1,10 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: monitor
   name: monitor

--- a/deploy/kubernetes/base/monitor-service.yaml
+++ b/deploy/kubernetes/base/monitor-service.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: monitor
   name: monitor

--- a/deploy/kubernetes/base/prometheus-deployment.yaml
+++ b/deploy/kubernetes/base/prometheus-deployment.yaml
@@ -1,10 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: prometheus
   name: prometheus

--- a/deploy/kubernetes/base/prometheus-service.yaml
+++ b/deploy/kubernetes/base/prometheus-service.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: prometheus
   name: prometheus

--- a/deploy/kubernetes/base/sequencer-deployment.yaml
+++ b/deploy/kubernetes/base/sequencer-deployment.yaml
@@ -1,10 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: sequencer
   name: sequencer

--- a/deploy/kubernetes/base/sequencer-service.yaml
+++ b/deploy/kubernetes/base/sequencer-service.yaml
@@ -1,10 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: sequencer
   name: sequencer

--- a/deploy/kubernetes/base/server-deployment.yaml
+++ b/deploy/kubernetes/base/server-deployment.yaml
@@ -1,11 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.service.type: LoadBalancer
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: server
   name: server

--- a/deploy/kubernetes/base/server-service.yaml
+++ b/deploy/kubernetes/base/server-service.yaml
@@ -1,11 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    kompose.cmd: kompose convert --file ../../docker-compose.yml
-    kompose.service.type: LoadBalancer
-    kompose.version: 1.14.0 ()
-  creationTimestamp: null
   labels:
     io.kompose.service: server
   name: server


### PR DESCRIPTION
The Kubernetes configs were originally created with `kompose convert` but the k8 configs have since significantly diverged due to sidecars, local and gke specific configs. 

This PR removes kompose metadata that is no longer correct. 

The k8 configs and the docker-compose configs are currently maintained by hand because there is not an exact 1:1 feature mapping between them. 