### PR TITLE
Set tags for init and prometheus docker images

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -53,9 +53,10 @@ docker-compose push
 
 echo "Updating jobs..."
 cd deploy/kubernetes/base
-kustomize edit set image gcr.io/${PROJECT_NAME_CI}/prometheus:${TRAVIS_COMMIT}
-kustomize edit set image gcr.io/${PROJECT_NAME_CI}/keytransparency-monitor:${TRAVIS_COMMIT}
-kustomize edit set image gcr.io/${PROJECT_NAME_CI}/keytransparency-sequencer:${TRAVIS_COMMIT}
-kustomize edit set image gcr.io/${PROJECT_NAME_CI}/keytransparency-server:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/prometheus:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/init:${TRAVIS_COMMIT}
 cd -
 kubectl apply -k deploy/kubernetes/overlays/gke

--- a/scripts/kubernetes_test.sh
+++ b/scripts/kubernetes_test.sh
@@ -13,11 +13,15 @@ docker-compose build --parallel
 kind load docker-image gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
 kind load docker-image gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}
 kind load docker-image gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
+kind load docker-image gcr.io/key-transparency/prometheus:${TRAVIS_COMMIT}
+kind load docker-image gcr.io/key-transparency/init:${TRAVIS_COMMIT}
 
 cd deploy/kubernetes/base
 kustomize edit set image gcr.io/key-transparency/keytransparency-monitor:${TRAVIS_COMMIT}
 kustomize edit set image gcr.io/key-transparency/keytransparency-sequencer:${TRAVIS_COMMIT}
 kustomize edit set image gcr.io/key-transparency/keytransparency-server:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/prometheus:${TRAVIS_COMMIT}
+kustomize edit set image gcr.io/key-transparency/init:${TRAVIS_COMMIT}
 cd -
 
 # kubectl exits with 1 if kt-secret does not exist


### PR DESCRIPTION
gcr.io does not consider 'latest' to be a valid docker tag,
so we must explicitly set one ourselves.