### PR TITLE
Serve HTTP metrics on separate port

### DIFF
--- a/cmd/keytransparency-monitor/Dockerfile
+++ b/cmd/keytransparency-monitor/Dockerfile
@@ -15,6 +15,7 @@ COPY --from=build /go/bin/keytransparency-monitor /
 COPY --from=build /go/bin/healthcheck /
 
 ENTRYPOINT ["/keytransparency-monitor"]
-HEALTHCHECK CMD ["/healthcheck","https://localhost:8099/healthz"]
+HEALTHCHECK CMD ["/healthcheck","http://localhost:8071/healthz"]
 
-EXPOSE 8099
+EXPOSE 8070
+EXPOSE 8071

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -43,8 +43,8 @@ import (
 )
 
 var (
-	addr        = flag.String("addr", ":8090", "The ip:port combination to listen on")
-	metricsAddr = flag.String("metrics-addr", ":8091", "The ip:port to publish metrics on")
+	addr        = flag.String("addr", ":8070", "The ip:port combination to listen on")
+	metricsAddr = flag.String("metrics-addr", ":8071", "The ip:port to publish metrics on")
 	keyFile     = flag.String("tls-key", "genfiles/server.key", "TLS private key file")
 	certFile    = flag.String("tls-cert", "genfiles/server.pem", "TLS cert file")
 

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 
+	"github.com/google/keytransparency/cmd/serverutil"
 	"github.com/google/keytransparency/core/adminserver"
 	"github.com/google/keytransparency/core/sequencer"
 	"github.com/google/keytransparency/core/sequencer/election"
@@ -185,7 +186,7 @@ func main() {
 	glog.Infof("Signer starting")
 
 	// Run servers
-	go serveHTTPMetrics(*metricsAddr, sqldb)
+	go func() { glog.Error(serverutil.ServeHTTPMetrics(*metricsAddr, serverutil.Readyz(sqldb))) }()
 	go serveHTTPGateway(ctx, lis, dopts, grpcServer,
 		pb.RegisterKeyTransparencyAdminHandlerFromEndpoint,
 	)

--- a/cmd/keytransparency-sequencer/server.go
+++ b/cmd/keytransparency-sequencer/server.go
@@ -16,29 +16,14 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"net"
 	"net/http"
 
 	"github.com/google/keytransparency/cmd/serverutil"
 
 	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
 )
-
-func serveHTTPMetrics(addr string, sqldb *sql.DB) {
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.Handler())
-	mux.Handle("/healthz", serverutil.Healthz())
-	mux.Handle("/readyz", serverutil.Readyz(sqldb))
-	mux.Handle("/", serverutil.Healthz())
-
-	glog.Infof("Hosting server status and metrics on %v", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
-		glog.Fatalf("ListenAndServeTLS(%v): %v", addr, err)
-	}
-}
 
 func serveHTTPGateway(ctx context.Context, lis net.Listener, dopts []grpc.DialOption,
 	grpcServer *grpc.Server, services ...serverutil.RegisterServiceFromEndpoint) {

--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -20,7 +20,8 @@ spec:
       containers:
       - command:
         - /keytransparency-monitor
-        - --addr=0.0.0.0:8099
+        - --addr=0.0.0.0:8070
+        - --metrics-addr=0.0.0.0:8071
         - --kt-url=server:443
         - --insecure
         - --directoryid=default
@@ -34,16 +35,17 @@ spec:
         livenessProbe:
          httpGet:
            path: /healthz
-           port: 8099
-           scheme: HTTPS
+           port: 8071
+           scheme: HTTP
         readinessProbe:
          httpGet:
            path: /readyz
-           port: 8099
-           scheme: HTTPS
+           port: 8071
+           scheme: HTTP
         name: monitor
         ports:
-        - containerPort: 8099
+        - containerPort: 8070
+        - containerPort: 8071
         resources: {}
         volumeMounts:
         - name: secrets

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,8 @@ services:
       - sequencer
     image: gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
     command:
-      - --addr=0.0.0.0:8099
+      - --addr=0.0.0.0:8070
+      - --metrics-addr=0.0.0.0:8071
       - --kt-url=server:8080
       - --insecure
       - --directoryid=default
@@ -139,7 +140,8 @@ services:
       - --alsologtostderr
       - --v=3
     ports:
-    - "8099:8099" # gRPC / HTTPS
+    - "8070:8070" # gRPC / HTTPS
+    - "8071:8071" # HTTP metrics
     secrets:
       - server.key
       - server.crt


### PR DESCRIPTION
- Move ServeHTTPMetrics to serverutil
- Create separate metrics port for monitor

This removes the need to do an HTTPS health check