### PR TITLE
Fix off by one error

### DIFF
--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -527,7 +527,7 @@ func (s *Server) PublishRevisions(ctx context.Context,
 		end = batch
 	}
 	logRootTrail.Set(float64(latestMapRoot.Revision - logRoot.TreeSize))
-	for rev := logRoot.TreeSize - 1; rev <= end; rev++ {
+	for rev := logRoot.TreeSize; rev <= end; rev++ {
 		rawMapRoot, mapRoot, err := mapClient.GetAndVerifyMapRootByRevision(ctx, int64(rev))
 		if err != nil {
 			return nil, err

--- a/core/sequencer/server.go
+++ b/core/sequencer/server.go
@@ -527,8 +527,9 @@ func (s *Server) PublishRevisions(ctx context.Context,
 		end = batch
 	}
 	logRootTrail.Set(float64(latestMapRoot.Revision - logRoot.TreeSize))
-	for rev := logRoot.TreeSize; rev <= end; rev++ {
-		rawMapRoot, mapRoot, err := mapClient.GetAndVerifyMapRootByRevision(ctx, int64(rev))
+	maxLeafIndex := logRoot.TreeSize - 1
+	for revToWrite := maxLeafIndex + 1; revToWrite <= end; revToWrite++ {
+		rawMapRoot, mapRoot, err := mapClient.GetAndVerifyMapRootByRevision(ctx, int64(revToWrite))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
For all Map Revisions, we want each Map Revision written in the log of map
roots such that Map Revision == Leaf Index.

When Max Map Revision > Max Leaf Index, we want to AddSequencedLeaf all the
revisions inbetween.