### PR TITLE
Use ingress object for HTTPS loadballancing

### DIFF
--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -138,7 +138,7 @@ func main() {
 	)
 
 	// Listen and create empty grpc client connection.
-	lis, conn, done, err := serverutil.Listen(ctx, *listenAddr)
+	lis, conn, done, err := serverutil.Listen(ctx, *addr)
 	if err != nil {
 		glog.Fatalf("Listen(%v): %v", *addr, err)
 	}

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -54,8 +54,6 @@ import (
 )
 
 var (
-	keyFile     = flag.String("tls-key", "genfiles/server.key", "TLS private key file")
-	certFile    = flag.String("tls-cert", "genfiles/server.crt", "TLS cert file")
 	addr        = flag.String("addr", ":8080", "The ip:port to serve on")
 	metricsAddr = flag.String("metrics-addr", ":8081", "The ip:port to publish metrics on")
 
@@ -140,7 +138,7 @@ func main() {
 	)
 
 	// Listen and create empty grpc client connection.
-	lis, conn, done, err := serverutil.ListenTLS(ctx, *addr, *certFile, *keyFile)
+	lis, conn, done, err := serverutil.Listen(ctx, *listenAddr)
 	if err != nil {
 		glog.Fatalf("Listen(%v): %v", *addr, err)
 	}

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -47,8 +47,6 @@ var (
 	addr         = flag.String("addr", ":8080", "The ip:port combination to listen on")
 	metricsAddr  = flag.String("metrics-addr", ":8081", "The ip:port to publish metrics on")
 	serverDBPath = flag.String("db", "test:zaphod@tcp(localhost:3306)/test", "Database connection string")
-	keyFile      = flag.String("tls-key", "genfiles/server.key", "TLS private key file")
-	certFile     = flag.String("tls-cert", "genfiles/server.crt", "TLS cert file")
 	authType     = flag.String("auth-type", "google", "Sets the type of authentication required from clients to update their entries. Accepted values are google (oauth tokens) and insecure-fake (for testing only).")
 
 	mapURL           = flag.String("map-url", "", "URL of Trillian Map Server")
@@ -131,7 +129,7 @@ func main() {
 	grpc_prometheus.Register(grpcServer)
 	grpc_prometheus.EnableHandlingTimeHistogram()
 
-	lis, conn, done, err := serverutil.ListenTLS(ctx, *addr, *certFile, *keyFile)
+	lis, conn, done, err := serverutil.Listen(ctx, *addr)
 	if err != nil {
 		glog.Fatalf("Listen(%v): %v", *addr, err)
 	}

--- a/deploy/kubernetes/base/ingress.yaml
+++ b/deploy/kubernetes/base/ingress.yaml
@@ -7,4 +7,4 @@ spec:
   - secretName: kt-tls
   backend:
     serviceName: server
-    servicePort: 443
+    servicePort: 8080

--- a/deploy/kubernetes/base/ingress.yaml
+++ b/deploy/kubernetes/base/ingress.yaml
@@ -1,10 +1,40 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: kt-ingress
+  name: kt-ingress-grpc
+  annotations:
+    nginx.org/grpc-services: "grpc.reflection.v1alpha,google.keytransparency.v1"
+    kubernetes.io/ingress.class: "nginx"
 spec:
   tls:
-  - secretName: kt-tls
-  backend:
-    serviceName: server
-    servicePort: 8080
+  - hosts:
+    - "localhost"
+    - "127.0.0.1"
+    secretName: kt-tls
+  rules:
+    - host: localhost
+      http:
+       paths:
+       - path: /grpc.reflection.v1alpha
+         backend:
+           serviceName: server
+           servicePort: 8080
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kt-ingress-http
+spec:
+  tls:
+  - hosts:
+    - "localhost"
+    - "127.0.0.1"
+    secretName: kt-tls
+  rules:
+    - host: localhost
+      http:
+       paths:
+       - path: /
+         backend:
+           serviceName: server
+           servicePort: 8080

--- a/deploy/kubernetes/base/ingress.yaml
+++ b/deploy/kubernetes/base/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: kt-ingress
 spec:
+  tls:
+  - secretName: kt-tls
   backend:
     serviceName: server
     servicePort: 443

--- a/deploy/kubernetes/base/ingress.yaml
+++ b/deploy/kubernetes/base/ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kt-ingress
+spec:
+  backend:
+    serviceName: server
+    servicePort: 443

--- a/deploy/kubernetes/base/init-pod.yaml
+++ b/deploy/kubernetes/base/init-pod.yaml
@@ -11,7 +11,7 @@ spec:
     - --
     - curl
     - -k
-    - https://sequencer:8080/v1/directories
+    - http://sequencer:8080/v1/directories
     - -d{"directory_id":"default","min_interval":"1s","max_interval":"60s"}
     image: gcr.io/key-transparency/init:latest
     name: init

--- a/deploy/kubernetes/base/kustomization.yaml
+++ b/deploy/kubernetes/base/kustomization.yaml
@@ -19,4 +19,5 @@ resources:
 - sequencer-service.yaml
 - server-deployment.yaml
 - server-service.yaml
+- ingress.yaml
 

--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       volumes:
        - name: secrets
          secret:
-           secretName: kt-secrets
+           secretName: kt-monitor
       containers:
       - command:
         - /keytransparency-monitor

--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -22,11 +22,8 @@ spec:
         - /keytransparency-monitor
         - --addr=0.0.0.0:8070
         - --metrics-addr=0.0.0.0:8071
-        - --kt-url=server:443
-        - --insecure
+        - --kt-url=server:8080
         - --directoryid=default
-        - --tls-key=/run/secrets/server.key
-        - --tls-cert=/run/secrets/server.crt
         - --sign-key=/run/secrets/monitor_sign-key.pem
         - --password=towel
         - --alsologtostderr

--- a/deploy/kubernetes/base/sequencer-deployment.yaml
+++ b/deploy/kubernetes/base/sequencer-deployment.yaml
@@ -21,8 +21,6 @@ spec:
         - --addr=0.0.0.0:8080
         - --log-url=log-server:8090
         - --map-url=map-server:8090
-        - --tls-key=/run/secrets/server.key
-        - --tls-cert=/run/secrets/server.crt
         - --alsologtostderr
         - --v=5
         image: gcr.io/key-transparency/keytransparency-sequencer:latest
@@ -39,9 +37,5 @@ spec:
         - containerPort: 8080
         - containerPort: 8081
         resources: {}
-        volumeMounts:
-        - name: secrets
-          mountPath: "/run/secrets"
-          readOnly: true
       restartPolicy: Always
 status: {}

--- a/deploy/kubernetes/base/sequencer-deployment.yaml
+++ b/deploy/kubernetes/base/sequencer-deployment.yaml
@@ -13,10 +13,6 @@ spec:
       labels:
         io.kompose.service: sequencer
     spec:
-      volumes:
-       - name: secrets
-         secret:
-           secretName: kt-secrets
       containers:
       - command:
         - /keytransparency-sequencer

--- a/deploy/kubernetes/base/server-deployment.yaml
+++ b/deploy/kubernetes/base/server-deployment.yaml
@@ -13,10 +13,6 @@ spec:
       labels:
         io.kompose.service: server
     spec:
-      volumes:
-       - name: secrets
-         secret:
-           secretName: kt-secrets
       containers:
       - command:
         - /keytransparency-server

--- a/deploy/kubernetes/base/server-deployment.yaml
+++ b/deploy/kubernetes/base/server-deployment.yaml
@@ -20,8 +20,6 @@ spec:
         - --db=test:zaphod@tcp(db:3306)/test
         - --log-url=log-server:8090
         - --map-url=map-server:8090
-        - --tls-key=/run/secrets/server.key
-        - --tls-cert=/run/secrets/server.crt
         - --auth-type=insecure-fake
         - --alsologtostderr
         - --v=5
@@ -39,9 +37,5 @@ spec:
         - containerPort: 8080
         - containerPort: 8081
         resources: {}
-        volumeMounts:
-        - name: secrets
-          mountPath: "/run/secrets"
-          readOnly: true
       restartPolicy: Always
 status: {}

--- a/deploy/kubernetes/base/server-service.yaml
+++ b/deploy/kubernetes/base/server-service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   ports:
   - name: "grpc-api"
-    port: 443
+    port: 8080
     targetPort: 8080
   - name: "http-metrics"
     port: 8081

--- a/deploy/kubernetes/overlays/gke/server-service.yaml
+++ b/deploy/kubernetes/overlays/gke/server-service.yaml
@@ -3,5 +3,5 @@ kind: Service
 metadata:
   name: server
 spec:
-  type: LoadBalancer
+  type: NodePort # Required for ingress
 

--- a/deploy/kubernetes/overlays/local/ingress-nginx/baremetal/kustomization.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/baremetal/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../cloud-generic
+patchesStrategicMerge:
+- service-nodeport.yaml

--- a/deploy/kubernetes/overlays/local/ingress-nginx/baremetal/service-nodeport.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/baremetal/service-nodeport.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingress-nginx
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+    - name: https
+      port: 443
+      targetPort: 443
+      protocol: TCP
+  externalTrafficPolicy: Cluster

--- a/deploy/kubernetes/overlays/local/ingress-nginx/baremetal/service-nodeport.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/baremetal/service-nodeport.yaml
@@ -12,5 +12,6 @@ spec:
     - name: https
       port: 443
       targetPort: 443
+      nodePort: 30443
       protocol: TCP
   externalTrafficPolicy: Cluster

--- a/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/deployment.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+    spec:
+      # wait up to five minutes for the drain of connections
+      terminationGracePeriodSeconds: 300
+      serviceAccountName: nginx-ingress-serviceaccount
+      containers:
+        - name: nginx-ingress-controller
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:master
+          args:
+            - /nginx-ingress-controller
+            - --configmap=$(POD_NAMESPACE)/$(NGINX_CONFIGMAP_NAME)
+            - --tcp-services-configmap=$(POD_NAMESPACE)/$(TCP_CONFIGMAP_NAME)
+            - --udp-services-configmap=$(POD_NAMESPACE)/$(UDP_CONFIGMAP_NAME)
+            - --publish-service=$(POD_NAMESPACE)/$(SERVICE_NAME)
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            # www-data -> 101
+            runAsUser: 101
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown

--- a/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/kustomization.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/kustomization.yaml
@@ -1,0 +1,50 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ingress-nginx
+commonLabels:
+  app.kubernetes.io/name: ingress-nginx
+  app.kubernetes.io/part-of: ingress-nginx
+resources:
+- deployment.yaml
+- role-binding.yaml
+- role.yaml
+- service-account.yaml
+- service.yaml
+images:
+- name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+  newTag: master
+vars:
+- fieldref:
+    fieldPath: metadata.name
+  name: NGINX_CONFIGMAP_NAME
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: nginx-configuration
+- fieldref:
+    fieldPath: metadata.name
+  name: TCP_CONFIGMAP_NAME
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: tcp-services
+- fieldref:
+    fieldPath: metadata.name
+  name: UDP_CONFIGMAP_NAME
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: udp-services
+- fieldref:
+    fieldPath: metadata.name
+  name: SERVICE_NAME
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: ingress-nginx
+configMapGenerator:
+- name: nginx-configuration
+- name: tcp-services
+- name: udp-services
+generatorOptions:
+  disableNameSuffixHash: true

--- a/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/kustomization.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/kustomization.yaml
@@ -1,5 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+bases:
+- ../static
 namespace: ingress-nginx
 commonLabels:
   app.kubernetes.io/name: ingress-nginx

--- a/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/role-binding.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-role-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount

--- a/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/role.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/role.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-ingress-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get

--- a/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/service-account.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-serviceaccount

--- a/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/service.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/cloud-generic/service.yaml
@@ -1,0 +1,16 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: https

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/clusterrole.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/clusterrole.yaml
@@ -1,0 +1,58 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-clusterrole
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
+

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/clusterrolebinding.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/clusterrolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-ingress-clusterrole-nisa-binding
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount
+    namespace: ingress-nginx
+
+

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/configmap.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/configmap.yaml
@@ -1,0 +1,29 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: nginx-configuration
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tcp-services
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: udp-services
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/deployment.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-ingress-controller
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ingress-nginx
+      app.kubernetes.io/part-of: ingress-nginx
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ingress-nginx
+        app.kubernetes.io/part-of: ingress-nginx
+      annotations:
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
+    spec:
+      # wait up to five minutes for the drain of connections
+      terminationGracePeriodSeconds: 300
+      serviceAccountName: nginx-ingress-serviceaccount
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: nginx-ingress-controller
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:master
+          args:
+            - /nginx-ingress-controller
+            - --configmap=$(POD_NAMESPACE)/nginx-configuration
+            - --tcp-services-configmap=$(POD_NAMESPACE)/tcp-services
+            - --udp-services-configmap=$(POD_NAMESPACE)/udp-services
+            - --publish-service=$(POD_NAMESPACE)/ingress-nginx
+            - --annotations-prefix=nginx.ingress.kubernetes.io
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_BIND_SERVICE
+            # www-data -> 101
+            runAsUser: 101
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /wait-shutdown

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/kustomization.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+- clusterrole.yaml
+- clusterrolebinding.yaml
+  # - configmap.yaml
+  #- deployment.yaml
+- namespace.yaml
+  #- role.yaml
+  #- rolebinding.yaml
+  #- serviceaccount.yaml

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/limitrange.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/limitrange.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+spec:
+  limits:
+  - default:
+    min:
+      memory: 90Mi
+      cpu: 100m
+    type: Container
+

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/namespace.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+
+

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/role.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/role.yaml
@@ -1,0 +1,44 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-ingress-role
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/rolebinding.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/rolebinding.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-role-nisa-binding
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress-serviceaccount
+    namespace: ingress-nginx
+
+

--- a/deploy/kubernetes/overlays/local/ingress-nginx/static/serviceaccount.yaml
+++ b/deploy/kubernetes/overlays/local/ingress-nginx/static/serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress-serviceaccount
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+

--- a/deploy/kubernetes/overlays/local/ingress.yaml
+++ b/deploy/kubernetes/overlays/local/ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kt-ingress-grpc
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"

--- a/deploy/kubernetes/overlays/local/kustomization.yaml
+++ b/deploy/kubernetes/overlays/local/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
 - ingress-nginx/baremetal
 patchesStrategicMerge:
 - server-service.yaml
+- ingress.yaml

--- a/deploy/kubernetes/overlays/local/kustomization.yaml
+++ b/deploy/kubernetes/overlays/local/kustomization.yaml
@@ -1,4 +1,6 @@
 bases:
 - ../../base
+resources:
+- ingress-nginx/baremetal
 patchesStrategicMerge:
 - server-service.yaml

--- a/deploy/kubernetes/overlays/local/server-service.yaml
+++ b/deploy/kubernetes/overlays/local/server-service.yaml
@@ -3,12 +3,11 @@ kind: Service
 metadata:
   name: server
 spec:
-  ports:
-  - name: "api"
-    port: 443
-    nodePort: 30443
-  - name: "metrics"
-    port: 8081
-    nodePort: 30081
   type: NodePort
+  ports:
+    - name: "api"
+      port: 443
+    - name: "metrics"
+      port: 8081
+      nodePort: 30081
 

--- a/deploy/kubernetes/overlays/local/server-service.yaml
+++ b/deploy/kubernetes/overlays/local/server-service.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - name: "api"
-      port: 443
-    - name: "metrics"
+    - name: "grpc-api"
+      port: 8080
+    - name: "http-metrics"
       port: 8081
       nodePort: 30081
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,17 @@ services:
       - log-server
       - map-server
     image: gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
+    deploy:
+      replicas: 1
+      labels:
+        com.docker.lb.hosts: keys.keytranspraency.org
+        com.docker.lb.network: kt-network
+        com.docker.lb.port: 443
+        com.docker.lb.ssl_cert: server.cert
+        com.docker.lb.ssl_key: server.key
+    environment:
+      METADATA: proxy-handles-tls
+    restart: always
     ports:
       - "443:8080" # json & grpc
       - "8081:8081" # metrics
@@ -90,9 +101,9 @@ services:
       - --v=1
     labels:
       kompose.service.type: LoadBalancer
-    secrets:
-      - server.key
-      - server.crt
+    networks:
+      - default
+      - ingress
 
   sequencer:
     depends_on:
@@ -143,3 +154,5 @@ networks:
   attachable:
     driver: overlay
     attachable: true
+  ingress:
+    driver: overlay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,8 +85,6 @@ services:
       - --db=test:zaphod@tcp(db:3306)/test
       - --log-url=log-server:8090
       - --map-url=map-server:8090
-      - --tls-key=/run/secrets/server.key
-      - --tls-cert=/run/secrets/server.crt
       - --auth-type=insecure-fake
       - --alsologtostderr
       - --v=1
@@ -108,8 +106,6 @@ services:
       - --addr=0.0.0.0:8080
       - --log-url=log-server:8090
       - --map-url=map-server:8090
-      - --tls-key=/run/secrets/server.key
-      - --tls-cert=/run/secrets/server.crt
       - --alsologtostderr
       - --v=5
     ports:
@@ -133,8 +129,6 @@ services:
       - --kt-url=server:8080
       - --insecure
       - --directoryid=default
-      - --tls-key=/run/secrets/server.key
-      - --tls-cert=/run/secrets/server.crt
       - --sign-key=/run/secrets/monitor.key
       - --password=towel
       - --alsologtostderr
@@ -143,8 +137,6 @@ services:
     - "8070:8070" # gRPC / HTTPS
     - "8071:8071" # HTTP metrics
     secrets:
-      - server.key
-      - server.crt
       - monitor.key
 
 networks:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,11 +37,12 @@ gcloud --quiet auth configure-docker
 test $(basename $(pwd)) == "keytransparency" || exit 1
 
 # kubectl exits with 1 if kt-secret does not exist
-if ! kubectl get secret kt-secrets; then
+if ! kubectl get secret kt-tls; then
   echo "Generating keys..."
   rm -f ./genfiles/*
   ./scripts/prepare_server.sh -f
-  kubectl create secret generic kt-secrets --from-file=genfiles/server.crt --from-file=genfiles/server.key --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret generic kt-monitor --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret tls kt-tls --cert=genfiles/server.crt --key=genfiles/server.key
 fi
 
 echo "Building docker images..."

--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -13,7 +13,7 @@ docker-compose build --parallel
 docker stack deploy -c docker-compose.yml -c docker-compose.prod.yml kt
 trap "docker stack rm kt" INT EXIT
 ./scripts/docker-stack-wait.sh -t 180 -n sequencer kt
-docker run -t --network kt_attachable gcr.io/key-transparency/init:${TRAVIS_COMMIT} sequencer:8080 -- curl -k -X POST https://sequencer:8080/v1/directories -d'{"directory_id":"default","min_interval":"1s","max_interval":"60s"}'
+docker run -t --network kt_attachable gcr.io/key-transparency/init:${TRAVIS_COMMIT} sequencer:8080 -- curl -k -X POST http://sequencer:8080/v1/directories -d'{"directory_id":"default","min_interval":"1s","max_interval":"60s"}'
 ./scripts/docker-stack-wait.sh -t 180 kt
 
 wget -T 60 --spider --retry-connrefused --waitretry=1 http://localhost:8081/readyz

--- a/scripts/kubernetes_test.sh
+++ b/scripts/kubernetes_test.sh
@@ -13,11 +13,13 @@ docker-compose build --parallel
 kind load docker-image gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
 kind load docker-image gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}
 kind load docker-image gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
+kind load docker-image gcr.io/key-transparency/prometheus:${TRAVIS_COMMIT}
 
 cd deploy/kubernetes/base
 kustomize edit set image gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
 kustomize edit set image gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}
 kustomize edit set image gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/prometheus:${TRAVIS_COMMIT}
 cd -
 
 # kubectl exits with 1 if kt-secret does not exist
@@ -32,9 +34,10 @@ fi
 # Hack to wait for the default service account's creation. https://github.com/kubernetes/kubernetes/issues/66689
 n=0; until ((n >= 60)); do kubectl -n default get serviceaccount default -o name && break; n=$((n + 1)); sleep 1; done; ((n < 60))
 
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.27.0/deploy/static/mandatory.yaml
-kubectl apply -k deploy/kubernetes/overlays/local 
-trap "kubectl delete -k deploy/kubernetes/overlays/local" INT EXIT
+# kubectl apply -k deploy/kubernetes/overlays/local
+kustomize build deploy/kubernetes/overlays/local/ | kubectl apply -f -
+# trap "kubectl delete -k deploy/kubernetes/overlays/local" INT EXIT
+trap "kustomize build deploy/kubernetes/overlays/local/ | kubectl delete -f -" INT EXIT
 TIMEOUT=2m
 timeout ${TIMEOUT} kubectl rollout status deployment/db
 timeout ${TIMEOUT} kubectl rollout status deployment/log-server

--- a/scripts/kubernetes_test.sh
+++ b/scripts/kubernetes_test.sh
@@ -21,11 +21,12 @@ kustomize edit set image gcr.io/key-transparency/keytransparency-server:${TRAVIS
 cd -
 
 # kubectl exits with 1 if kt-secret does not exist
-if ! kubectl get secret kt-secrets; then
+if ! kubectl get secret kt-tls; then
   echo "Generating keys..."
   rm -f ./genfiles/*
   ./scripts/prepare_server.sh -f
-  kubectl create secret generic kt-secrets --from-file=genfiles/server.crt --from-file=genfiles/server.key --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret generic kt-monitor --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret tls kt-tls --cert=genfiles/server.crt --key=genfiles/server.key
 fi
 
 # Hack to wait for the default service account's creation. https://github.com/kubernetes/kubernetes/issues/66689

--- a/scripts/kubernetes_test.sh
+++ b/scripts/kubernetes_test.sh
@@ -32,6 +32,7 @@ fi
 # Hack to wait for the default service account's creation. https://github.com/kubernetes/kubernetes/issues/66689
 n=0; until ((n >= 60)); do kubectl -n default get serviceaccount default -o name && break; n=$((n + 1)); sleep 1; done; ((n < 60))
 
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.27.0/deploy/static/mandatory.yaml
 kubectl apply -k deploy/kubernetes/overlays/local 
 trap "kubectl delete -k deploy/kubernetes/overlays/local" INT EXIT
 TIMEOUT=2m


### PR DESCRIPTION
This PR shifts the responsibility for terminating TLS connections from the job binaries to an ingress this will significantly reduce the complexity of acquiring a legitimate TLS certificate. 