### PR TITLE
Split kt-secrets into kt-tls and kt-monitor

### DIFF
--- a/deploy/kubernetes/base/monitor-deployment.yaml
+++ b/deploy/kubernetes/base/monitor-deployment.yaml
@@ -16,7 +16,10 @@ spec:
       volumes:
        - name: secrets
          secret:
-           secretName: kt-secrets
+           secretName: kt-monitor
+       - name: tls
+         secret:
+           secretName: kt-tls
       containers:
       - command:
         - /keytransparency-monitor
@@ -25,8 +28,8 @@ spec:
         - --kt-url=server:443
         - --insecure
         - --directoryid=default
-        - --tls-key=/run/secrets/server.key
-        - --tls-cert=/run/secrets/server.crt
+        - --tls-key=/run/tls/tls.key
+        - --tls-cert=/run/tls/tls.crt
         - --sign-key=/run/secrets/monitor_sign-key.pem
         - --password=towel
         - --alsologtostderr
@@ -50,6 +53,9 @@ spec:
         volumeMounts:
         - name: secrets
           mountPath: "/run/secrets"
+          readOnly: true
+        - name: tls
+          mountPath: "/run/tls"
           readOnly: true
       restartPolicy: Always
 status: {}

--- a/deploy/kubernetes/base/sequencer-deployment.yaml
+++ b/deploy/kubernetes/base/sequencer-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       volumes:
        - name: secrets
          secret:
-           secretName: kt-secrets
+           secretName: kt-tls
       containers:
       - command:
         - /keytransparency-sequencer
@@ -25,8 +25,8 @@ spec:
         - --addr=0.0.0.0:8080
         - --log-url=log-server:8090
         - --map-url=map-server:8090
-        - --tls-key=/run/secrets/server.key
-        - --tls-cert=/run/secrets/server.crt
+        - --tls-key=/run/secrets/tls.key
+        - --tls-cert=/run/secrets/tls.crt
         - --alsologtostderr
         - --v=5
         image: gcr.io/key-transparency/keytransparency-sequencer:latest

--- a/deploy/kubernetes/base/server-deployment.yaml
+++ b/deploy/kubernetes/base/server-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       volumes:
        - name: secrets
          secret:
-           secretName: kt-secrets
+           secretName: kt-tls
       containers:
       - command:
         - /keytransparency-server
@@ -24,8 +24,8 @@ spec:
         - --db=test:zaphod@tcp(db:3306)/test
         - --log-url=log-server:8090
         - --map-url=map-server:8090
-        - --tls-key=/run/secrets/server.key
-        - --tls-cert=/run/secrets/server.crt
+        - --tls-key=/run/secrets/tls.key
+        - --tls-cert=/run/secrets/tls.crt
         - --auth-type=insecure-fake
         - --alsologtostderr
         - --v=5

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,11 +37,12 @@ gcloud --quiet auth configure-docker
 test $(basename $(pwd)) == "keytransparency" || exit 1
 
 # kubectl exits with 1 if kt-secret does not exist
-if ! kubectl get secret kt-secrets; then
+if ! kubectl get secret kt-tls; then
   echo "Generating keys..."
   rm -f ./genfiles/*
   ./scripts/prepare_server.sh -f
-  kubectl create secret generic kt-secrets --from-file=genfiles/server.crt --from-file=genfiles/server.key --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret generic kt-monitor --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret tls kt-tls --cert=genfiles/server.crt --key=genfiles/server.key
 fi
 
 echo "Building docker images..."

--- a/scripts/kubernetes_test.sh
+++ b/scripts/kubernetes_test.sh
@@ -21,11 +21,12 @@ kustomize edit set image gcr.io/key-transparency/keytransparency-server:${TRAVIS
 cd -
 
 # kubectl exits with 1 if kt-secret does not exist
-if ! kubectl get secret kt-secrets; then
+if ! kubectl get secret kt-tls; then
   echo "Generating keys..."
   rm -f ./genfiles/*
   ./scripts/prepare_server.sh -f
-  kubectl create secret generic kt-secrets --from-file=genfiles/server.crt --from-file=genfiles/server.key --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret generic kt-monitor --from-file=genfiles/monitor_sign-key.pem
+  kubectl create secret tls kt-tls --cert=genfiles/server.crt --key=genfiles/server.key
 fi
 
 # Hack to wait for the default service account's creation. https://github.com/kubernetes/kubernetes/issues/66689


### PR DESCRIPTION
- Move Monitor key to it's own secret
- Move the TLS keys to a TLS secret

By moving the TLS certs into a proper kubernets tls secret, it can be read by an ingress object in the future.