### PR TITLE
Use TLS Listener

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -123,7 +123,7 @@ func main() {
 	grpc_prometheus.Register(grpcServer)
 	grpc_prometheus.EnableHandlingTimeHistogram()
 
-	lis, conn, done, err := serverutil.Listen(ctx, *addr, *certFile)
+	lis, conn, done, err := serverutil.ListenTLS(ctx, *addr, *certFile, *keyFile)
 	if err != nil {
 		glog.Fatalf("Listen(%v): %v", *addr, err)
 	}
@@ -132,8 +132,7 @@ func main() {
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return serverutil.ServeHTTPMetrics(*metricsAddr, serverutil.Healthz()) })
 	g.Go(func() error {
-		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, *keyFile, *certFile,
-			grpcServer, conn, mopb.RegisterMonitorHandler)
+		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, grpcServer, conn, mopb.RegisterMonitorHandler)
 	})
 	glog.Errorf("Monitor exiting: %v", g.Wait())
 }

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -227,9 +227,11 @@ func runSequencer(ctx context.Context, conn *grpc.ClientConn, directoryStorage d
 		}
 	})
 
-	sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
+	go sequencer.PeriodicallyRun(ctx, time.Tick(*refresh), func(ctx context.Context) {
 		if err := signer.PublishLogForAllMasterships(ctx); err != nil {
 			glog.Errorf("PeriodicallyRun(PublishRevisionsForAllMasterships): %v", err)
 		}
 	})
+
+	<-ctx.Done() // Block until server exit.
 }

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -139,7 +139,7 @@ func main() {
 	)
 
 	// Listen and create empty grpc client connection.
-	lis, conn, done, err := serverutil.Listen(ctx, *addr, *certFile)
+	lis, conn, done, err := serverutil.ListenTLS(ctx, *listenAddr, *certFile, *keyFile)
 	if err != nil {
 		glog.Fatalf("Listen(%v): %v", *addr, err)
 	}
@@ -174,8 +174,8 @@ func main() {
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return serverutil.ServeHTTPMetrics(*metricsAddr, serverutil.Readyz(sqldb)) })
 	g.Go(func() error {
-		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, *keyFile, *certFile,
-			grpcServer, conn, pb.RegisterKeyTransparencyAdminHandler)
+		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, grpcServer, conn,
+			pb.RegisterKeyTransparencyAdminHandler)
 	})
 	g.Go(func() error { return runSequencer(gctx, conn, directoryStorage) })
 

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -137,7 +137,7 @@ func main() {
 	grpc_prometheus.Register(grpcServer)
 	grpc_prometheus.EnableHandlingTimeHistogram()
 
-	lis, conn, done, err := serverutil.Listen(ctx, *addr, *certFile)
+	lis, conn, done, err := serverutil.ListenTLS(ctx, *addr, *certFile, *keyFile)
 	if err != nil {
 		glog.Fatalf("Listen(%v): %v", *addr, err)
 	}
@@ -146,8 +146,7 @@ func main() {
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return serverutil.ServeHTTPMetrics(*metricsAddr, serverutil.Readyz(sqldb)) })
 	g.Go(func() error {
-		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, *keyFile, *certFile,
-			grpcServer, conn, pb.RegisterKeyTransparencyHandler)
+		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, grpcServer, conn, pb.RegisterKeyTransparencyHandler)
 	})
 
 	glog.Errorf("Key Transparency Server exiting: %v", g.Wait())

--- a/cmd/serverutil/listen.go
+++ b/cmd/serverutil/listen.go
@@ -28,7 +28,7 @@ import (
 func ListenTLS(ctx context.Context, listenAddr, certFile, keyFile string) (net.Listener, *grpc.ClientConn, func(), error) {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		glog.Exitf("error reading keypair: %v", err)
+		return nil, nil, nil, err
 	}
 	config := &tls.Config{
 		Certificates: []tls.Certificate{cert},

--- a/cmd/serverutil/listen.go
+++ b/cmd/serverutil/listen.go
@@ -32,6 +32,7 @@ func ListenTLS(ctx context.Context, listenAddr, certFile, keyFile string) (net.L
 	}
 	config := &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"http/1.1", "h2"},
 	}
 	lis, err := tls.Listen("tcp", listenAddr, config)
 	if err != nil {

--- a/cmd/serverutil/listen.go
+++ b/cmd/serverutil/listen.go
@@ -16,6 +16,7 @@ package serverutil
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 
 	"github.com/golang/glog"
@@ -23,12 +24,20 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-// Listen binds to listenAddr and returns a gRPC connection to it.
-func Listen(ctx context.Context, listenAddr, certFile string) (net.Listener, *grpc.ClientConn, func(), error) {
-	lis, err := net.Listen("tcp", listenAddr)
+// ListenTLS binds to listenAddr and returns a gRPC connection to it.
+func ListenTLS(ctx context.Context, listenAddr, certFile, keyFile string) (net.Listener, *grpc.ClientConn, func(), error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		glog.Exitf("error reading keypair: %v", err)
+	}
+	config := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+	}
+	lis, err := tls.Listen("tcp", listenAddr, config)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
 	addr := lis.Addr().String()
 	glog.Infof("Listening on %v", addr)
 

--- a/cmd/serverutil/serverutil.go
+++ b/cmd/serverutil/serverutil.go
@@ -46,8 +46,7 @@ func GrpcHandlerFunc(grpcServer http.Handler, otherHandler http.Handler) http.Ha
 type RegisterServiceFromConn func(context.Context, *runtime.ServeMux, *grpc.ClientConn) error
 
 // ServeAPIGatewayAndGRPC serves the given services over HTTP / JSON and gRPC.
-func ServeHTTPAPIAndGRPC(ctx context.Context,
-	lis net.Listener, keyFile, certFile string,
+func ServeHTTPAPIAndGRPC(ctx context.Context, lis net.Listener,
 	grpcServer *grpc.Server, conn *grpc.ClientConn,
 	services ...RegisterServiceFromConn) error {
 	// Wire up gRPC and HTTP servers.
@@ -62,8 +61,7 @@ func ServeHTTPAPIAndGRPC(ctx context.Context,
 	mux := http.NewServeMux()
 	mux.Handle("/", RootHealthHandler(gwmux))
 
-	server := &http.Server{Handler: GrpcHandlerFunc(grpcServer, mux)}
-	return server.ServeTLS(lis, certFile, keyFile)
+	return http.Serve(lis, GrpcHandlerFunc(grpcServer, mux))
 }
 
 // ServeHTTPMetrics serves monitoring APIs


### PR DESCRIPTION
By moving TLS setup to the listener, we better isolate the crypto bits, and make things more API compatible with cmux.

Interesting Notes For Posterity:
- To support HTTP2, we need to explicitly ask for it in the `NextProtos` of the TLS config