### PR TITLE
Portable docker images cleanup script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,9 @@ jobs:
       - curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash && sudo mv kustomize /usr/local/bin/
       - openssl aes-256-cbc -K $encrypted_555d9b2948d2_key -iv $encrypted_555d9b2948d2_iv
         -in client_secrets.json.enc -d | gcloud auth activate-service-account --key-file /dev/stdin
-      script: ./scripts/deploy.sh
+      script:
+      - ./scripts/deploy.sh
+      - ./scripts/cleanup_images.sh
 
 before_install:
   - |

--- a/scripts/cleanup_images.sh
+++ b/scripts/cleanup_images.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+export PROJECT_NAME_CI=key-transparency
+export CLOUDSDK_COMPUTE_ZONE=us-central1-a
+export CLUSTER_NAME_CI=ci-cluster
+
+gnudate() {
+    if hash gdate 2>/dev/null; then
+        gdate "$@"
+    else
+        date "$@"
+    fi
+}
+
+echo "Cleaning old docker images..."
+BEFORE_DATE=$(gnudate --date="30 days ago" +%Y-%m-%d)
+./scripts/gcrgc.sh gcr.io/key-transparency/init $BEFORE_DATE
+./scripts/gcrgc.sh gcr.io/key-transparency/prometheus $BEFORE_DATE
+./scripts/gcrgc.sh gcr.io/key-transparency/keytransparency-server $BEFORE_DATE
+./scripts/gcrgc.sh gcr.io/key-transparency/keytransparency-sequencer $BEFORE_DATE
+./scripts/gcrgc.sh gcr.io/key-transparency/keytransparency-monitor $BEFORE_DATE

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -51,14 +51,6 @@ docker-compose build --parallel
 echo "Pushing docker images..."
 docker-compose push
 
-echo "Cleaning old docker images..."
-BEFORE_DATE=$(date --date="30 days ago" +%Y-%m-%d)
-./scripts/gcrgc.sh gcr.io/key-transparency/init $BEFORE_DATE
-./scripts/gcrgc.sh gcr.io/key-transparency/prometheus $BEFORE_DATE
-./scripts/gcrgc.sh gcr.io/key-transparency/keytransparency-server $BEFORE_DATE
-./scripts/gcrgc.sh gcr.io/key-transparency/keytransparency-sequencer $BEFORE_DATE
-./scripts/gcrgc.sh gcr.io/key-transparency/keytransparency-monitor $BEFORE_DATE
-
 echo "Updating jobs..."
 cd deploy/kubernetes/base
 kustomize edit set image gcr.io/${PROJECT_NAME_CI}/prometheus:${TRAVIS_COMMIT}


### PR DESCRIPTION
Support running the cleanup script on both mac and linux.
gnudate on mac is `gdate`, while it is `date` on linux.

Also separate the cleanup script so deployments can be run in smaller steps.