### PR TITLE
Fix scripts to not depend on KT being in $GOPATH

### DIFF
--- a/scripts/gen_monitor_keys.sh
+++ b/scripts/gen_monitor_keys.sh
@@ -15,8 +15,9 @@
 # limitations under the License.
 
 # Create output directory.
-mkdir -p "$(go env GOPATH)/src/github.com/google/keytransparency/genfiles"
-cd "$(go env GOPATH)/src/github.com/google/keytransparency/genfiles"
+KT_DIR=$(go list -f '{{ .Dir }}' -m github.com/google/keytransparency)
+mkdir -p "${KT_DIR}/genfiles"
+cd "${KT_DIR}/genfiles"
 
 INTERACTIVE=1
 

--- a/scripts/gen_server_keys.sh
+++ b/scripts/gen_server_keys.sh
@@ -39,8 +39,9 @@ fi
 SANEXT="[SAN]\nbasicConstraints=CA:TRUE\nsubjectAltName=@alt_names\n\n${ALTNAMES}"
 
 # Create output directory.
-mkdir -p "$(go env GOPATH)/src/github.com/google/keytransparency/genfiles"
-cd "$(go env GOPATH)/src/github.com/google/keytransparency/genfiles"
+KT_DIR=$(go list -f '{{ .Dir }}' -m github.com/google/keytransparency)
+mkdir -p "${KT_DIR}/genfiles"
+cd "${KT_DIR}/genfiles"
 
 # Generate TLS keys.
 openssl genrsa -des3 -passout pass:xxxx -out server.pass.key 2048

--- a/scripts/prepare_server.sh
+++ b/scripts/prepare_server.sh
@@ -125,7 +125,7 @@ fi
 ##### Executing #####
 #####################
 
-cd "$(go env GOPATH)/src/github.com/google/keytransparency"
+cd $(go list -f '{{ .Dir }}' -m github.com/google/keytransparency)
 
 # Create keys.
 if ((FRONTEND == 1)); then


### PR DESCRIPTION
Since Go Modules became supported by KT, it should also support being checked out to an arbitrary location.