### PR TITLE
Fix permissions on Prometheus config files

### DIFF
--- a/deploy/prometheus/Dockerfile
+++ b/deploy/prometheus/Dockerfile
@@ -1,5 +1,5 @@
 FROM prom/prometheus
 
-ADD ./deploy/prometheus/prometheus.yml /etc/prometheus/prometheus.yml
-ADD ./deploy/prometheus/prometheus.rules /etc/prometheus/prometheus.rules
+ADD --chown=nobody:nogroup ./deploy/prometheus/prometheus.yml /etc/prometheus/prometheus.yml
+ADD --chown=nobody:nogroup ./deploy/prometheus/prometheus.rules /etc/prometheus/prometheus.rules
 


### PR DESCRIPTION
Prometheus runs as nobody, which meant it couldn't read the config files in /etc/prometheus. Change ownership of the files we place there so that it can read them.