### PR TITLE
README.md Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,61 @@ development.
 
 ### Setup
 1. Install [Go 1.13](https://golang.org/doc/install).
-2. `GO111MODULE=on go get github.com/google/keytransparency/cmd/keytransparency-client`
+3. `GO111MODULE=on go get github.com/google/keytransparency/cmd/keytransparency-client`
 
 ### Client operations
+
+
+## View the Server's Public Keys for a Directory 
+The Key Transparency server publishes a separate set of public keys for each directory that it hosts.
+
+Within a directory the server uses the following public keys to sign its responses:
+1. `log.public_key` signs the top-most merkle tree root, covering the ordered list of map roots.
+2. `map.public_key` signs each snapshot of the key-value database in the form of a sparse merkle tree.
+3. `vrf.der` signs outputs of the [Verifiable Random Function](https://en.wikipedia.org/wiki/Verifiable_random_function)
+    which obscures the key values in the key-value database.
+
+A directory's keys default can be retrieved over HTTPS/JSON with curl
+or over gRPC with [grpcurl](https://github.com/fullstorydev/grpcurl).
+```sh
+$ curl -s https://sandbox.keytransparency.dev/v1/directories/default | json_pp
+$ grpcurl -d '{"directory_id": "default"}' sandbox.keytransparency.dev:443 google.keytransparency.v1.KeyTransparency/GetDirectory
+```
+
+<details>
+  <summary>Show output</summary>
+
+```sh
+{
+   "directory_id" : "default",
+   "log" : {
+      "hash_algorithm" : "SHA256",
+      "hash_strategy" : "RFC6962_SHA256",
+      "public_key" : {
+         "der" : "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXPi4Ut3cRY3OCXWvcSnE/sk6tbDEgBeZapfEy/BIKfsMbj3hPLG+WEjzh1IP2TDirc9GpQ+r9HVGR81KqRpbjw=="
+      },
+      "signature_algorithm" : "ECDSA",
+      "tree_id" : "4565568921879890247",
+      "tree_type" : "PREORDERED_LOG"
+   },
+   "map" : {
+      "hash_algorithm" : "SHA256",
+      "hash_strategy" : "CONIKS_SHA256",
+      "public_key" : {
+         "der" : "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgX6ITeFrqLmclqH+3XVhbaEeJO37vy1dZYRFxpKScERdeeu3XRirJszc5KJgaZs0LdvJqOccfNc2gJfInLGIuA=="
+      },
+      "signature_algorithm" : "ECDSA",
+      "tree_id" : "5601540825264769688",
+      "tree_type" : "MAP"
+   },
+   "max_interval" : "60s",
+   "min_interval" : "1s",
+   "vrf" : {
+      "der" : "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvuqCkY9rM/jq/8hAoQn2PClvlNvVeV0MSUqzc67q6W+MzY/YZKmPLY5t/n/VUEqeSgwU+/sXgER3trsL6nZu+A=="
+   }
+}
+```
+</details>
 
 #### Generate a private key
 
@@ -56,7 +108,7 @@ NB A default for the Key Transparency server URL is being used here. The default
   ```sh
   keytransparency-client post user@domain.com \
   --client-secret=client_secret.json \
-  --insecure \
+  --kt-url sandbox.keytransparency.dev \
   --password=${PASSWORD} \
   --data='dGVzdA==' #Base64
   ```

--- a/README.md
+++ b/README.md
@@ -89,8 +89,27 @@ $ grpcurl -d '{"directory_id": "default"}' sandbox.keytransparency.dev:443 googl
 ```
 </details>
 
-#### Generate a private key
+#### [Optional] Generate a key signing key
+Key Transparency supports key signing keys for the purpose of making the provenance of public keys explicit.
 
+This feature can be deployed in a variety of configurations:
+1. Only the service provider signs updates.
+   This mode most clearly models most applications today that support account-reset.
+   The service provider authenticates the user using SMS, OAuth, Email, or some other mechanism and then updates the key directory.
+2. The service provider and, optionially, the user sign updates.
+   This mode allows relyinig parties to distinguish between account reset
+   events and new devices that were added by the user from other devices.
+3. The reset providers, and optionally, the user sign updates.
+   This mode removes the power of the service provder to unilaterally update a
+   user's account, while preserving the ability for users to recover their accounts.
+4. Require user signed updates after account setup.
+   This mode requires the user maintain access to their key signing keys in
+   perpetuity or risk loosing access to their account.
+
+If supported by the service provider, each user can select the mode most
+appropriate for their own account by modifying the set of key signing keys in `authorized_keys`.
+
+The sandbox server has been setup in mode 4.
   ```sh
   PASSWORD=[[YOUR-KEYSET-PASSWORD]]
   keytransparency-client authorized-keys create-keyset --password=${PASSWORD}
@@ -98,9 +117,6 @@ $ grpcurl -d '{"directory_id": "default"}' sandbox.keytransparency.dev:443 googl
   ```
 The `create-keyset` command will create a `.keyset` file in the user's working directory.
 To specify custom directory use `--keyset-file` or `-k` shortcut.
-
-NB A default for the Key Transparency server URL is being used here. The default value is "35.202.56.9:443". The flag `--kt-url` may be used to specify the URL of Key Transparency server explicitly.
-
 
 #### Publish the public key
 1. Get an [OAuth client ID](https://console.developers.google.com/apis/credentials) and download the generated JSON file to `client_secret.json`.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ development.
 
 ### Setup
 1. Install [Go 1.13](https://golang.org/doc/install).
-2. `go get github.com/google/keytransparency/cmd/keytransparency-client `
+2. `GO111MODULE=on go get github.com/google/keytransparency/cmd/keytransparency-client`
 
 ### Client operations
 

--- a/README.md
+++ b/README.md
@@ -119,12 +119,13 @@ The `create-keyset` command will create a `.keyset` file in the user's working d
 To specify custom directory use `--keyset-file` or `-k` shortcut.
 
 #### Publish the public key
-1. Get an [OAuth client ID](https://console.developers.google.com/apis/credentials) and download the generated JSON file to `client_secret.json`.
+Any number of protocols may be used to prove to the server that a client owns a userID.
+The sandbox server supports a fake authentication string and [OAuth](https://console.developers.google.com/apis/credentials).
 
   ```sh
   keytransparency-client post user@domain.com \
-  --client-secret=client_secret.json \
   --kt-url sandbox.keytransparency.dev \
+  --fake-auth-userid user@domain.com \
   --password=${PASSWORD} \
   --data='dGVzdA==' #Base64
   ```

--- a/README.md
+++ b/README.md
@@ -122,12 +122,22 @@ To specify custom directory use `--keyset-file` or `-k` shortcut.
 Any number of protocols may be used to prove to the server that a client owns a userID.
 The sandbox server supports a fake authentication string and [OAuth](https://console.developers.google.com/apis/credentials).
 
+Create or fetch the public key for your specific application.
+  ```sh
+   openssl genpkey -algorithm X25519 -out xkey.pem
+   openssl pkey -in xkey.pem -pubout 
+   -----BEGIN PUBLIC KEY-----
+   MCowBQYDK2VuAyEAtCAsIMDyVUUooA5yhgRefcEr7edVOmyNCUaN1LCYl3s=
+   -----END PUBLIC KEY-----
+  ```
+
   ```sh
   keytransparency-client post user@domain.com \
-  --kt-url sandbox.keytransparency.dev \
+  --kt-url sandbox.keytransparency.dev:443 \
   --fake-auth-userid user@domain.com \
   --password=${PASSWORD} \
-  --data='dGVzdA==' #Base64
+  --verbose \
+  --data='MCowBQYDK2VuAyEAtCAsIMDyVUUooA5yhgRefcEr7edVOmyNCUaN1LCYl3s=' #Your public key in base64
   ```
 
 #### Get and verify a public key


### PR DESCRIPTION
Fixes #1394 - Show how to fetch the public keys the server is showing for the default directory.
Fixes #1207 - Explain directories
Fixes #1390 - Correct the download instructions for the KT client for Go Modules.
Fixes #1392 - Use a real public key in the example