### PR TITLE
Serve HTTP2 health check

### DIFF
--- a/cmd/serverutil/listen.go
+++ b/cmd/serverutil/listen.go
@@ -32,7 +32,7 @@ func ListenTLS(ctx context.Context, listenAddr, certFile, keyFile string) (net.L
 	}
 	config := &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		NextProtos:   []string{"http/1.1", "h2"},
+		NextProtos:   []string{"h2", "http/1.1"},
 	}
 	lis, err := tls.Listen("tcp", listenAddr, config)
 	if err != nil {

--- a/cmd/serverutil/serverutil.go
+++ b/cmd/serverutil/serverutil.go
@@ -27,12 +27,12 @@ import (
 	"google.golang.org/grpc"
 )
 
-// GrpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
-// connections or otherHandler otherwise. Copied from cockroachdb.
-func GrpcHandlerFunc(grpcServer http.Handler, otherHandler http.Handler) http.Handler {
+// gRPCHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
+// connections or otherHandler otherwise.
+func gRPCHandlerFunc(grpcServer http.Handler, otherHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// This is a partial recreation of gRPC's internal checks.
-		// https://github.com/grpc/grpc-go/blob/master/transport/handler_server.go#L62
+		// https://github.com/grpc/grpc-go/blob/v1.26.0/internal/transport/handler_server.go#L62
 		if r.ProtoMajor == 2 && strings.HasPrefix(
 			r.Header.Get("Content-Type"), "application/grpc") {
 			grpcServer.ServeHTTP(w, r)
@@ -61,7 +61,7 @@ func ServeHTTPAPIAndGRPC(ctx context.Context, lis net.Listener,
 	mux := http.NewServeMux()
 	mux.Handle("/", RootHealthHandler(gwmux))
 
-	return http.Serve(lis, GrpcHandlerFunc(grpcServer, mux))
+	return http.Serve(lis, gRPCHandlerFunc(grpcServer, mux))
 }
 
 // ServeHTTPMetrics serves monitoring APIs

--- a/cmd/serverutil/serverutil.go
+++ b/cmd/serverutil/serverutil.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
@@ -26,12 +27,30 @@ import (
 	"google.golang.org/grpc"
 )
 
+// GrpcHandlerFunc returns an http.Handler that delegates to grpcServer on incoming gRPC
+// connections or otherHandler otherwise. Copied from cockroachdb.
+func GrpcHandlerFunc(grpcServer http.Handler, otherHandler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This is a partial recreation of gRPC's internal checks.
+		// https://github.com/grpc/grpc-go/blob/master/transport/handler_server.go#L62
+		if r.ProtoMajor == 2 && strings.HasPrefix(
+			r.Header.Get("Content-Type"), "application/grpc") {
+			grpcServer.ServeHTTP(w, r)
+		} else {
+			otherHandler.ServeHTTP(w, r)
+		}
+	})
+}
+
 // RegisterServiceFromConn registers services with a grpc server's ServeMux
 type RegisterServiceFromConn func(context.Context, *runtime.ServeMux, *grpc.ClientConn) error
 
-// ServeHTTPAPI serves the given services over HTTP / JSON.
-func ServeHTTPAPI(ctx context.Context, lis net.Listener,
-	conn *grpc.ClientConn, services ...RegisterServiceFromConn) error {
+// ServeAPIGatewayAndGRPC serves the given services over HTTP / JSON and gRPC.
+func ServeHTTPAPIAndGRPC(ctx context.Context, lis net.Listener,
+	grpcServer *grpc.Server, conn *grpc.ClientConn,
+	services ...RegisterServiceFromConn) error {
+	// Wire up gRPC and HTTP servers.
+
 	gwmux := runtime.NewServeMux()
 	for _, s := range services {
 		if err := s(ctx, gwmux, conn); err != nil {
@@ -41,7 +60,8 @@ func ServeHTTPAPI(ctx context.Context, lis net.Listener,
 
 	mux := http.NewServeMux()
 	mux.Handle("/", RootHealthHandler(gwmux))
-	return http.Serve(lis, mux)
+
+	return http.Serve(lis, GrpcHandlerFunc(grpcServer, mux))
 }
 
 // ServeHTTPMetrics serves monitoring APIs

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/prometheus/procfs v0.0.7 // indirect
 	github.com/russross/blackfriday v2.0.0+incompatible // indirect
 	github.com/securego/gosec v0.0.0-20191119104125-df484bfa9e9f // indirect
-	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.5.0


### PR DESCRIPTION
Prioritize HTTP2 over HTTP1

Revert #1435 and use `http.ServeHTTP` rather than cmux.
- cmux prevents http.Serve from serving HTTP2
- http.Serve will only serve HTTP2 over TLS
   - http.Serve uses a type assertion to validate this
   - cmux interrupts this because it wraps the connection.
   - even if the connection did come from a TLS listener 

The GCE ingress load ballancer requires services to serve 
an HTTP 200 OK at / on the same protocol that the server uses.
To support GRPC, this means using HTTP2 throuought.
HTTP2 also requires TLS, both by golang and GCE ingress.