### PR TITLE
Use sandbox.keytransparency.dev as example server

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ NB A default for the Key Transparency server URL is being used here. The default
 #### Get and verify a public key
 
   ```
-  keytransparency-client get <email> --insecure --verbose
+  keytransparency-client get <email> --kt-url sandbox.keytransparency.dev:443 --verbose
   ✓ Commitment verified.
   ✓ VRF verified.
   ✓ Sparse tree proof verified.
@@ -79,14 +79,14 @@ NB A default for the Key Transparency server URL is being used here. The default
 
 #### Verify key history
   ```
-  keytransparency-client history <email> --insecure
+  keytransparency-client history user@domain.com --kt-url sandbox.keytransparency.dev:443
   Revision |Timestamp                    |Profile
   4        |Mon Sep 12 22:23:54 UTC 2016 |keys:<key:"app1" value:"test" >
   ```
 
 #### Checks
-- [Proof for foo@bar.com](https://35.202.56.9/v1/directories/default/users/foo@bar.com)
-- [Server configuration info](https://35.202.56.9/v1/directories/default)
+- [Proof for foo@bar.com](https://sandbox.keytransparency.dev/v1/directories/default/users/foo@bar.com)
+- [Server configuration info](https://sandbox.keytransparency.dev/v1/directories/default)
 
 ## Running the server
 

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"net"
 	"os"
 	"time"
 
@@ -154,14 +153,9 @@ func getCreds(ctx context.Context, clientSecretFile string) (credentials.PerRPCC
 	return oauth.NewOauthAccess(tok), nil
 }
 
-func transportCreds(ktURL string) (credentials.TransportCredentials, error) {
+func transportCreds() (credentials.TransportCredentials, error) {
 	ktCert := viper.GetString("kt-cert")
 	insecure := viper.GetBool("insecure")
-
-	host, _, err := net.SplitHostPort(ktURL)
-	if err != nil {
-		return nil, err
-	}
 
 	switch {
 	case insecure: // Impatient insecure.
@@ -170,10 +164,10 @@ func transportCreds(ktURL string) (credentials.TransportCredentials, error) {
 		}), nil
 
 	case ktCert != "": // Custom CA Cert.
-		return credentials.NewClientTLSFromFile(ktCert, host)
+		return credentials.NewClientTLSFromFile(ktCert, "")
 
 	default: // Use the local set of root certs.
-		return credentials.NewClientTLSFromCert(nil, host), nil
+		return credentials.NewClientTLSFromCert(nil, ""), nil
 	}
 }
 
@@ -196,7 +190,7 @@ func userCreds(ctx context.Context) (credentials.PerRPCCredentials, error) {
 
 func dial(ctx context.Context) (pb.KeyTransparencyClient, error) {
 	addr := viper.GetString("kt-url")
-	transportCreds, err := transportCreds(addr)
+	transportCreds, err := transportCreds()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/keytransparency-client/cmd/root.go
+++ b/cmd/keytransparency-client/cmd/root.go
@@ -77,10 +77,10 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.keytransparency.yaml)")
 
 	RootCmd.PersistentFlags().String("directory", "default", "Directory within the KT server")
-	RootCmd.PersistentFlags().String("kt-url", "35.202.56.9:443", "URL of Key Transparency server")
-	RootCmd.PersistentFlags().String("kt-cert", "genfiles/server.crt", "Path to public key for Key Transparency")
+	RootCmd.PersistentFlags().String("kt-url", "sandbox.keytransparency.dev:443", "URL of Key Transparency server")
+	RootCmd.PersistentFlags().String("kt-cert", "", "Path to public key for Key Transparency")
 	RootCmd.PersistentFlags().Bool("autoconfig", true, "Fetch config info from the server's /v1/directory/info")
-	RootCmd.PersistentFlags().Bool("insecure", true, "Skip TLS checks")
+	RootCmd.PersistentFlags().Bool("insecure", false, "Skip TLS checks")
 
 	RootCmd.PersistentFlags().String("vrf", "genfiles/vrf-pubkey.pem", "path to vrf public key")
 


### PR DESCRIPTION
This removes the need to pass `--insecure` because sandbox.keytransparency.dev
has a valid TLS certificate.