### PR TITLE
don't overwrite the ReplicaSet service label

### DIFF
--- a/deploy/kubernetes/overlays/gke/cloudsql-sidecar.yaml
+++ b/deploy/kubernetes/overlays/gke/cloudsql-sidecar.yaml
@@ -4,9 +4,6 @@ metadata:
   name: cloud-sql-sidecar
 spec:
   template:
-    metadata:
-      labels:
-        io.kompose.service: cloud-sql-sidecar
     spec:
       volumes:
        - name: secrets-cloudsql


### PR DESCRIPTION
All pods were only declaring the 'cloud-sql-sidecar' service label, completely breaking service discovery