### PR TITLE
Set fresh  TRAVIS_COMMIT

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,7 +25,7 @@ set -eufx
 export PROJECT_NAME_CI=key-transparency
 export CLOUDSDK_COMPUTE_ZONE=us-central1-a
 export CLUSTER_NAME_CI=ci-cluster
-export TRAVIS_COMMIT=${TRAVIS_COMMIT:-$(git rev-parse HEAD)}
+export TRAVIS_COMMIT=$(git rev-parse HEAD)
 
 gcloud --quiet config set project ${PROJECT_NAME_CI}
 gcloud --quiet config set compute/zone ${CLOUDSDK_COMPUTE_ZONE}

--- a/scripts/docker-compose_test.sh
+++ b/scripts/docker-compose_test.sh
@@ -6,7 +6,7 @@ if [ ! -f genfiles/server.key ]; then
 	./scripts/prepare_server.sh -f
 fi
 
-export TRAVIS_COMMIT=${TRAVIS_COMMIT:-$(git rev-parse HEAD)}
+export TRAVIS_COMMIT=$(git rev-parse HEAD)
 docker-compose build --parallel
 # Assumes there is a docker swarm already configured.
 # docker swarm init

--- a/scripts/kubernetes_test.sh
+++ b/scripts/kubernetes_test.sh
@@ -8,7 +8,7 @@ set -o pipefail
 # kubectl cluster-info --context kind-kind
 
 # Build docker images and make them available inside of the k8 cluster
-export TRAVIS_COMMIT=${TRAVIS_COMMIT:-$(git rev-parse HEAD)}
+export TRAVIS_COMMIT=$(git rev-parse HEAD)
 docker-compose build --parallel
 kind load docker-image gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
 kind load docker-image gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}


### PR DESCRIPTION
Refer to the current commit hash every time.
This script results in incorrect hashes when HEAD moves after setting the
TRAVIS_COMMIT environment variable.