### PR TITLE
Add ipv6 localhost address to self-signed-cert

### DIFF
--- a/cmd/serverutil/listen.go
+++ b/cmd/serverutil/listen.go
@@ -33,7 +33,7 @@ func Listen(ctx context.Context, listenAddr, certFile string) (net.Listener, *gr
 	glog.Infof("Listening on %v", addr)
 
 	// Non-blocking dial before we start the server.
-	tcreds, err := credentials.NewClientTLSFromFile(certFile, "localhost")
+	tcreds, err := credentials.NewClientTLSFromFile(certFile, "")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/scripts/gen_server_keys.sh
+++ b/scripts/gen_server_keys.sh
@@ -32,9 +32,9 @@ if [[ -n "${COMMONNAME}" ]]; then
 fi
 
 # TODO(ismail): make the IPs configurable as well
-ALTNAMES="[alt_names]\nDNS.1=${SAN_DNS}\nDNS.2=localhost\nIP.1=0.0.0.0"
+ALTNAMES="[alt_names]\nDNS.1=${SAN_DNS}\nDNS.2=localhost\nIP.1=0.0.0.0\nIP.2=::"
 if [[ -n "${ADDRESS}" ]]; then
-    ALTNAMES="${ALTNAMES}\nIP.2=${ADDRESS}"
+    ALTNAMES="${ALTNAMES}\nIP.3=${ADDRESS}"
 fi
 SANEXT="[SAN]\nbasicConstraints=CA:TRUE\nsubjectAltName=@alt_names\n\n${ALTNAMES}"
 


### PR DESCRIPTION
Removes the need to overwrite the host name