### PR TITLE
Use cmux

### DIFF
--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -131,7 +131,7 @@ func main() {
 	defer done()
 
 	m := cmux.New(lis)
-	grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpL := m.Match(cmux.HTTP1Fast())
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/cmd/keytransparency-monitor/main.go
+++ b/cmd/keytransparency-monitor/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/google/trillian/crypto/keys/pem"
+	"github.com/soheilhy/cmux"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -129,11 +130,15 @@ func main() {
 	}
 	defer done()
 
+	m := cmux.New(lis)
+	grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	httpL := m.Match(cmux.HTTP1Fast())
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return serverutil.ServeHTTPMetrics(*metricsAddr, serverutil.Healthz()) })
-	g.Go(func() error {
-		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, grpcServer, conn, mopb.RegisterMonitorHandler)
-	})
+	g.Go(func() error { return grpcServer.Serve(grpcL) })
+	g.Go(func() error { return serverutil.ServeHTTPAPI(gctx, httpL, conn, mopb.RegisterMonitorHandler) })
+	g.Go(m.Serve)
 	glog.Errorf("Monitor exiting: %v", g.Wait())
 }
 

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/trillian/monitoring/prometheus"
 	"github.com/google/trillian/util/election2"
 	"github.com/google/trillian/util/etcd"
+	"github.com/soheilhy/cmux"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -170,13 +171,17 @@ func main() {
 	grpc_prometheus.Register(grpcServer)
 	grpc_prometheus.EnableHandlingTimeHistogram()
 
-	// Run servers
+	m := cmux.New(lis)
+	grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	httpL := m.Match(cmux.HTTP1Fast())
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return serverutil.ServeHTTPMetrics(*metricsAddr, serverutil.Readyz(sqldb)) })
+	g.Go(func() error { return grpcServer.Serve(grpcL) })
 	g.Go(func() error {
-		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, grpcServer, conn,
-			pb.RegisterKeyTransparencyAdminHandler)
+		return serverutil.ServeHTTPAPI(gctx, httpL, conn, pb.RegisterKeyTransparencyAdminHandler)
 	})
+	g.Go(m.Serve)
 	go runSequencer(gctx, conn, directoryStorage)
 
 	glog.Errorf("Signer exiting: %v", g.Wait())

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -172,7 +172,7 @@ func main() {
 	grpc_prometheus.EnableHandlingTimeHistogram()
 
 	m := cmux.New(lis)
-	grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpL := m.Match(cmux.HTTP1Fast())
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/cmd/keytransparency-sequencer/main.go
+++ b/cmd/keytransparency-sequencer/main.go
@@ -184,7 +184,7 @@ func main() {
 	g.Go(m.Serve)
 	go runSequencer(gctx, conn, directoryStorage)
 
-	glog.Errorf("Signer exiting: %v", g.Wait())
+	glog.Errorf("Sequencer exiting: %v", g.Wait())
 }
 
 func runSequencer(ctx context.Context, conn *grpc.ClientConn, directoryStorage dir.Storage) {

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -145,7 +145,7 @@ func main() {
 	defer done()
 
 	m := cmux.New(lis)
-	grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	grpcL := m.MatchWithWriters(cmux.HTTP2MatchHeaderFieldSendSettings("content-type", "application/grpc"))
 	httpL := m.Match(cmux.HTTP1Fast())
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -24,7 +24,6 @@ import (
 	"github.com/soheilhy/cmux"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/reflection"
 
 	"github.com/google/keytransparency/cmd/serverutil"
@@ -67,11 +66,6 @@ func main() {
 		glog.Exit(err)
 	}
 	defer sqldb.Close()
-
-	creds, err := credentials.NewServerTLSFromFile(*certFile, *keyFile)
-	if err != nil {
-		glog.Exitf("Failed to load server credentials %v", err)
-	}
 
 	authz := &authorization.AuthzPolicy{}
 	var authFunc grpc_auth.AuthFunc
@@ -116,7 +110,6 @@ func main() {
 	ksvr := keyserver.New(tlog, tmap, entry.IsValidEntry, directories, logs, logs,
 		prometheus.MetricFactory{}, int32(*revisionPageSize))
 	grpcServer := grpc.NewServer(
-		grpc.Creds(creds),
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(
 			grpc_prometheus.StreamServerInterceptor,
 			authorization.StreamServerInterceptor(map[string]authorization.AuthPair{

--- a/cmd/keytransparency-server/main.go
+++ b/cmd/keytransparency-server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/trillian"
 	"github.com/google/trillian/monitoring/prometheus"
+	"github.com/soheilhy/cmux"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -143,11 +144,15 @@ func main() {
 	}
 	defer done()
 
+	m := cmux.New(lis)
+	grpcL := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	httpL := m.Match(cmux.HTTP1Fast())
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return serverutil.ServeHTTPMetrics(*metricsAddr, serverutil.Readyz(sqldb)) })
-	g.Go(func() error {
-		return serverutil.ServeHTTPAPIAndGRPC(gctx, lis, grpcServer, conn, pb.RegisterKeyTransparencyHandler)
-	})
+	g.Go(func() error { return grpcServer.Serve(grpcL) })
+	g.Go(func() error { return serverutil.ServeHTTPAPI(gctx, httpL, conn, pb.RegisterKeyTransparencyHandler) })
+	g.Go(m.Serve)
 
 	glog.Errorf("Key Transparency Server exiting: %v", g.Wait())
 }

--- a/cmd/serverutil/healthz.go
+++ b/cmd/serverutil/healthz.go
@@ -21,7 +21,7 @@ func Healthz() http.HandlerFunc { return healthz }
 
 func healthz(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("ok"))
+	w.Write([]byte("ok\n"))
 }
 
 // RootHeaalthHandler handles liveness checks at "/".

--- a/cmd/serverutil/readyz.go
+++ b/cmd/serverutil/readyz.go
@@ -27,5 +27,6 @@ func Readyz(db *sql.DB) http.HandlerFunc {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok\n"))
 	}
 }

--- a/cmd/serverutil/serverutil.go
+++ b/cmd/serverutil/serverutil.go
@@ -32,7 +32,6 @@ type RegisterServiceFromConn func(context.Context, *runtime.ServeMux, *grpc.Clie
 // ServeHTTPAPI serves the given services over HTTP / JSON.
 func ServeHTTPAPI(ctx context.Context, lis net.Listener,
 	conn *grpc.ClientConn, services ...RegisterServiceFromConn) error {
-
 	gwmux := runtime.NewServeMux()
 	for _, s := range services {
 		if err := s(ctx, gwmux, conn); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/prometheus/procfs v0.0.7 // indirect
 	github.com/russross/blackfriday v2.0.0+incompatible // indirect
 	github.com/securego/gosec v0.0.0-20191119104125-df484bfa9e9f // indirect
+	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.5.0


### PR DESCRIPTION
Use cmux to differentiate between HTTP and GRPC connections.

cmux also (critically) supports serving gRPC over HTTP2 without TLS.