### PR TITLE
Use go1.14 t.Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 version: ~> 1.0
 language: go
 go:
-- "1.13.x"
+- "1.14.x"
 dist: bionic
 
 go_import_path: github.com/google/keytransparency

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   include:
     - name: "lint"
-      install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.0
+      install: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.26.0
       script: golangci-lint run --deadline=7m
     - name: "coverage"
       script:

--- a/core/integration/storagetest/batch.go
+++ b/core/integration/storagetest/batch.go
@@ -28,7 +28,7 @@ import (
 )
 
 // batchStorageFactory returns a new database object, and a function for cleaning it up.
-type batchStorageFactory func(ctx context.Context, t *testing.T, dirID string) (sequencer.Batcher, func(context.Context))
+type batchStorageFactory func(ctx context.Context, t *testing.T, dirID string) sequencer.Batcher
 
 type BatchStorageTest func(ctx context.Context, t *testing.T, f batchStorageFactory)
 
@@ -52,8 +52,7 @@ type BatchTests struct{}
 
 func (*BatchTests) TestNotFound(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "testnotfounddir"
-	b, done := f(ctx, t, domainID)
-	defer done(ctx)
+	b := f(ctx, t, domainID)
 	_, err := b.ReadBatch(ctx, domainID, 0)
 	st := status.Convert(err)
 	if got, want := st.Code(), codes.NotFound; got != want {
@@ -63,8 +62,7 @@ func (*BatchTests) TestNotFound(ctx context.Context, t *testing.T, f batchStorag
 
 func (*BatchTests) TestWriteBatch(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "writebatchtest"
-	b, done := f(ctx, t, domainID)
-	defer done(ctx)
+	b := f(ctx, t, domainID)
 	for _, tc := range []struct {
 		rev     int64
 		wantErr bool
@@ -88,8 +86,7 @@ func (*BatchTests) TestWriteBatch(ctx context.Context, t *testing.T, f batchStor
 
 func (*BatchTests) TestReadBatch(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "readbatchtest"
-	b, done := f(ctx, t, domainID)
-	defer done(ctx)
+	b := f(ctx, t, domainID)
 	for _, tc := range []struct {
 		rev  int64
 		want *spb.MapMetadata
@@ -123,8 +120,7 @@ func (*BatchTests) TestReadBatch(ctx context.Context, t *testing.T, f batchStora
 
 func (*BatchTests) TestHighestRev(ctx context.Context, t *testing.T, f batchStorageFactory) {
 	domainID := "writebatchtest"
-	b, done := f(ctx, t, domainID)
-	defer done(ctx)
+	b := f(ctx, t, domainID)
 	for _, tc := range []struct {
 		rev     int64
 		sources []*spb.MapMetadata_SourceSlice

--- a/core/integration/storagetest/mutation_logs.go
+++ b/core/integration/storagetest/mutation_logs.go
@@ -31,7 +31,7 @@ import (
 )
 
 // mutationLogsFactory returns a new database object, and a function for cleaning it up.
-type mutationLogsFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (keyserver.MutationLogs, func(context.Context))
+type mutationLogsFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) keyserver.MutationLogs
 
 // RunMutationLogsTests runs all the tests against the provided storage implementation.
 func RunMutationLogsTests(t *testing.T, factory mutationLogsFactory) {
@@ -61,8 +61,7 @@ func mustMarshal(t *testing.T, p proto.Message) []byte {
 func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTest mutationLogsFactory) {
 	directoryID := "TestReadLog"
 	logID := int64(5) // Any log ID.
-	m, done := newForTest(ctx, t, directoryID, logID)
-	defer done(ctx)
+	m := newForTest(ctx, t, directoryID, logID)
 
 	type entryID struct {
 		logID   int64
@@ -117,8 +116,7 @@ func (mutationLogsTests) TestReadLog(ctx context.Context, t *testing.T, newForTe
 func (mutationLogsTests) TestReadLogExact(ctx context.Context, t *testing.T, newForTest mutationLogsFactory) {
 	directoryID := "TestReadLogExact"
 	logID := int64(5) // Any log ID.
-	m, done := newForTest(ctx, t, directoryID, logID)
-	defer done(ctx)
+	m := newForTest(ctx, t, directoryID, logID)
 	// Write ten batches.
 	idx := make([]water.Mark, 0, 10)
 	for i := byte(0); i < 10; i++ {
@@ -162,8 +160,7 @@ func (mutationLogsTests) TestReadLogExact(ctx context.Context, t *testing.T, new
 func (mutationLogsTests) TestConcurrentWrites(ctx context.Context, t *testing.T, newForTest mutationLogsFactory) {
 	directoryID := "TestConcurrentWrites"
 	logID := int64(5)
-	m, done := newForTest(ctx, t, directoryID, logID)
-	defer done(ctx)
+	m := newForTest(ctx, t, directoryID, logID)
 	for i, concurrency := range []int{1, 2, 4, 8, 16, 32, 64} {
 		var g errgroup.Group
 		entry := &pb.EntryUpdate{Mutation: &pb.SignedEntry{Entry: mustMarshal(t, &pb.Entry{Index: []byte{byte(i)}})}}

--- a/core/integration/storagetest/mutation_logs_admin.go
+++ b/core/integration/storagetest/mutation_logs_admin.go
@@ -25,7 +25,7 @@ import (
 )
 
 // logAdminFactory returns a new database object, and a function for cleaning it up.
-type logAdminFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (adminserver.LogsAdmin, func(context.Context))
+type logAdminFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) adminserver.LogsAdmin
 
 // RunLogsAdminTests runs all the admin tests against the provided storage implementation.
 func RunLogsAdminTests(t *testing.T, factory logAdminFactory) {
@@ -44,8 +44,7 @@ type logsAdminTests struct{}
 
 func (logsAdminTests) TestSetWritable(ctx context.Context, t *testing.T, f logAdminFactory) {
 	directoryID := "TestSetWritable"
-	m, done := f(ctx, t, directoryID, 1)
-	defer done(ctx)
+	m := f(ctx, t, directoryID, 1)
 	if st := status.Convert(m.SetWritable(ctx, directoryID, 2, true)); st.Code() != codes.NotFound {
 		t.Errorf("SetWritable(non-existent logid): %v, want %v", st, codes.NotFound)
 	}
@@ -66,8 +65,7 @@ func (logsAdminTests) TestListLogs(ctx context.Context, t *testing.T, f logAdmin
 		{desc: "multi", logIDs: []int64{1, 2, 3}, setWritable: map[int64]bool{1: true, 2: false}, wantLogIDs: []int64{1, 3}},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			m, done := f(ctx, t, directoryID, tc.logIDs...)
-			defer done(ctx)
+			m := f(ctx, t, directoryID, tc.logIDs...)
 			wantLogs := make(map[int64]bool)
 			for _, logID := range tc.wantLogIDs {
 				wantLogs[logID] = true

--- a/core/integration/storagetest/mutation_logs_reader.go
+++ b/core/integration/storagetest/mutation_logs_reader.go
@@ -37,7 +37,7 @@ type LogsReadWriter interface {
 }
 
 // logsRWFactory returns a new database object, and a function for cleaning it up.
-type logsRWFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (LogsReadWriter, func(context.Context))
+type logsRWFactory func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) LogsReadWriter
 
 // RunMutationLogsReaderTests runs all the tests against the provided storage implementation.
 func RunMutationLogsReaderTests(t *testing.T, factory logsRWFactory) {
@@ -84,8 +84,7 @@ func setupWatermarks(ctx context.Context, t *testing.T, m LogsReadWriter, dirID 
 func (mutationLogsReaderTests) TestHighWatermarkPreserve(ctx context.Context, t *testing.T, newForTest logsRWFactory) {
 	directoryID := "TestHighWatermarkPreserve"
 	logID := int64(1)
-	m, done := newForTest(ctx, t, directoryID, logID)
-	defer done(ctx)
+	m := newForTest(ctx, t, directoryID, logID)
 	maxIndex := 9
 	sent, _ := setupWatermarks(ctx, t, m, directoryID, logID, maxIndex)
 
@@ -124,8 +123,7 @@ func (mutationLogsReaderTests) TestHighWatermarkPreserve(ctx context.Context, t 
 func (mutationLogsReaderTests) TestHighWatermarkRead(ctx context.Context, t *testing.T, newForTest logsRWFactory) {
 	directoryID := "TestHighWatermarkRead"
 	logID := int64(1)
-	m, done := newForTest(ctx, t, directoryID, logID)
-	defer done(ctx)
+	m := newForTest(ctx, t, directoryID, logID)
 	maxIndex := 9
 	_, hwm := setupWatermarks(ctx, t, m, directoryID, logID, maxIndex)
 	for _, tc := range []struct {
@@ -160,8 +158,7 @@ func (mutationLogsReaderTests) TestHighWatermarkRead(ctx context.Context, t *tes
 func (mutationLogsReaderTests) TestHighWatermarkBatch(ctx context.Context, t *testing.T, newForTest logsRWFactory) {
 	directoryID := "TestHighWatermarkBatch"
 	logID := int64(1)
-	m, done := newForTest(ctx, t, directoryID, logID)
-	defer done(ctx)
+	m := newForTest(ctx, t, directoryID, logID)
 	maxIndex := 9
 	sent, _ := setupWatermarks(ctx, t, m, directoryID, logID, maxIndex)
 	for _, tc := range []struct {

--- a/impl/integration/env.go
+++ b/impl/integration/env.go
@@ -97,7 +97,6 @@ type Env struct {
 	admin      *adminserver.Server
 	grpcServer *grpc.Server
 	grpcCC     *grpc.ClientConn
-	dbDone     func(context.Context)
 	db         *sql.DB
 }
 
@@ -121,7 +120,7 @@ func NewEnv(ctx context.Context, t testing.TB) *Env {
 	timeout := 6 * time.Second
 	directoryID := "integration"
 
-	db, dbDone := testdb.NewForTest(ctx, t)
+	db := testdb.NewForTest(ctx, t)
 
 	// Map server
 	mapEnv, err := ttest.NewMapEnv(ctx, false)
@@ -224,7 +223,6 @@ func NewEnv(ctx context.Context, t testing.TB) *Env {
 		admin:      adminSvr,
 		grpcServer: gsvr,
 		grpcCC:     cc,
-		dbDone:     dbDone,
 		db:         db,
 	}
 }
@@ -241,6 +239,5 @@ func (env *Env) Close() {
 	env.grpcServer.Stop()
 	env.mapEnv.Close()
 	env.logEnv.Close()
-	env.dbDone(ctx)
 	env.db.Close()
 }

--- a/impl/memory/mutation_logs_test.go
+++ b/impl/memory/mutation_logs_test.go
@@ -25,22 +25,22 @@ import (
 // Tests for the tests!
 func TestMutationLogsIntegration(t *testing.T) {
 	storagetest.RunMutationLogsTests(t,
-		func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (keyserver.MutationLogs, func(context.Context)) {
+		func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) keyserver.MutationLogs {
 			m := NewMutationLogs()
 			if err := m.AddLogs(ctx, dirID, logIDs...); err != nil {
 				t.Fatal(err)
 			}
-			return m, func(context.Context) {}
+			return m
 		})
 }
 
 func TestMutationLogsReaderIntegration(t *testing.T) {
 	storagetest.RunMutationLogsReaderTests(t,
-		func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) (storagetest.LogsReadWriter, func(context.Context)) {
+		func(ctx context.Context, t *testing.T, dirID string, logIDs ...int64) storagetest.LogsReadWriter {
 			m := NewMutationLogs()
 			if err := m.AddLogs(ctx, dirID, logIDs...); err != nil {
 				t.Fatal(err)
 			}
-			return m, func(context.Context) {}
+			return m
 		})
 }

--- a/impl/mysql/directory/storage_test.go
+++ b/impl/mysql/directory/storage_test.go
@@ -30,21 +30,19 @@ import (
 	tpb "github.com/google/trillian"
 )
 
-func newStorage(ctx context.Context, t *testing.T) (directory.Storage, func(context.Context)) {
+func newStorage(ctx context.Context, t *testing.T) directory.Storage {
 	t.Helper()
-	db, done := testdb.NewForTest(ctx, t)
+	db := testdb.NewForTest(ctx, t)
 	s, err := NewStorage(db)
 	if err != nil {
-		done(ctx)
 		t.Fatalf("Failed to create adminstorage: %v", err)
 	}
-	return s, done
+	return s
 }
 
 func TestList(t *testing.T) {
 	ctx := context.Background()
-	s, done := newStorage(ctx, t)
-	defer done(ctx)
+	s := newStorage(ctx, t)
 	for _, tc := range []struct {
 		directories []*directory.Directory
 		readDeleted bool
@@ -100,8 +98,7 @@ func TestList(t *testing.T) {
 
 func TestWriteReadDelete(t *testing.T) {
 	ctx := context.Background()
-	s, done := newStorage(ctx, t)
-	defer done(ctx)
+	s := newStorage(ctx, t)
 	for _, tc := range []struct {
 		desc                 string
 		d                    directory.Directory
@@ -244,8 +241,7 @@ func TestWriteReadDelete(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
-	s, done := newStorage(ctx, t)
-	defer done(ctx)
+	s := newStorage(ctx, t)
 	for _, tc := range []struct {
 		directoryID string
 	}{

--- a/impl/mysql/mutationstorage/mutations_test.go
+++ b/impl/mysql/mutationstorage/mutations_test.go
@@ -23,13 +23,13 @@ import (
 )
 
 func TestBatchIntegration(t *testing.T) {
-	storageFactory := func(ctx context.Context, t *testing.T, _ string) (sequencer.Batcher, func(context.Context)) {
-		db, done := testdb.NewForTest(ctx, t)
+	storageFactory := func(ctx context.Context, t *testing.T, _ string) sequencer.Batcher {
+		db := testdb.NewForTest(ctx, t)
 		m, err := New(db)
 		if err != nil {
 			t.Fatalf("Failed to create mutations: %v", err)
 		}
-		return m, done
+		return m
 	}
 
 	storagetest.RunBatchStorageTests(t, storageFactory)

--- a/impl/mysql/testdb/testdb.go
+++ b/impl/mysql/testdb/testdb.go
@@ -31,7 +31,7 @@ var dataSourceURI = flag.String("kt_test_mysql_uri", "root@tcp(127.0.0.1)/", "Th
 
 // NewForTest creates a temporary database.
 // Returns a function for deleting the database.
-func NewForTest(ctx context.Context, t testing.TB) (*sql.DB, func(context.Context)) {
+func NewForTest(ctx context.Context, t testing.TB) *sql.DB {
 	t.Helper()
 	db, err := ktsql.Open(*dataSourceURI)
 	if err != nil {
@@ -50,11 +50,12 @@ func NewForTest(ctx context.Context, t testing.TB) (*sql.DB, func(context.Contex
 		t.Fatal(err)
 	}
 
-	done := func(ctx context.Context) {
+	t.Cleanup(func() {
+		ctx := context.Background()
 		defer db.Close()
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP DATABASE `%s`", dbName)); err != nil {
 			log.Printf("Failed to drop test database %q: %v", dbName, err)
 		}
-	}
-	return db, done
+	})
+	return db
 }

--- a/impl/mysql/testdb/testdb_test.go
+++ b/impl/mysql/testdb/testdb_test.go
@@ -21,12 +21,8 @@ import (
 
 func TestNewForTest(t *testing.T) {
 	ctx := context.Background()
-	db, done := NewForTest(ctx, t)
+	db := NewForTest(ctx, t)
 	if err := db.Ping(); err != nil {
 		t.Error(err)
 	}
-	done(ctx)
-	// Verify that the databse was really closed by looking for the
-	// error in the logs when running the test with -v
-	done(ctx)
 }

--- a/impl/spanner/directory/directory_test.go
+++ b/impl/spanner/directory/directory_test.go
@@ -35,20 +35,19 @@ import (
 // Verify that Table implements the directory.Storage interface.
 var _ directory.Storage = &Table{}
 
-func NewForTest(ctx context.Context, t *testing.T) (directory.Storage, func()) {
+func NewForTest(ctx context.Context, t *testing.T) directory.Storage {
 	t.Helper()
 	ddl, err := ktspanner.ReadDDL()
 	if err != nil {
 		t.Fatalf("ReadDDL: %v", err)
 	}
-	client, cleanup := testutil.CreateDatabase(ctx, t, ddl)
-	return New(client), cleanup
+	client := testutil.CreateDatabase(ctx, t, ddl)
+	return New(client)
 }
 
 func TestList(t *testing.T) {
 	ctx := context.Background()
-	admin, cleanup := NewForTest(ctx, t)
-	defer cleanup()
+	admin := NewForTest(ctx, t)
 
 	directories := []*directory.Directory{
 		{
@@ -106,8 +105,7 @@ func TestList(t *testing.T) {
 
 func TestWriteReadDelete(t *testing.T) {
 	ctx := context.Background()
-	admin, cleanup := NewForTest(ctx, t)
-	defer cleanup()
+	admin := NewForTest(ctx, t)
 
 	d := &directory.Directory{
 		DirectoryID: "testdirectory",
@@ -168,8 +166,7 @@ func TestWriteReadDelete(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
-	s, cleanup := NewForTest(ctx, t)
-	defer cleanup()
+	s := NewForTest(ctx, t)
 
 	for _, dirID := range []string{"test", ""} {
 		d := &directory.Directory{

--- a/impl/spanner/testutil/testutil.go
+++ b/impl/spanner/testutil/testutil.go
@@ -66,7 +66,7 @@ func inMemClient(ctx context.Context, t testing.TB, dbName string) (*spanner.Cli
 	if err != nil {
 		t.Fatalf("Dialing in-memory fake: %v", err)
 	}
-	t.Cleanup(func() { conn.Close() })
+	t.Cleanup(func() { conn.Close() /* May already be closed by adminClient */ })
 	client, err := spanner.NewClient(ctx, dbName, option.WithGRPCConn(conn))
 	if err != nil {
 		t.Fatalf("Connecting to in-memory fake: %v", err)
@@ -76,7 +76,11 @@ func inMemClient(ctx context.Context, t testing.TB, dbName string) (*spanner.Cli
 	if err != nil {
 		t.Fatalf("Connecting to in-memory fake DB admin: %v", err)
 	}
-	t.Cleanup(func() { adminClient.Close() })
+	t.Cleanup(func() {
+		if err := adminClient.Close(); err != nil {
+			t.Error(err)
+		}
+	})
 
 	return client, adminClient
 }


### PR DESCRIPTION
Go 1.14 introduced `t.Cleanup()`, eliminating the need to pass
callback cleanup functions throughout the testing infrastructure
as well as achieve better test cleanup reliability.