### PR TITLE
Fix Docker HEALTHCHECK

### DIFF
--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -1,0 +1,41 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// healthcheck makes a HTTP(S) request to the supplied url and exits with 0
+// (success) if the HTTP response code was in the 2xx range or 1 (unhealthy).
+//
+// TLS certificate errors are ignored in order to support self-signed certs.
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("Expected URL as command-line argument")
+	}
+	url := os.Args[1]
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatalf("http.Get(%v): %v", url, err)
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+		log.Fatalf("HTTP status %v was not in the 2xx range", resp.StatusCode)
+	}
+}

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -33,7 +33,7 @@ func main() {
 	//nolint:gas
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
-	// TODO(gbelvin): sanitize user input to avoice SSRF attacks.
+	//nolint:gas
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Fatalf("http.Get(%v): %v", url, err)

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -30,7 +30,10 @@ func main() {
 		log.Fatal("Expected URL as command-line argument")
 	}
 	url := os.Args[1]
+	//nolint:gas
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	// TODO(gbelvin): sanitize user input to avoice SSRF attacks.
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Fatalf("http.Get(%v): %v", url, err)

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2020 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,10 +31,10 @@ func main() {
 	}
 	url := os.Args[1]
 	//nolint:gas
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	client := &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
 
 	//nolint:gas
-	resp, err := http.Get(url)
+	resp, err := client.Get(url)
 	if err != nil {
 		log.Fatalf("http.Get(%v): %v", url, err)
 	}

--- a/cmd/healthcheck/main.go
+++ b/cmd/healthcheck/main.go
@@ -35,7 +35,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("http.Get(%v): %v", url, err)
 	}
-	if resp.StatusCode >= 200 && resp.StatusCode <= 299 {
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		log.Fatalf("HTTP status %v was not in the 2xx range", resp.StatusCode)
 	}
 }

--- a/cmd/keytransparency-monitor/Dockerfile
+++ b/cmd/keytransparency-monitor/Dockerfile
@@ -12,6 +12,7 @@ RUN go get ./cmd/healthcheck
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/keytransparency-monitor /
+COPY --from=build /go/bin/healthcheck /
 
 ENTRYPOINT ["/keytransparency-monitor"]
 HEALTHCHECK CMD ["/healthcheck","https://localhost:8099/healthz"]

--- a/cmd/keytransparency-monitor/Dockerfile
+++ b/cmd/keytransparency-monitor/Dockerfile
@@ -7,11 +7,13 @@ RUN go mod download
 COPY . .
 
 RUN go get ./cmd/keytransparency-monitor
+RUN go get ./cmd/healthcheck
 
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/keytransparency-monitor /
 
 ENTRYPOINT ["/keytransparency-monitor"]
+HEALTHCHECK CMD ["/healthcheck","https://localhost:8099/healthz"]
 
 EXPOSE 8099

--- a/cmd/keytransparency-sequencer/Dockerfile
+++ b/cmd/keytransparency-sequencer/Dockerfile
@@ -7,9 +7,12 @@ RUN go mod download
 COPY . .
 
 RUN go get ./cmd/keytransparency-sequencer
+RUN go get ./cmd/healthcheck
 
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/keytransparency-sequencer /
+COPY --from=build /go/bin/healthcheck /
 
 ENTRYPOINT ["/keytransparency-sequencer"]
+HEALTHCHECK CMD ["/healthcheck","http://localhost:8081/healthz"]

--- a/cmd/keytransparency-sequencer/Dockerfile
+++ b/cmd/keytransparency-sequencer/Dockerfile
@@ -16,3 +16,6 @@ COPY --from=build /go/bin/healthcheck /
 
 ENTRYPOINT ["/keytransparency-sequencer"]
 HEALTHCHECK CMD ["/healthcheck","http://localhost:8081/healthz"]
+
+EXPOSE 8080
+EXPOSE 8081

--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -7,11 +7,14 @@ RUN go mod download
 COPY . .
 
 RUN go get ./cmd/keytransparency-server
+RUN go get ./cmd/healthcheck
 
 FROM gcr.io/distroless/base
 
 COPY --from=build /go/bin/keytransparency-server /
+COPY --from=build /go/bin/healthcheck /
 
 ENTRYPOINT ["/keytransparency-server"]
+HEALTHCHECK CMD ["/healthcheck","http://localhost:8081/healthz"]
 
 EXPOSE 8080

--- a/cmd/keytransparency-server/Dockerfile
+++ b/cmd/keytransparency-server/Dockerfile
@@ -18,3 +18,4 @@ ENTRYPOINT ["/keytransparency-server"]
 HEALTHCHECK CMD ["/healthcheck","http://localhost:8081/healthz"]
 
 EXPOSE 8080
+EXPOSE 8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,11 +132,6 @@ services:
       - --v=1
     labels:
       kompose.service.type: LoadBalancer
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/readyz"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
     secrets:
       - server.key
       - server.crt
@@ -164,11 +159,6 @@ services:
     ports:
       - "8080"
       - "8081"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/readyz"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
     secrets:
       - server.key
       - server.crt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,11 +60,6 @@ services:
     ports:
       - "8090"
       - "8091"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8091/metrics"]
-      interval: 30s
-      timeout: 30s
-      retries: 3
 
   log-signer:
     depends_on:
@@ -82,11 +77,6 @@ services:
       - --alsologtostderr
     ports:
       - "8091"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8091/metrics"]
-      interval: 30s
-      timeout: 30s
-      retries: 3
 
   map-server:
     depends_on:
@@ -101,11 +91,6 @@ services:
     ports:
       - "8090"
       - "8091"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8091/metrics"]
-      interval: 30s
-      timeout: 30s
-      retries: 3
 
   server:
     depends_on:

--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -15,9 +15,9 @@ timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(d
 timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q log-server)`" == "running" ]; do sleep 0.1; done;'
 timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q log-signer)`" == "running" ]; do sleep 0.1; done;'
 timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q map-server)`" == "running" ]; do sleep 0.1; done;'
-timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q sequencer)`" == "running" ]; do sleep 0.1; done;'
-timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q server)`" == "running" ]; do sleep 0.1; done;'
-timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Status}} $(docker-compose ps -q monitor)`" == "running" ]; do sleep 0.1; done;'
+timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Health.Status}} $(docker-compose ps -q sequencer)`" == "healthy" ]; do sleep 0.1; done;'
+timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Health.Status}} $(docker-compose ps -q server)`" == "healthy" ]; do sleep 0.1; done;'
+timeout ${TIMEOUT} bash -c -- 'until [ "`docker inspect -f {{.State.Health.Status}} $(docker-compose ps -q monitor)`" == "healthy" ]; do sleep 0.1; done;'
 
 wget -T 60 --spider --retry-connrefused --waitretry=1 http://localhost:8081/readyz
 wget -T 60 -O /dev/null --no-check-certificate  \

--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -6,6 +6,7 @@ if [ ! -f genfiles/server.key ]; then
 	./scripts/prepare_server.sh -f
 fi
 
+export TRAVIS_COMMIT=${TRAVIS_COMMIT:-$(git rev-parse HEAD)}
 docker-compose build --parallel
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 trap "docker-compose down" INT EXIT


### PR DESCRIPTION
- cmd/healthcheck binary to make http(s) requests.
- Move HEALTHCHECK to Dockerfile
- Verify health in test scripts
- Remove unsupported Trillian health checks https://github.com/google/keytransparency/issues/1200
